### PR TITLE
Add Coeval class to make run_coeval more homogeneous

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 ignore = E203, E266, E501, W503, F403, F401
 max-line-length = 88
-max-complexity = 19
+max-complexity = 21
 select = B,C,E,F,W,T4,B9

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -138,3 +138,4 @@ void Broadcast_struct_global_UF(struct UserParams *user_params, struct CosmoPara
 void Broadcast_struct_global_HF(struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params, struct FlagOptions *flag_options);
 
 void free_TsCalcBoxes();
+bool photon_cons_inited = false;

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -2255,6 +2255,8 @@ int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cos
     
     free(z_arr);
     free(Q_arr);
+
+    photon_cons_inited = true;
     return(0);
 }
 

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -2571,6 +2571,8 @@ def calibrate_photon_cons(
     regenerate, write
         See docs of :func:`initial_conditions` for more information.
     """
+    if not flag_options.PHOTON_CONS:
+        return
 
     # Create a new astro_params and flag_options just for the photon_cons correction
     astro_params_photoncons = deepcopy(astro_params)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -301,13 +301,11 @@ def test_bt(ionize_box, spin_temp, perturb_field):
 
 
 def test_coeval_against_direct(init_box, perturb_field, ionize_box):
-    init, pf, ib, bt = wrapper.run_coeval(
-        perturb=perturb_field, init_box=init_box, write=False
-    )
+    coeval = wrapper.run_coeval(perturb=perturb_field, init_box=init_box, write=False)
 
-    assert init == init_box
-    assert pf[0] == perturb_field
-    assert ib[0] == ionize_box
+    assert coeval[0].init_box == init_box
+    assert coeval[0].perturb_field == perturb_field
+    assert coeval[0].ionization_box == ionize_box
 
 
 def test_lightcone(init_box, perturb_field):


### PR DESCRIPTION
This PR adds a `Coeval` class, a list of which is what is returned by `run_coeval`. This makes it easier to digest the output of `run_coeval` (originally written as a fix to the problem introduced in `PhotonCons` in where the return values had to be defined). 

It also adds a docstring to `get_photon_nonconservation_data`.

It also adds a `photoncons_inited` variable to the C globals, which can be accessed by Python -- in  `get_photon_nonconservation_data`, it returns None if this is False. Otherwise, this function can be called any time and will give garbage.