### PR TITLE
Enable pythons fault handler on tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ commands=
 [testenv]
 passenv = TRAVIS TRAVIS_*
 setenv =
+    PYTHONFAULTHANDLER = 1
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/requirements_dev.txt


### PR DESCRIPTION
Enables python to print out a stack trace during tests when a `SEGFAULT` or similar is encountered. Since we are using a lot of C backend code, this should come in handy.

Closes #6.