### PR TITLE
More rigorous exceptions

### DIFF
--- a/docs/notes_for_developers.rst
+++ b/docs/notes_for_developers.rst
@@ -26,7 +26,11 @@ below about running with valgrind). When changing C code, before
 testing, ensure that the new C code is compiled into your environment by running::
 
     $ rm -rf build
-    $ pip install -e .
+    $ pip install .
+
+Note that using a developer install (`-e`) is not recommended as it stores compiled
+objects in the working directory which don't get updated as you change code, and can
+cause problems later.
 
 There are two main purposes you may want to write some C code:
 
@@ -89,6 +93,23 @@ changes in the Python are necessary. However, you may want to consider adding th
 parameter to relevant ``_filter_params`` lists for the output struct wrapping classes in
 the wrapper. These lists control which global parameters affect which output structs,
 and merely provide for more accurate caching mechanisms.
+
+C Function Standards
+~~~~~~~~~~~~~~~~~~~~
+The C-level functions are split into two groups -- low-level "private" functions, and
+higher-level "public" or "API" functions. All API-level functions are callable from
+python (but may also be called from other C functions). All API-level functions are
+currently prototyped in `21cmFAST.h`.
+
+To enable consistency of error-checking in Python (and a reasonable standard for any
+kind of code), we enforce that any API-level function must return an integer status.
+Any "return" objects must be modified in-place (i.e. passed as pointers). This enables
+Python to control the memory access of these variables, and also to receive proper
+error statuses (see below for how we do exception handling). We also adhere to the
+convention that "output" variables should be passed to the function as its last
+argument(s). In the case that _only_ the last argument is meant to be "output", there
+exists a simple wrapper `_call_c_simple` in `wrapper.py` that will neatly handle the
+calling of the function in an intuitive pythonic way.
 
 Running with Valgrind
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/notes_for_developers.rst
+++ b/docs/notes_for_developers.rst
@@ -134,3 +134,50 @@ Producing Integration Test Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 There are bunch of so-called "integration tests", which rely on previously-produced
 data. To produce this data, run `python tests/produce_integration_test_data.py`.
+
+Furthermore, this data should only be produced with good reason -- the idea is to keep
+it static while the code changes, to have something steady to compare to. If a particular
+PR fixes a bug which affects a certain tests' data, then that data should be re-run, in
+the context of the PR, so it can be explained.
+
+Logging in C
+~~~~~~~~~~~~
+The C code has a header file ``logging.h``. The C code should *never* contain bare
+print-statements -- everything should be formally logged, so that the different levels
+can be printed to screen correctly. The levels are defined in ``logging.h``, and include
+levels such as ``INFO``, ``WARNING`` and ``DEBUG``. Each level has a corresponding macro
+that starts with ``LOG_``. Thus to log run-time information to stdout, you would use
+``LOG_INFO("message");``. Note that the message does not require a final newline character.
+
+Exception handling in C
+~~~~~~~~~~~~~~~~~~~~~~~
+There are various places that things can go wrong in the C code, and they need to be
+handled gracefully so that Python knows what to do with it (rather than just quitting!).
+We use the simple ``cexcept.h`` header file from http://www.nicemice.net/cexcept/ to
+enable a simple form of exception handling. That file itself should **not be edited**.
+There is another header -- ``exceptions.h`` -- that defines how we use exceptions
+throughout ``21cmFAST``. Any time an error arises that can be understood, the developer
+should add a ``Throw <ErrorKind>;`` line. The ``ErrorKind`` can be any of the kinds
+defined in ``exceptions.h`` (eg. ``GSLError`` or ``ValueError``). These are just integers.
+
+Any C function that has a header in ``21cmFAST.h`` -- i.e. any function that is callable
+directly from Python -- *must* be globally wrapped in a ``Try {} Catch(error_code) {}`` block. See
+``GenerateICs.c`` for an example. Most of the code should be in the ``Try`` block.
+Anything that does a ``Throw`` at any level of the call stack within that ``Try`` will
+trigger a jump to the ``Catch``. The ``error_code`` is the integer that was thrown.
+Typically, one will perhaps want to do some cleanup here, and then finally *return* the
+error code.
+
+Python knows about the exit codes it can expect to receive, and will raise Python
+exceptions accordingly. From the python side, two main kinds of exceptions could be
+raised, depending on the error code returned from C. The lesser exception is called a
+``ParameterError``, and is supposed to indicate an error that happened merely because
+the parameters that were input to the calculation were just too extreme to handle.
+In the case of something like an automatic Monte Carlo algorithm that's iterating over
+random parameters, one would *usually* want to just keep going at this point, because
+perhaps it just wandered too far in parameter space.
+The other kind of error is a ``FatalCError``, and this is where things went truly wrong,
+and probably will do for any combination of parameters.
+
+If you add a kind of Exception in the C code (to ``exceptions.h``), then be sure to add
+a handler for it in the ``_process_exitcode`` function in ``wrapper.py``.

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -131,7 +131,7 @@ int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cos
                          struct AstroParams *astro_params, struct FlagOptions *flag_options);
 
 int PhotonCons_Calibration(double *z_estimate, double *xH_estimate, int NSpline);
-double ComputeZstart_PhotonCons();
+int ComputeZstart_PhotonCons(double *zstart);
 
 int ObtainPhotonConsData(double *z_at_Q_data, double *Q_data, int *Ndata_analytic, double *z_cal_data, double *nf_cal_data, int *Ndata_calibration,
                          double *PhotonCons_NFdata, double *PhotonCons_deltaz, int *Ndata_PhotonCons);
@@ -148,3 +148,6 @@ void Broadcast_struct_global_HF(struct UserParams *user_params, struct CosmoPara
 void free_TsCalcBoxes(struct FlagOptions *flag_options);
 void FreePhotonConsMemory();
 bool photon_cons_allocated = false;
+int SomethingThatCatches(bool sub_func);
+int FunctionThatCatches(bool sub_func, bool pass, double* result);
+void FunctionThatThrows();

--- a/src/py21cmfast/src/BrightnessTemperatureBox.c
+++ b/src/py21cmfast/src/BrightnessTemperatureBox.c
@@ -103,7 +103,7 @@ int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct
 
     if(isfinite(ave)==0) {
         LOG_ERROR("Average brightness temperature is infinite or NaN!");
-        return(2);
+        Throw(ParameterError);
     }
 
     ave /= (float)HII_TOT_NUM_PIXELS;
@@ -554,7 +554,7 @@ int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct
 
     if(isfinite(ave)==0) {
         LOG_ERROR("Average brightness temperature (after including velocities) is infinite or NaN!");
-        return(2);
+        Throw(ParameterError);
     }
 
     LOG_DEBUG("z = %.2f, ave Tb = %e", redshift, ave);

--- a/src/py21cmfast/src/BrightnessTemperatureBox.c
+++ b/src/py21cmfast/src/BrightnessTemperatureBox.c
@@ -5,6 +5,9 @@ int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct
                            struct AstroParams *astro_params, struct FlagOptions *flag_options,
                            struct TsBox *spin_temp, struct IonizedBox *ionized_box,
                            struct PerturbedField *perturb_field, struct BrightnessTemp *box) {
+
+    int status;
+    Try{ // Try block around whole function.
     LOG_DEBUG("Starting Brightness Temperature calculation for redshift %f", redshift);
     // Makes the parameter structs visible to a variety of functions/macros
     // Do each time to avoid Python garbage collection issues
@@ -567,8 +570,12 @@ int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct
     free(delta_T_RSD_LOS);
     fftwf_cleanup_threads();
     fftwf_cleanup();
-
     LOG_DEBUG("Cleaned up.");
+
+    } // End of try
+    Catch(status){
+        return(status);
+    }
 
     return(0);
 }

--- a/src/py21cmfast/src/GenerateICs.c
+++ b/src/py21cmfast/src/GenerateICs.c
@@ -36,8 +36,10 @@
 
 // Re-write of init.c for being accessible within the MCMC
 
-int ComputeInitialConditions(unsigned long long random_seed, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct InitialConditions *boxes) {
-
+int ComputeInitialConditions(
+    unsigned long long random_seed, struct UserParams *user_params,
+    struct CosmoParams *cosmo_params, struct InitialConditions *boxes
+){
     /*
      Generates the initial conditions: gaussian random density field (DIM^3) as well as the equal or lower resolution velocity fields, and smoothed density field (HII_DIM^3).
      See INIT_PARAMS.H and ANAL_PARAMS.H to set the appropriate parameters.
@@ -45,7 +47,10 @@ int ComputeInitialConditions(unsigned long long random_seed, struct UserParams *
 
      Author: Andrei Mesinger
      Date: 9/29/06
-     */
+    */
+    int status;
+
+    Try{ // This Try wraps the entire function so we don't indent.
 
     // Makes the parameter structs visible to a variety of functions/macros
     // Do each time to avoid Python garbage collection issues
@@ -895,8 +900,12 @@ int ComputeInitialConditions(unsigned long long random_seed, struct UserParams *
     for (i=0; i<user_params->N_THREADS; i++) {
         gsl_rng_free (r[i]);
     }
-
     LOG_DEBUG("Cleaned Up.");
+    } // End of Try{}
+
+    Catch(status){
+        return(status);
+    }
     return(0);
 }
 

--- a/src/py21cmfast/src/GenerateICs.c
+++ b/src/py21cmfast/src/GenerateICs.c
@@ -19,6 +19,7 @@
 #include <gsl/gsl_spline.h>
 
 #include "21cmFAST.h"
+#include "exceptions.h"
 #include "logger.h"
 #include "Constants.h"
 #include "Globals.h"
@@ -32,6 +33,7 @@
 #include "IonisationBox.c"
 #include "SpinTemperatureBox.c"
 #include "BrightnessTemperatureBox.c"
+
 
 
 // Re-write of init.c for being accessible within the MCMC
@@ -157,7 +159,6 @@ int ComputeInitialConditions(
 
 
     init_ps();
-    LOG_DEBUG("Initalialized Power Spectrum.");
 
 #pragma omp parallel shared(HIRES_box,HIRES_box_vcb_x,HIRES_box_vcb_y,HIRES_box_vcb_z,r) \
                     private(n_x,n_y,n_z,k_x,k_y,k_z,k_mag,p,a,b,p_vcb) num_threads(user_params->N_THREADS)

--- a/src/py21cmfast/src/Globals.h
+++ b/src/py21cmfast/src/Globals.h
@@ -75,7 +75,7 @@ struct GlobalParams{
 
 };
 
-struct GlobalParams global_params = {
+extern struct GlobalParams global_params = {
 
     .ALPHA_UVB = 5.0,
     .EVOLVE_DENSITY_LINEARLY = 0,

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -14,14 +14,17 @@ int ComputeIonizedBox(float redshift, float prev_redshift, struct UserParams *us
                        struct IonizedBox *previous_ionize_box,
                        struct TsBox *spin_temp, struct IonizedBox *box) {
 
-LOG_DEBUG("input values:");
-LOG_DEBUG("redshift=%f, prev_redshift=%f", redshift, prev_redshift);
-#if LOG_LEVEL >= DEBUG_LEVEL
-    writeUserParams(user_params);
-    writeCosmoParams(cosmo_params);
-    writeAstroParams(flag_options, astro_params);
-    writeFlagOptions(flag_options);
-#endif
+    int status;
+
+    Try{ // This Try brackets the whole function, so we don't indent.
+    LOG_DEBUG("input values:");
+    LOG_DEBUG("redshift=%f, prev_redshift=%f", redshift, prev_redshift);
+    #if LOG_LEVEL >= DEBUG_LEVEL
+        writeUserParams(user_params);
+        writeCosmoParams(cosmo_params);
+        writeAstroParams(flag_options, astro_params);
+        writeFlagOptions(flag_options);
+    #endif
 
     // Makes the parameter structs visible to a variety of functions/macros
     // Do each time to avoid Python garbage collection issues
@@ -1791,6 +1794,11 @@ LOG_SUPER_DEBUG("freed fftw boxes");
 
     free(overdense_int_boundexceeded_threaded);
 
-LOG_DEBUG("finished!\n");
+    LOG_DEBUG("finished!\n");
+
+    } // End of Try()
+    Catch(status){
+        return(status);
+    }
     return(0);
 }

--- a/src/py21cmfast/src/PerturbField.c
+++ b/src/py21cmfast/src/PerturbField.c
@@ -13,43 +13,49 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
 
     // Makes the parameter structs visible to a variety of functions/macros
     // Do each time to avoid Python garbage collection issues
-    Broadcast_struct_global_PS(user_params,cosmo_params);
-    Broadcast_struct_global_UF(user_params,cosmo_params);
+    int error_code;
 
+<<<<<<< HEAD
     omp_set_num_threads(user_params->N_THREADS);
     fftwf_init_threads();
     fftwf_plan_with_nthreads(user_params->N_THREADS);
     fftwf_cleanup_threads();
 
     char wisdom_filename[500];
+=======
+    Try {
+>>>>>>> fed43ec... More rigorous exceptions
 
-    fftwf_complex *LOWRES_density_perturb, *LOWRES_density_perturb_saved;
-    fftwf_plan plan;
 
-    float growth_factor, displacement_factor_2LPT, init_growth_factor, init_displacement_factor_2LPT, xf, yf, zf;
-    float mass_factor, dDdt, f_pixel_factor, velocity_displacement_factor, velocity_displacement_factor_2LPT;
-    unsigned long long ct, HII_i, HII_j, HII_k;
-    int i,j,k, xi, yi, zi;
-    double ave_delta, new_ave_delta;
-    // ***************   BEGIN INITIALIZATION   ************************** //
+        Broadcast_struct_global_PS(user_params,cosmo_params);
+        Broadcast_struct_global_UF(user_params,cosmo_params);
 
+<<<<<<< HEAD
     // perform a very rudimentary check to see if we are underresolved and not using the linear approx
     if ((user_params->BOX_LEN > user_params->DIM) && !(global_params.EVOLVE_DENSITY_LINEARLY)){
         fprintf(stderr, "perturb_field.c: WARNING: Resolution is likely too low for accurate evolved density fields\n \
                 It Is recommended that you either increase the resolution (DIM/Box_LEN) or set the EVOLVE_DENSITY_LINEARLY flag to 1\n");
     }
+=======
+        char wisdom_filename[500];
+>>>>>>> fed43ec... More rigorous exceptions
 
-    growth_factor = dicke(redshift);
-    displacement_factor_2LPT = -(3.0/7.0) * growth_factor*growth_factor; // 2LPT eq. D8
+        fftwf_complex *LOWRES_density_perturb, *LOWRES_density_perturb_saved;
+        fftwf_plan plan;
 
-    dDdt = ddickedt(redshift); // time derivative of the growth factor (1/s)
-    init_growth_factor = dicke(global_params.INITIAL_REDSHIFT);
-    init_displacement_factor_2LPT = -(3.0/7.0) * init_growth_factor*init_growth_factor; // 2LPT eq. D8
+        float growth_factor, displacement_factor_2LPT, init_growth_factor, init_displacement_factor_2LPT, xf, yf, zf;
+        float mass_factor, dDdt, f_pixel_factor, velocity_displacement_factor, velocity_displacement_factor_2LPT;
+        unsigned long long ct, HII_i, HII_j, HII_k;
+        int i,j,k, xi, yi, zi;
+        double ave_delta, new_ave_delta;
+        // ***************   BEGIN INITIALIZATION   ************************** //
 
-    // allocate memory for the updated density, and initialize
-    LOWRES_density_perturb = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
-    LOWRES_density_perturb_saved = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+        // perform a very rudimentary check to see if we are underresolved and not using the linear approx
+        if ((user_params->BOX_LEN > user_params->DIM) && !(global_params.EVOLVE_DENSITY_LINEARLY)){
+            LOG_WARNING("Resolution is likely too low for accurate evolved density fields\n It Is recommended that you either increase the resolution (DIM/Box_LEN) or set the EVOLVE_DENSITY_LINEARLY flag to 1");
+        }
 
+<<<<<<< HEAD
     double *resampled_box;
 
     // check if the linear evolution flag was set
@@ -57,6 +63,21 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
 #pragma omp parallel shared(growth_factor,boxes,LOWRES_density_perturb) private(i,j,k) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
+=======
+        growth_factor = dicke(redshift);
+        displacement_factor_2LPT = -(3.0/7.0) * growth_factor*growth_factor; // 2LPT eq. D8
+
+        dDdt = ddickedt(redshift); // time derivative of the growth factor (1/s)
+        init_growth_factor = dicke(global_params.INITIAL_REDSHIFT);
+        init_displacement_factor_2LPT = -(3.0/7.0) * init_growth_factor*init_growth_factor; // 2LPT eq. D8
+
+        // allocate memory for the updated density, and initialize
+        LOWRES_density_perturb = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+        LOWRES_density_perturb_saved = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+
+        // check if the linear evolution flag was set
+        if (global_params.EVOLVE_DENSITY_LINEARLY){
+>>>>>>> fed43ec... More rigorous exceptions
             for (i=0; i<user_params->HII_DIM; i++){
                 for (j=0; j<user_params->HII_DIM; j++){
                     for (k=0; k<user_params->HII_DIM; k++){
@@ -65,6 +86,7 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                 }
             }
         }
+<<<<<<< HEAD
     }
     // first order Zel'Dovich perturbation
 
@@ -72,6 +94,11 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
 #pragma omp parallel shared(LOWRES_density_perturb) private(i,j,k) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
+=======
+        // first order Zel'Dovich perturbation
+        else{
+
+>>>>>>> fed43ec... More rigorous exceptions
             for (i=0; i<user_params->HII_DIM; i++){
                 for (j=0; j<user_params->HII_DIM; j++){
                     for (k=0; k<user_params->HII_DIM; k++){
@@ -79,46 +106,56 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     }
                 }
             }
-        }
 
-        velocity_displacement_factor = (growth_factor-init_growth_factor) / user_params->BOX_LEN;
+            velocity_displacement_factor = (growth_factor-init_growth_factor) / user_params->BOX_LEN;
 
+<<<<<<< HEAD
         // now add the missing factor of D
 #pragma omp parallel shared(boxes,velocity_displacement_factor) private(ct) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
+=======
+            // now add the missing factor of D
+>>>>>>> fed43ec... More rigorous exceptions
             for (ct=0; ct<HII_TOT_NUM_PIXELS; ct++){
                 boxes->lowres_vx[ct] *= velocity_displacement_factor; // this is now comoving displacement in units of box size
                 boxes->lowres_vy[ct] *= velocity_displacement_factor; // this is now comoving displacement in units of box size
                 boxes->lowres_vz[ct] *= velocity_displacement_factor; // this is now comoving displacement in units of box size
             }
+<<<<<<< HEAD
         }
+=======
+>>>>>>> fed43ec... More rigorous exceptions
 
-        // find factor of HII pixel size / deltax pixel size
-        f_pixel_factor = user_params->DIM/(float)(user_params->HII_DIM);
-        mass_factor = pow(f_pixel_factor, 3);
+            // find factor of HII pixel size / deltax pixel size
+            f_pixel_factor = user_params->DIM/(float)(user_params->HII_DIM);
+            mass_factor = pow(f_pixel_factor, 3);
 
-        // * ************************************************************************* * //
-        // *                           BEGIN 2LPT PART                                 * //
-        // * ************************************************************************* * //
-        // reference: reference: Scoccimarro R., 1998, MNRAS, 299, 1097-1118 Appendix D
-        if(global_params.SECOND_ORDER_LPT_CORRECTIONS){
+            // * ************************************************************************* * //
+            // *                           BEGIN 2LPT PART                                 * //
+            // * ************************************************************************* * //
+            // reference: reference: Scoccimarro R., 1998, MNRAS, 299, 1097-1118 Appendix D
+            if(global_params.SECOND_ORDER_LPT_CORRECTIONS){
 
-            // allocate memory for the velocity boxes and read them in
-            velocity_displacement_factor_2LPT = (displacement_factor_2LPT - init_displacement_factor_2LPT) / user_params->BOX_LEN;
+                // allocate memory for the velocity boxes and read them in
+                velocity_displacement_factor_2LPT = (displacement_factor_2LPT - init_displacement_factor_2LPT) / user_params->BOX_LEN;
 
+<<<<<<< HEAD
             // now add the missing factor in eq. D9
 #pragma omp parallel shared(boxes,velocity_displacement_factor_2LPT) private(ct) num_threads(user_params->N_THREADS)
             {
 #pragma omp for
+=======
+                // now add the missing factor in eq. D9
+>>>>>>> fed43ec... More rigorous exceptions
                 for (ct=0; ct<HII_TOT_NUM_PIXELS; ct++){
                     boxes->lowres_vx_2LPT[ct] *= velocity_displacement_factor_2LPT; // this is now comoving displacement in units of box size
                     boxes->lowres_vy_2LPT[ct] *= velocity_displacement_factor_2LPT; // this is now comoving displacement in units of box size
                     boxes->lowres_vz_2LPT[ct] *= velocity_displacement_factor_2LPT; // this is now comoving displacement in units of box size
                 }
             }
-        }
 
+<<<<<<< HEAD
         // * ************************************************************************* * //
         // *                            END 2LPT PART                                  * //
         // * ************************************************************************* * //
@@ -134,6 +171,15 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     private(i,j,k,xi,xf,yi,yf,zi,zf,HII_i,HII_j,HII_k) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
+=======
+            // * ************************************************************************* * //
+            // *                            END 2LPT PART                                  * //
+            // * ************************************************************************* * //
+
+            // ************  END INITIALIZATION **************************** //
+
+            // go through the high-res box, mapping the mass onto the low-res (updated) box
+>>>>>>> fed43ec... More rigorous exceptions
             for (i=0; i<user_params->DIM;i++){
                 for (j=0; j<user_params->DIM;j++){
                     for (k=0; k<user_params->DIM;k++){
@@ -178,6 +224,7 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                         if (zi >= (user_params->HII_DIM)){ zi -= (user_params->HII_DIM);}
                         if (zi < 0) {zi += (user_params->HII_DIM);}
 
+<<<<<<< HEAD
 #pragma omp atomic
                         resampled_box[HII_R_INDEX(xi,yi,zi)] += (double)(1. + init_growth_factor*(boxes->hires_density)[R_INDEX(i,j,k)]);
                     }
@@ -203,6 +250,15 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
 #pragma omp parallel shared(LOWRES_density_perturb,mass_factor) private(i,j,k) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
+=======
+                        *( (float *)LOWRES_density_perturb + HII_R_FFT_INDEX(xi, yi, zi) ) +=
+                        (1 + init_growth_factor*(boxes->hires_density)[R_INDEX(i,j,k)]);
+                    }
+                }
+            }
+
+            // renormalize to the new pixel size, and make into delta
+>>>>>>> fed43ec... More rigorous exceptions
             for (i=0; i<user_params->HII_DIM; i++){
                 for (j=0; j<user_params->HII_DIM; j++){
                     for (k=0; k<user_params->HII_DIM; k++){
@@ -211,16 +267,20 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     }
                 }
             }
-        }
 
+<<<<<<< HEAD
         // deallocate
 #pragma omp parallel shared(boxes,velocity_displacement_factor) private(ct) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
+=======
+            // deallocate
+>>>>>>> fed43ec... More rigorous exceptions
             for (ct=0; ct<HII_TOT_NUM_PIXELS; ct++){
                 boxes->lowres_vx[ct] /= velocity_displacement_factor; // convert back to z = 0 quantity
                 boxes->lowres_vy[ct] /= velocity_displacement_factor; // convert back to z = 0 quantity
                 boxes->lowres_vz[ct] /= velocity_displacement_factor; // convert back to z = 0 quantity
+<<<<<<< HEAD
             }
         }
 
@@ -233,10 +293,11 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     boxes->lowres_vy_2LPT[ct] /= velocity_displacement_factor_2LPT; // convert back to z = 0 quantity
                     boxes->lowres_vz_2LPT[ct] /= velocity_displacement_factor_2LPT; // convert back to z = 0 quantity
                 }
+=======
+>>>>>>> fed43ec... More rigorous exceptions
             }
-        }
-    }
 
+<<<<<<< HEAD
     // ****  Print and convert to velocities ***** //
     if (global_params.EVOLVE_DENSITY_LINEARLY){
 #pragma omp parallel shared(perturbed_field,LOWRES_density_perturb) private(i,j,k) num_threads(user_params->N_THREADS)
@@ -247,10 +308,18 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     for (k=0; k<user_params->HII_DIM; k++){
                         *((float *)perturbed_field->density + HII_R_INDEX(i,j,k)) = *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k));
                     }
+=======
+            if(global_params.SECOND_ORDER_LPT_CORRECTIONS){
+                for (ct=0; ct<HII_TOT_NUM_PIXELS; ct++){
+                    boxes->lowres_vx_2LPT[ct] /= velocity_displacement_factor_2LPT; // convert back to z = 0 quantity
+                    boxes->lowres_vy_2LPT[ct] /= velocity_displacement_factor_2LPT; // convert back to z = 0 quantity
+                    boxes->lowres_vz_2LPT[ct] /= velocity_displacement_factor_2LPT; // convert back to z = 0 quantity
+>>>>>>> fed43ec... More rigorous exceptions
                 }
             }
         }
 
+<<<<<<< HEAD
         // transform to k-space
         if(user_params->USE_FFTW_WISDOM) {
             // Check to see if the wisdom exists, create it if it doesn't
@@ -268,31 +337,86 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                 plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                              (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_PATIENT);
                 fftwf_execute(plan);
+=======
+        // ****  Print and convert to velocities ***** //
+        if (global_params.EVOLVE_DENSITY_LINEARLY){
+            for (i=0; i<user_params->HII_DIM; i++){
+                for (j=0; j<user_params->HII_DIM; j++){
+                    for (k=0; k<user_params->HII_DIM; k++){
+                        *((float *)perturbed_field->density + HII_R_INDEX(i,j,k)) = *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k));
+                    }
+                }
+            }
 
-                // Store the wisdom for later use
-                fftwf_export_wisdom_to_filename(wisdom_filename);
+            // transform to k-space
+            if(user_params->USE_FFTW_WISDOM) {
+                // Check to see if the wisdom exists, create it if it doesn't
+                sprintf(wisdom_filename,"real_to_complex_%d.fftwf_wisdom",user_params->HII_DIM);
+                if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
+                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
+                    fftwf_execute(plan);
 
-                // copy over unfiltered box
-                memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+                }
+                else {
+>>>>>>> fed43ec... More rigorous exceptions
 
+                    // save a copy of the k-space density field
+                    memcpy(LOWRES_density_perturb_saved, LOWRES_density_perturb, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+
+                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_PATIENT);
+                    fftwf_execute(plan);
+
+<<<<<<< HEAD
                 fftwf_destroy_plan(plan);
 
                 plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                              (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
+=======
+                    // Store the wisdom for later use
+                    fftwf_export_wisdom_to_filename(wisdom_filename);
+
+                    // copy over unfiltered box
+                    memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+
+                    fftwf_destroy_plan(plan);
+                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
+                    fftwf_execute(plan);
+                }
+            }
+            else {
+                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_ESTIMATE);
+>>>>>>> fed43ec... More rigorous exceptions
                 fftwf_execute(plan);
             }
+            fftwf_destroy_plan(plan);
+
+            // save a copy of the k-space density field
         }
+<<<<<<< HEAD
         else {
             plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                          (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_ESTIMATE);
             fftwf_execute(plan);
         }
         fftwf_destroy_plan(plan);
+=======
+        else{
 
-        // save a copy of the k-space density field
-    }
-    else{
+            // transform to k-space
+            if(user_params->USE_FFTW_WISDOM) {
+                // Check to see if the wisdom exists, create it if it doesn't
+                sprintf(wisdom_filename,"real_to_complex_%d.fftwf_wisdom",user_params->HII_DIM);
+                if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
+                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
+                    fftwf_execute(plan);
+                }
+                else {
+>>>>>>> fed43ec... More rigorous exceptions
 
+                    // save a copy of the k-space density field
+                    memcpy(LOWRES_density_perturb_saved, LOWRES_density_perturb, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+
+<<<<<<< HEAD
         // transform to k-space
         if(user_params->USE_FFTW_WISDOM) {
             // Check to see if the wisdom exists, create it if it doesn't
@@ -309,31 +433,135 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                 plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                              (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_PATIENT);
                 fftwf_execute(plan);
+=======
+                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_PATIENT);
+                    fftwf_execute(plan);
 
-                // Store the wisdom for later use
-                fftwf_export_wisdom_to_filename(wisdom_filename);
+                    // Store the wisdom for later use
+                    fftwf_export_wisdom_to_filename(wisdom_filename);
 
+                    // copy over unfiltered box
+                    memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+                    fftwf_destroy_plan(plan);
+                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
+                    fftwf_execute(plan);
+                }
+            }
+            else {
+                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_ESTIMATE);
+                fftwf_execute(plan);
+            }
+            fftwf_destroy_plan(plan);
+
+            //smooth the field
+            if (!global_params.EVOLVE_DENSITY_LINEARLY && global_params.SMOOTH_EVOLVED_DENSITY_FIELD){
+                filter_box(LOWRES_density_perturb, 1, 2, global_params.R_smooth_density*user_params->BOX_LEN/(float)user_params->HII_DIM);
+            }
+
+            // save a copy of the k-space density field
+            memcpy(LOWRES_density_perturb_saved, LOWRES_density_perturb, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+>>>>>>> fed43ec... More rigorous exceptions
+
+            if(user_params->USE_FFTW_WISDOM) {
+                // Check to see if the wisdom exists, create it if it doesn't
+                sprintf(wisdom_filename,"complex_to_real_%d.fftwf_wisdom",user_params->HII_DIM);
+                if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
+                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
+                    fftwf_execute(plan);
+                }
+                else {
+
+<<<<<<< HEAD
                 // copy over unfiltered box
                 memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
                 fftwf_destroy_plan(plan);
                 plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                              (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
+=======
+                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_PATIENT);
+                    fftwf_execute(plan);
+
+                    // Store the wisdom for later use
+                    fftwf_export_wisdom_to_filename(wisdom_filename);
+
+                    // copy over unfiltered box
+                    memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+
+                    fftwf_destroy_plan(plan);
+                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
+                    fftwf_execute(plan);
+                }
+            }
+            else {
+                plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_ESTIMATE);
+>>>>>>> fed43ec... More rigorous exceptions
                 fftwf_execute(plan);
             }
+            fftwf_destroy_plan(plan);
+
+            // normalize after FFT
+            for(i=0; i<user_params->HII_DIM; i++){
+                for(j=0; j<user_params->HII_DIM; j++){
+                    for(k=0; k<user_params->HII_DIM; k++){
+                        *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k)) /= (float)HII_TOT_NUM_PIXELS;
+                        if (*((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k)) < -1) // shouldn't happen
+                            *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k)) = -1+FRACT_FLOAT_ERR;
+                    }
+                }
+            }
+
+            for (i=0; i<user_params->HII_DIM; i++){
+                for (j=0; j<user_params->HII_DIM; j++){
+                    for (k=0; k<user_params->HII_DIM; k++){
+                        *((float *)perturbed_field->density + HII_R_INDEX(i,j,k)) = *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k));
+                    }
+                }
+            }
+
+            memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
         }
+<<<<<<< HEAD
         else {
             plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                          (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_ESTIMATE);
             fftwf_execute(plan);
         }
         fftwf_destroy_plan(plan);
+=======
+>>>>>>> fed43ec... More rigorous exceptions
 
-        //smooth the field
-        if (!global_params.EVOLVE_DENSITY_LINEARLY && global_params.SMOOTH_EVOLVED_DENSITY_FIELD){
-            filter_box(LOWRES_density_perturb, 1, 2, global_params.R_smooth_density*user_params->BOX_LEN/(float)user_params->HII_DIM);
+        float k_x, k_y, k_z, k_sq, dDdt_over_D;
+        int n_x, n_y, n_z;
+
+        dDdt_over_D = dDdt/growth_factor;
+
+        for (n_x=0; n_x<user_params->HII_DIM; n_x++){
+            if (n_x>HII_MIDDLE)
+                k_x =(n_x-user_params->HII_DIM) * DELTA_K;  // wrap around for FFT convention
+            else
+                k_x = n_x * DELTA_K;
+
+            for (n_y=0; n_y<user_params->HII_DIM; n_y++){
+                if (n_y>HII_MIDDLE)
+                    k_y =(n_y-user_params->HII_DIM) * DELTA_K;
+                else
+                    k_y = n_y * DELTA_K;
+
+                for (n_z=0; n_z<=HII_MIDDLE; n_z++){
+                    k_z = n_z * DELTA_K;
+
+                    k_sq = k_x*k_x + k_y*k_y + k_z*k_z;
+
+                    // now set the velocities
+                    if ((n_x==0) && (n_y==0) && (n_z==0)) // DC mode
+                        LOWRES_density_perturb[0] = 0;
+                    else{
+                        LOWRES_density_perturb[HII_C_INDEX(n_x,n_y,n_z)] *= dDdt_over_D*k_z*I/k_sq/(HII_TOT_NUM_PIXELS+0.0);
+                    }
+                }
+            }
         }
 
-        // save a copy of the k-space density field
         memcpy(LOWRES_density_perturb_saved, LOWRES_density_perturb, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
 
         if(user_params->USE_FFTW_WISDOM) {
@@ -346,8 +574,12 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
             }
             else {
 
+<<<<<<< HEAD
                 plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                              (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_PATIENT);
+=======
+                plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_ESTIMATE);
+>>>>>>> fed43ec... More rigorous exceptions
                 fftwf_execute(plan);
 
                 // Store the wisdom for later use
@@ -369,6 +601,7 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
         }
         fftwf_destroy_plan(plan);
 
+<<<<<<< HEAD
         // normalize after FFT
 #pragma omp parallel shared(LOWRES_density_perturb) private(i,j,k) num_threads(user_params->N_THREADS)
         {
@@ -392,10 +625,17 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     for (k=0; k<user_params->HII_DIM; k++){
                         *((float *)perturbed_field->density + HII_R_INDEX(i,j,k)) = *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k));
                     }
+=======
+        for (i=0; i<user_params->HII_DIM; i++){
+            for (j=0; j<user_params->HII_DIM; j++){
+                for (k=0; k<user_params->HII_DIM; k++){
+                    *((float *)perturbed_field->velocity + HII_R_INDEX(i,j,k)) = *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k));
+>>>>>>> fed43ec... More rigorous exceptions
                 }
             }
         }
 
+<<<<<<< HEAD
         memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
     }
 
@@ -502,6 +742,15 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
 //    fftwf_destroy_plan(plan);
     fftwf_cleanup();
 
-    return(0);
+=======
+        // deallocate
+        fftwf_free(LOWRES_density_perturb);
+        fftwf_free(LOWRES_density_perturb_saved);
 
+    //    fftwf_destroy_plan(plan);
+        fftwf_cleanup();
+    }
+    Catch(error_code) return(error_code);
+>>>>>>> fed43ec... More rigorous exceptions
+    return(0);
 }

--- a/src/py21cmfast/src/PerturbField.c
+++ b/src/py21cmfast/src/PerturbField.c
@@ -40,8 +40,8 @@ int ComputePerturbField(
 
     // perform a very rudimentary check to see if we are underresolved and not using the linear approx
     if ((user_params->BOX_LEN > user_params->DIM) && !(global_params.EVOLVE_DENSITY_LINEARLY)){
-        fprintf(stderr, "perturb_field.c: WARNING: Resolution is likely too low for accurate evolved density fields\n \
-                It Is recommended that you either increase the resolution (DIM/Box_LEN) or set the EVOLVE_DENSITY_LINEARLY flag to 1\n");
+        LOG_WARNING("Resolution is likely too low for accurate evolved density fields\n \
+                It is recommended that you either increase the resolution (DIM/Box_LEN) or set the EVOLVE_DENSITY_LINEARLY flag to 1\n");
     }
 
     growth_factor = dicke(redshift);

--- a/src/py21cmfast/src/PerturbField.c
+++ b/src/py21cmfast/src/PerturbField.c
@@ -1,61 +1,60 @@
 
 // Re-write of perturb_field.c for being accessible within the MCMC
 
-int ComputePerturbField(float redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct InitialConditions *boxes, struct PerturbedField *perturbed_field) {
-
+int ComputePerturbField(
+    float redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params,
+    struct InitialConditions *boxes, struct PerturbedField *perturbed_field
+){
     /*
-     USAGE: perturb_field <REDSHIFT>
+     ComputePerturbField uses the first-order Langragian displacement field to move the
+     masses in the cells of the density field. The high-res density field is extrapolated
+     to some high-redshift (INITIAL_REDSHIFT in ANAL_PARAMS.H), then uses the zeldovich
+     approximation to move the grid "particles" onto the lower-res grid we use for the
+     maps. Then we recalculate the velocity fields on the perturbed grid.
+    */
 
-     PROGRAM PERTURB_FIELD uses the first-order Langragian displacement field to move the masses in the cells of the density field.
-     The high-res density field is extrapolated to some high-redshift (INITIAL_REDSHIFT in ANAL_PARAMS.H), then uses the zeldovich approximation
-     to move the grid "particles" onto the lower-res grid we use for the maps.  Then we recalculate the velocity fields on the perturbed grid.
-     */
+    int status;
+    Try{  // This Try{} wraps the whole function, so we don't indent.
 
     // Makes the parameter structs visible to a variety of functions/macros
     // Do each time to avoid Python garbage collection issues
-    int error_code;
+    Broadcast_struct_global_PS(user_params,cosmo_params);
+    Broadcast_struct_global_UF(user_params,cosmo_params);
 
-<<<<<<< HEAD
     omp_set_num_threads(user_params->N_THREADS);
     fftwf_init_threads();
     fftwf_plan_with_nthreads(user_params->N_THREADS);
     fftwf_cleanup_threads();
 
     char wisdom_filename[500];
-=======
-    Try {
->>>>>>> fed43ec... More rigorous exceptions
 
+    fftwf_complex *LOWRES_density_perturb, *LOWRES_density_perturb_saved;
+    fftwf_plan plan;
 
-        Broadcast_struct_global_PS(user_params,cosmo_params);
-        Broadcast_struct_global_UF(user_params,cosmo_params);
+    float growth_factor, displacement_factor_2LPT, init_growth_factor, init_displacement_factor_2LPT, xf, yf, zf;
+    float mass_factor, dDdt, f_pixel_factor, velocity_displacement_factor, velocity_displacement_factor_2LPT;
+    unsigned long long ct, HII_i, HII_j, HII_k;
+    int i,j,k, xi, yi, zi;
+    double ave_delta, new_ave_delta;
+    // ***************   BEGIN INITIALIZATION   ************************** //
 
-<<<<<<< HEAD
     // perform a very rudimentary check to see if we are underresolved and not using the linear approx
     if ((user_params->BOX_LEN > user_params->DIM) && !(global_params.EVOLVE_DENSITY_LINEARLY)){
         fprintf(stderr, "perturb_field.c: WARNING: Resolution is likely too low for accurate evolved density fields\n \
                 It Is recommended that you either increase the resolution (DIM/Box_LEN) or set the EVOLVE_DENSITY_LINEARLY flag to 1\n");
     }
-=======
-        char wisdom_filename[500];
->>>>>>> fed43ec... More rigorous exceptions
 
-        fftwf_complex *LOWRES_density_perturb, *LOWRES_density_perturb_saved;
-        fftwf_plan plan;
+    growth_factor = dicke(redshift);
+    displacement_factor_2LPT = -(3.0/7.0) * growth_factor*growth_factor; // 2LPT eq. D8
 
-        float growth_factor, displacement_factor_2LPT, init_growth_factor, init_displacement_factor_2LPT, xf, yf, zf;
-        float mass_factor, dDdt, f_pixel_factor, velocity_displacement_factor, velocity_displacement_factor_2LPT;
-        unsigned long long ct, HII_i, HII_j, HII_k;
-        int i,j,k, xi, yi, zi;
-        double ave_delta, new_ave_delta;
-        // ***************   BEGIN INITIALIZATION   ************************** //
+    dDdt = ddickedt(redshift); // time derivative of the growth factor (1/s)
+    init_growth_factor = dicke(global_params.INITIAL_REDSHIFT);
+    init_displacement_factor_2LPT = -(3.0/7.0) * init_growth_factor*init_growth_factor; // 2LPT eq. D8
 
-        // perform a very rudimentary check to see if we are underresolved and not using the linear approx
-        if ((user_params->BOX_LEN > user_params->DIM) && !(global_params.EVOLVE_DENSITY_LINEARLY)){
-            LOG_WARNING("Resolution is likely too low for accurate evolved density fields\n It Is recommended that you either increase the resolution (DIM/Box_LEN) or set the EVOLVE_DENSITY_LINEARLY flag to 1");
-        }
+    // allocate memory for the updated density, and initialize
+    LOWRES_density_perturb = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+    LOWRES_density_perturb_saved = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
 
-<<<<<<< HEAD
     double *resampled_box;
 
     // check if the linear evolution flag was set
@@ -63,21 +62,6 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
 #pragma omp parallel shared(growth_factor,boxes,LOWRES_density_perturb) private(i,j,k) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
-=======
-        growth_factor = dicke(redshift);
-        displacement_factor_2LPT = -(3.0/7.0) * growth_factor*growth_factor; // 2LPT eq. D8
-
-        dDdt = ddickedt(redshift); // time derivative of the growth factor (1/s)
-        init_growth_factor = dicke(global_params.INITIAL_REDSHIFT);
-        init_displacement_factor_2LPT = -(3.0/7.0) * init_growth_factor*init_growth_factor; // 2LPT eq. D8
-
-        // allocate memory for the updated density, and initialize
-        LOWRES_density_perturb = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
-        LOWRES_density_perturb_saved = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
-
-        // check if the linear evolution flag was set
-        if (global_params.EVOLVE_DENSITY_LINEARLY){
->>>>>>> fed43ec... More rigorous exceptions
             for (i=0; i<user_params->HII_DIM; i++){
                 for (j=0; j<user_params->HII_DIM; j++){
                     for (k=0; k<user_params->HII_DIM; k++){
@@ -86,7 +70,6 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                 }
             }
         }
-<<<<<<< HEAD
     }
     // first order Zel'Dovich perturbation
 
@@ -94,11 +77,6 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
 #pragma omp parallel shared(LOWRES_density_perturb) private(i,j,k) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
-=======
-        // first order Zel'Dovich perturbation
-        else{
-
->>>>>>> fed43ec... More rigorous exceptions
             for (i=0; i<user_params->HII_DIM; i++){
                 for (j=0; j<user_params->HII_DIM; j++){
                     for (k=0; k<user_params->HII_DIM; k++){
@@ -106,56 +84,46 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     }
                 }
             }
+        }
 
-            velocity_displacement_factor = (growth_factor-init_growth_factor) / user_params->BOX_LEN;
+        velocity_displacement_factor = (growth_factor-init_growth_factor) / user_params->BOX_LEN;
 
-<<<<<<< HEAD
         // now add the missing factor of D
 #pragma omp parallel shared(boxes,velocity_displacement_factor) private(ct) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
-=======
-            // now add the missing factor of D
->>>>>>> fed43ec... More rigorous exceptions
             for (ct=0; ct<HII_TOT_NUM_PIXELS; ct++){
                 boxes->lowres_vx[ct] *= velocity_displacement_factor; // this is now comoving displacement in units of box size
                 boxes->lowres_vy[ct] *= velocity_displacement_factor; // this is now comoving displacement in units of box size
                 boxes->lowres_vz[ct] *= velocity_displacement_factor; // this is now comoving displacement in units of box size
             }
-<<<<<<< HEAD
         }
-=======
->>>>>>> fed43ec... More rigorous exceptions
 
-            // find factor of HII pixel size / deltax pixel size
-            f_pixel_factor = user_params->DIM/(float)(user_params->HII_DIM);
-            mass_factor = pow(f_pixel_factor, 3);
+        // find factor of HII pixel size / deltax pixel size
+        f_pixel_factor = user_params->DIM/(float)(user_params->HII_DIM);
+        mass_factor = pow(f_pixel_factor, 3);
 
-            // * ************************************************************************* * //
-            // *                           BEGIN 2LPT PART                                 * //
-            // * ************************************************************************* * //
-            // reference: reference: Scoccimarro R., 1998, MNRAS, 299, 1097-1118 Appendix D
-            if(global_params.SECOND_ORDER_LPT_CORRECTIONS){
+        // * ************************************************************************* * //
+        // *                           BEGIN 2LPT PART                                 * //
+        // * ************************************************************************* * //
+        // reference: reference: Scoccimarro R., 1998, MNRAS, 299, 1097-1118 Appendix D
+        if(global_params.SECOND_ORDER_LPT_CORRECTIONS){
 
-                // allocate memory for the velocity boxes and read them in
-                velocity_displacement_factor_2LPT = (displacement_factor_2LPT - init_displacement_factor_2LPT) / user_params->BOX_LEN;
+            // allocate memory for the velocity boxes and read them in
+            velocity_displacement_factor_2LPT = (displacement_factor_2LPT - init_displacement_factor_2LPT) / user_params->BOX_LEN;
 
-<<<<<<< HEAD
             // now add the missing factor in eq. D9
 #pragma omp parallel shared(boxes,velocity_displacement_factor_2LPT) private(ct) num_threads(user_params->N_THREADS)
             {
 #pragma omp for
-=======
-                // now add the missing factor in eq. D9
->>>>>>> fed43ec... More rigorous exceptions
                 for (ct=0; ct<HII_TOT_NUM_PIXELS; ct++){
                     boxes->lowres_vx_2LPT[ct] *= velocity_displacement_factor_2LPT; // this is now comoving displacement in units of box size
                     boxes->lowres_vy_2LPT[ct] *= velocity_displacement_factor_2LPT; // this is now comoving displacement in units of box size
                     boxes->lowres_vz_2LPT[ct] *= velocity_displacement_factor_2LPT; // this is now comoving displacement in units of box size
                 }
             }
+        }
 
-<<<<<<< HEAD
         // * ************************************************************************* * //
         // *                            END 2LPT PART                                  * //
         // * ************************************************************************* * //
@@ -171,15 +139,6 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     private(i,j,k,xi,xf,yi,yf,zi,zf,HII_i,HII_j,HII_k) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
-=======
-            // * ************************************************************************* * //
-            // *                            END 2LPT PART                                  * //
-            // * ************************************************************************* * //
-
-            // ************  END INITIALIZATION **************************** //
-
-            // go through the high-res box, mapping the mass onto the low-res (updated) box
->>>>>>> fed43ec... More rigorous exceptions
             for (i=0; i<user_params->DIM;i++){
                 for (j=0; j<user_params->DIM;j++){
                     for (k=0; k<user_params->DIM;k++){
@@ -224,7 +183,6 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                         if (zi >= (user_params->HII_DIM)){ zi -= (user_params->HII_DIM);}
                         if (zi < 0) {zi += (user_params->HII_DIM);}
 
-<<<<<<< HEAD
 #pragma omp atomic
                         resampled_box[HII_R_INDEX(xi,yi,zi)] += (double)(1. + init_growth_factor*(boxes->hires_density)[R_INDEX(i,j,k)]);
                     }
@@ -250,15 +208,6 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
 #pragma omp parallel shared(LOWRES_density_perturb,mass_factor) private(i,j,k) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
-=======
-                        *( (float *)LOWRES_density_perturb + HII_R_FFT_INDEX(xi, yi, zi) ) +=
-                        (1 + init_growth_factor*(boxes->hires_density)[R_INDEX(i,j,k)]);
-                    }
-                }
-            }
-
-            // renormalize to the new pixel size, and make into delta
->>>>>>> fed43ec... More rigorous exceptions
             for (i=0; i<user_params->HII_DIM; i++){
                 for (j=0; j<user_params->HII_DIM; j++){
                     for (k=0; k<user_params->HII_DIM; k++){
@@ -267,20 +216,16 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     }
                 }
             }
+        }
 
-<<<<<<< HEAD
         // deallocate
 #pragma omp parallel shared(boxes,velocity_displacement_factor) private(ct) num_threads(user_params->N_THREADS)
         {
 #pragma omp for
-=======
-            // deallocate
->>>>>>> fed43ec... More rigorous exceptions
             for (ct=0; ct<HII_TOT_NUM_PIXELS; ct++){
                 boxes->lowres_vx[ct] /= velocity_displacement_factor; // convert back to z = 0 quantity
                 boxes->lowres_vy[ct] /= velocity_displacement_factor; // convert back to z = 0 quantity
                 boxes->lowres_vz[ct] /= velocity_displacement_factor; // convert back to z = 0 quantity
-<<<<<<< HEAD
             }
         }
 
@@ -293,11 +238,10 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     boxes->lowres_vy_2LPT[ct] /= velocity_displacement_factor_2LPT; // convert back to z = 0 quantity
                     boxes->lowres_vz_2LPT[ct] /= velocity_displacement_factor_2LPT; // convert back to z = 0 quantity
                 }
-=======
->>>>>>> fed43ec... More rigorous exceptions
             }
+        }
+    }
 
-<<<<<<< HEAD
     // ****  Print and convert to velocities ***** //
     if (global_params.EVOLVE_DENSITY_LINEARLY){
 #pragma omp parallel shared(perturbed_field,LOWRES_density_perturb) private(i,j,k) num_threads(user_params->N_THREADS)
@@ -308,18 +252,10 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     for (k=0; k<user_params->HII_DIM; k++){
                         *((float *)perturbed_field->density + HII_R_INDEX(i,j,k)) = *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k));
                     }
-=======
-            if(global_params.SECOND_ORDER_LPT_CORRECTIONS){
-                for (ct=0; ct<HII_TOT_NUM_PIXELS; ct++){
-                    boxes->lowres_vx_2LPT[ct] /= velocity_displacement_factor_2LPT; // convert back to z = 0 quantity
-                    boxes->lowres_vy_2LPT[ct] /= velocity_displacement_factor_2LPT; // convert back to z = 0 quantity
-                    boxes->lowres_vz_2LPT[ct] /= velocity_displacement_factor_2LPT; // convert back to z = 0 quantity
->>>>>>> fed43ec... More rigorous exceptions
                 }
             }
         }
 
-<<<<<<< HEAD
         // transform to k-space
         if(user_params->USE_FFTW_WISDOM) {
             // Check to see if the wisdom exists, create it if it doesn't
@@ -337,86 +273,31 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                 plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                              (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_PATIENT);
                 fftwf_execute(plan);
-=======
-        // ****  Print and convert to velocities ***** //
-        if (global_params.EVOLVE_DENSITY_LINEARLY){
-            for (i=0; i<user_params->HII_DIM; i++){
-                for (j=0; j<user_params->HII_DIM; j++){
-                    for (k=0; k<user_params->HII_DIM; k++){
-                        *((float *)perturbed_field->density + HII_R_INDEX(i,j,k)) = *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k));
-                    }
-                }
-            }
 
-            // transform to k-space
-            if(user_params->USE_FFTW_WISDOM) {
-                // Check to see if the wisdom exists, create it if it doesn't
-                sprintf(wisdom_filename,"real_to_complex_%d.fftwf_wisdom",user_params->HII_DIM);
-                if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
-                    fftwf_execute(plan);
+                // Store the wisdom for later use
+                fftwf_export_wisdom_to_filename(wisdom_filename);
 
-                }
-                else {
->>>>>>> fed43ec... More rigorous exceptions
+                // copy over unfiltered box
+                memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
 
-                    // save a copy of the k-space density field
-                    memcpy(LOWRES_density_perturb_saved, LOWRES_density_perturb, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
-
-                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_PATIENT);
-                    fftwf_execute(plan);
-
-<<<<<<< HEAD
                 fftwf_destroy_plan(plan);
 
                 plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                              (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
-=======
-                    // Store the wisdom for later use
-                    fftwf_export_wisdom_to_filename(wisdom_filename);
-
-                    // copy over unfiltered box
-                    memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
-
-                    fftwf_destroy_plan(plan);
-                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
-                    fftwf_execute(plan);
-                }
-            }
-            else {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_ESTIMATE);
->>>>>>> fed43ec... More rigorous exceptions
                 fftwf_execute(plan);
             }
-            fftwf_destroy_plan(plan);
-
-            // save a copy of the k-space density field
         }
-<<<<<<< HEAD
         else {
             plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                          (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_ESTIMATE);
             fftwf_execute(plan);
         }
         fftwf_destroy_plan(plan);
-=======
-        else{
 
-            // transform to k-space
-            if(user_params->USE_FFTW_WISDOM) {
-                // Check to see if the wisdom exists, create it if it doesn't
-                sprintf(wisdom_filename,"real_to_complex_%d.fftwf_wisdom",user_params->HII_DIM);
-                if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
-                    fftwf_execute(plan);
-                }
-                else {
->>>>>>> fed43ec... More rigorous exceptions
+        // save a copy of the k-space density field
+    }
+    else{
 
-                    // save a copy of the k-space density field
-                    memcpy(LOWRES_density_perturb_saved, LOWRES_density_perturb, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
-
-<<<<<<< HEAD
         // transform to k-space
         if(user_params->USE_FFTW_WISDOM) {
             // Check to see if the wisdom exists, create it if it doesn't
@@ -433,135 +314,31 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                 plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                              (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_PATIENT);
                 fftwf_execute(plan);
-=======
-                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_PATIENT);
-                    fftwf_execute(plan);
 
-                    // Store the wisdom for later use
-                    fftwf_export_wisdom_to_filename(wisdom_filename);
+                // Store the wisdom for later use
+                fftwf_export_wisdom_to_filename(wisdom_filename);
 
-                    // copy over unfiltered box
-                    memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
-                    fftwf_destroy_plan(plan);
-                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
-                    fftwf_execute(plan);
-                }
-            }
-            else {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_ESTIMATE);
-                fftwf_execute(plan);
-            }
-            fftwf_destroy_plan(plan);
-
-            //smooth the field
-            if (!global_params.EVOLVE_DENSITY_LINEARLY && global_params.SMOOTH_EVOLVED_DENSITY_FIELD){
-                filter_box(LOWRES_density_perturb, 1, 2, global_params.R_smooth_density*user_params->BOX_LEN/(float)user_params->HII_DIM);
-            }
-
-            // save a copy of the k-space density field
-            memcpy(LOWRES_density_perturb_saved, LOWRES_density_perturb, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
->>>>>>> fed43ec... More rigorous exceptions
-
-            if(user_params->USE_FFTW_WISDOM) {
-                // Check to see if the wisdom exists, create it if it doesn't
-                sprintf(wisdom_filename,"complex_to_real_%d.fftwf_wisdom",user_params->HII_DIM);
-                if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
-                    fftwf_execute(plan);
-                }
-                else {
-
-<<<<<<< HEAD
                 // copy over unfiltered box
                 memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
                 fftwf_destroy_plan(plan);
                 plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                              (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
-=======
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_PATIENT);
-                    fftwf_execute(plan);
-
-                    // Store the wisdom for later use
-                    fftwf_export_wisdom_to_filename(wisdom_filename);
-
-                    // copy over unfiltered box
-                    memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
-
-                    fftwf_destroy_plan(plan);
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_WISDOM_ONLY);
-                    fftwf_execute(plan);
-                }
-            }
-            else {
-                plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_ESTIMATE);
->>>>>>> fed43ec... More rigorous exceptions
                 fftwf_execute(plan);
             }
-            fftwf_destroy_plan(plan);
-
-            // normalize after FFT
-            for(i=0; i<user_params->HII_DIM; i++){
-                for(j=0; j<user_params->HII_DIM; j++){
-                    for(k=0; k<user_params->HII_DIM; k++){
-                        *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k)) /= (float)HII_TOT_NUM_PIXELS;
-                        if (*((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k)) < -1) // shouldn't happen
-                            *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k)) = -1+FRACT_FLOAT_ERR;
-                    }
-                }
-            }
-
-            for (i=0; i<user_params->HII_DIM; i++){
-                for (j=0; j<user_params->HII_DIM; j++){
-                    for (k=0; k<user_params->HII_DIM; k++){
-                        *((float *)perturbed_field->density + HII_R_INDEX(i,j,k)) = *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k));
-                    }
-                }
-            }
-
-            memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
         }
-<<<<<<< HEAD
         else {
             plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                          (float *)LOWRES_density_perturb, (fftwf_complex *)LOWRES_density_perturb, FFTW_ESTIMATE);
             fftwf_execute(plan);
         }
         fftwf_destroy_plan(plan);
-=======
->>>>>>> fed43ec... More rigorous exceptions
 
-        float k_x, k_y, k_z, k_sq, dDdt_over_D;
-        int n_x, n_y, n_z;
-
-        dDdt_over_D = dDdt/growth_factor;
-
-        for (n_x=0; n_x<user_params->HII_DIM; n_x++){
-            if (n_x>HII_MIDDLE)
-                k_x =(n_x-user_params->HII_DIM) * DELTA_K;  // wrap around for FFT convention
-            else
-                k_x = n_x * DELTA_K;
-
-            for (n_y=0; n_y<user_params->HII_DIM; n_y++){
-                if (n_y>HII_MIDDLE)
-                    k_y =(n_y-user_params->HII_DIM) * DELTA_K;
-                else
-                    k_y = n_y * DELTA_K;
-
-                for (n_z=0; n_z<=HII_MIDDLE; n_z++){
-                    k_z = n_z * DELTA_K;
-
-                    k_sq = k_x*k_x + k_y*k_y + k_z*k_z;
-
-                    // now set the velocities
-                    if ((n_x==0) && (n_y==0) && (n_z==0)) // DC mode
-                        LOWRES_density_perturb[0] = 0;
-                    else{
-                        LOWRES_density_perturb[HII_C_INDEX(n_x,n_y,n_z)] *= dDdt_over_D*k_z*I/k_sq/(HII_TOT_NUM_PIXELS+0.0);
-                    }
-                }
-            }
+        //smooth the field
+        if (!global_params.EVOLVE_DENSITY_LINEARLY && global_params.SMOOTH_EVOLVED_DENSITY_FIELD){
+            filter_box(LOWRES_density_perturb, 1, 2, global_params.R_smooth_density*user_params->BOX_LEN/(float)user_params->HII_DIM);
         }
 
+        // save a copy of the k-space density field
         memcpy(LOWRES_density_perturb_saved, LOWRES_density_perturb, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
 
         if(user_params->USE_FFTW_WISDOM) {
@@ -574,12 +351,8 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
             }
             else {
 
-<<<<<<< HEAD
                 plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
                                              (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_PATIENT);
-=======
-                plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM, (fftwf_complex *)LOWRES_density_perturb, (float *)LOWRES_density_perturb, FFTW_ESTIMATE);
->>>>>>> fed43ec... More rigorous exceptions
                 fftwf_execute(plan);
 
                 // Store the wisdom for later use
@@ -601,7 +374,6 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
         }
         fftwf_destroy_plan(plan);
 
-<<<<<<< HEAD
         // normalize after FFT
 #pragma omp parallel shared(LOWRES_density_perturb) private(i,j,k) num_threads(user_params->N_THREADS)
         {
@@ -625,17 +397,10 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
                     for (k=0; k<user_params->HII_DIM; k++){
                         *((float *)perturbed_field->density + HII_R_INDEX(i,j,k)) = *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k));
                     }
-=======
-        for (i=0; i<user_params->HII_DIM; i++){
-            for (j=0; j<user_params->HII_DIM; j++){
-                for (k=0; k<user_params->HII_DIM; k++){
-                    *((float *)perturbed_field->velocity + HII_R_INDEX(i,j,k)) = *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k));
->>>>>>> fed43ec... More rigorous exceptions
                 }
             }
         }
 
-<<<<<<< HEAD
         memcpy(LOWRES_density_perturb, LOWRES_density_perturb_saved, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
     }
 
@@ -738,19 +503,12 @@ int ComputePerturbField(float redshift, struct UserParams *user_params, struct C
     // deallocate
     fftwf_free(LOWRES_density_perturb);
     fftwf_free(LOWRES_density_perturb_saved);
-
-//    fftwf_destroy_plan(plan);
     fftwf_cleanup();
 
-=======
-        // deallocate
-        fftwf_free(LOWRES_density_perturb);
-        fftwf_free(LOWRES_density_perturb_saved);
-
-    //    fftwf_destroy_plan(plan);
-        fftwf_cleanup();
+    } // End of Try{}
+    Catch(status){
+        return(status);
     }
-    Catch(error_code) return(error_code);
->>>>>>> fed43ec... More rigorous exceptions
+
     return(0);
 }

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -39,7 +39,8 @@ int ComputeTsBox(float redshift, float prev_redshift, struct UserParams *user_pa
                   struct AstroParams *astro_params, struct FlagOptions *flag_options,
                   float perturbed_field_redshift, short cleanup,
                   struct PerturbedField *perturbed_field, struct TsBox *previous_spin_temp, struct TsBox *this_spin_temp) {
-
+    int status;
+    Try{ // This Try{} wraps the whole function.
 LOG_DEBUG("input values:");
 LOG_DEBUG("redshift=%f, prev_redshift=%f perturbed_field_redshift=%f", redshift, prev_redshift, perturbed_field_redshift);
 if (LOG_LEVEL >= DEBUG_LEVEL){
@@ -2073,7 +2074,10 @@ LOG_SUPER_DEBUG("finished loop");
 
     free(table_int_boundexceeded_threaded);
     free(fcoll_int_boundexceeded_threaded);
-
+    } // End of try
+    Catch(status){
+        return(status);
+    }
     return(0);
 }
 

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -386,16 +386,10 @@ LOG_SUPER_DEBUG("Initialised PS");
 
         if(flag_options->M_MIN_in_Mass || flag_options->USE_MASS_DEPENDENT_ZETA) {
             if (flag_options->USE_MINI_HALOS){
-                if(initialiseSigmaMInterpTable(global_params.M_MIN_INTEGRAL/50,1e20)!=0) {
-                    LOG_ERROR("Detected either an infinite or NaN value in initialiseSigmaMInterpTable");
-                    return(2);
-                }
+                initialiseSigmaMInterpTable(global_params.M_MIN_INTEGRAL/50,1e20);
             }
             else{
-                if(initialiseSigmaMInterpTable(M_MIN,1e20)!=0) {
-                    LOG_ERROR("Detected either an infinite or NaN value in initialiseSigmaMInterpTable");
-                    return(2);
-                }
+                initialiseSigmaMInterpTable(M_MIN,1e20);
             }
         }
         LOG_SUPER_DEBUG("Initialised sigmaM interp table");
@@ -433,13 +427,11 @@ LOG_SUPER_DEBUG("read in file");
 
         if(!flag_options->M_MIN_in_Mass) {
             M_MIN = TtoM(redshift, astro_params->X_RAY_Tvir_MIN, mu_for_Ts);
-LOG_DEBUG("Attempting to initialise sigmaM table with M_MIN=%e, Tvir_MIN=%e, mu=%e", M_MIN, astro_params->X_RAY_Tvir_MIN, mu_for_Ts);
-            if(initialiseSigmaMInterpTable(M_MIN,1e20)!=0) {
-                LOG_ERROR("Detected either an infinite or NaN value in initialiseSigmaMInterpTable");
-                return(2);
-            }
+            LOG_DEBUG("Attempting to initialise sigmaM table with M_MIN=%e, Tvir_MIN=%e, mu=%e",
+                      M_MIN, astro_params->X_RAY_Tvir_MIN, mu_for_Ts);
+            initialiseSigmaMInterpTable(M_MIN,1e20);
         }
-LOG_SUPER_DEBUG("Initialised Sigma interp table");
+        LOG_SUPER_DEBUG("Initialised Sigma interp table");
 
     }
     else {
@@ -630,7 +622,7 @@ LOG_ULTRA_DEBUG("Executed FFT for R=%f", R);
                             for (k=0;k<user_params->HII_DIM; k++){
                                 curr_delNL0 = *((float *)box + HII_R_FFT_INDEX(i,j,k));
 
-                                if (curr_delNL0 <= -1){ // correct for alliasing in the filtering step
+                                if (curr_delNL0 <= -1){ // correct for aliasing in the filtering step
                                     curr_delNL0 = -1+FRACT_FLOAT_ERR;
                                 }
 
@@ -727,14 +719,10 @@ LOG_SUPER_DEBUG("Finished loop through filter scales R");
 
         if(!flag_options->M_MIN_in_Mass) {
             M_MIN = TtoM(determine_zpp_max, astro_params->X_RAY_Tvir_MIN, mu_for_Ts);
-
-            if(initialiseSigmaMInterpTable(M_MIN,1e20)!=0) {
-                LOG_ERROR("Detected either an infinite or NaN value in initialiseSigmaMInterpTable");
-                return(2);
-            }
+            initialiseSigmaMInterpTable(M_MIN,1e20);
         }
 
-LOG_SUPER_DEBUG("Initialised sigma interp table");
+        LOG_SUPER_DEBUG("Initialised sigma interp table");
 
         zpp_bin_width = (determine_zpp_max - determine_zpp_min)/((float)zpp_interp_points_SFR-1.0);
 
@@ -753,32 +741,20 @@ LOG_SUPER_DEBUG("Initialised sigma interp table");
 
                 /* initialise interpolation of the mean collapse fraction for global reionization.*/
                 if (!flag_options->USE_MINI_HALOS){
-                    if(initialise_Nion_Ts_spline(zpp_interp_points_SFR, determine_zpp_min, determine_zpp_max,
+                    initialise_Nion_Ts_spline(zpp_interp_points_SFR, determine_zpp_min, determine_zpp_max,
                                                  astro_params->M_TURN, astro_params->ALPHA_STAR, astro_params->ALPHA_ESC,
-                                                 astro_params->F_STAR10, astro_params->F_ESC10)!=0) {
-                        LOG_ERROR("Detected either an infinite or NaN value in initialise_Nion_Ts_spline");
-                        return(2);
-                    }
+                                                 astro_params->F_STAR10, astro_params->F_ESC10);
 
-                    if(initialise_SFRD_spline(zpp_interp_points_SFR, determine_zpp_min, determine_zpp_max,
-                                              astro_params->M_TURN, astro_params->ALPHA_STAR, astro_params->F_STAR10)!=0) {
-                        LOG_ERROR("Detected either an infinite or NaN value in initialise_SFRD_spline");
-                        return(2);
-                    }
+                    initialise_SFRD_spline(zpp_interp_points_SFR, determine_zpp_min, determine_zpp_max,
+                                              astro_params->M_TURN, astro_params->ALPHA_STAR, astro_params->F_STAR10);
                 }
                 else{
-                    if(initialise_Nion_Ts_spline_MINI(zpp_interp_points_SFR, determine_zpp_min, determine_zpp_max,
+                    initialise_Nion_Ts_spline_MINI(zpp_interp_points_SFR, determine_zpp_min, determine_zpp_max,
                                                       astro_params->ALPHA_STAR, astro_params->ALPHA_ESC, astro_params->F_STAR10,
-                                                      astro_params->F_ESC10, astro_params->F_STAR7_MINI, astro_params->F_ESC7_MINI)!=0) {
-                        LOG_ERROR("Detected either an infinite or NaN value in initialise_Nion_Ts_spline_MINI");
-                        return(2);
-                    }
+                                                      astro_params->F_ESC10, astro_params->F_STAR7_MINI, astro_params->F_ESC7_MINI);
 
-                    if(initialise_SFRD_spline_MINI(zpp_interp_points_SFR, determine_zpp_min, determine_zpp_max,
-                                                   astro_params->ALPHA_STAR, astro_params->F_STAR10, astro_params->F_STAR7_MINI)!=0) {
-                        LOG_ERROR("Detected either an infinite or NaN value in initialise_SFRD_spline_MINI");
-                        return(2);
-                    }
+                    initialise_SFRD_spline_MINI(zpp_interp_points_SFR, determine_zpp_min, determine_zpp_max,
+                                                   astro_params->ALPHA_STAR, astro_params->F_STAR10, astro_params->F_STAR7_MINI);
                 }
             }
             else {
@@ -892,26 +868,20 @@ LOG_SUPER_DEBUG("got density gridpoints");
             }
 
             if (!flag_options->USE_MINI_HALOS){
-                if(initialise_SFRD_Conditional_table(global_params.NUM_FILTER_STEPS_FOR_Ts,min_densities,
+                initialise_SFRD_Conditional_table(global_params.NUM_FILTER_STEPS_FOR_Ts,min_densities,
                                                      max_densities,zpp_growth,R_values, astro_params->M_TURN,
-                                                     astro_params->ALPHA_STAR, astro_params->F_STAR10)!=0) {
-                    LOG_ERROR("Detected either an infinite or NaN value in initialise_SFRD_Conditional_table");
-                    return(2);
-                };
+                                                     astro_params->ALPHA_STAR, astro_params->F_STAR10);
             }
             else{
-                if(initialise_SFRD_Conditional_table_MINI(global_params.NUM_FILTER_STEPS_FOR_Ts,min_densities,
+                initialise_SFRD_Conditional_table_MINI(global_params.NUM_FILTER_STEPS_FOR_Ts,min_densities,
                                                           max_densities,zpp_growth,R_values,Mcrit_atom_interp_table,
                                                           astro_params->ALPHA_STAR, astro_params->F_STAR10,
-                                                          astro_params->F_STAR7_MINI)!=0) {
-                    LOG_ERROR("Detected either an infinite or NaN value in initialise_SFRD_Conditional_table_MINI");
-                    return(2);
-                };
+                                                          astro_params->F_STAR7_MINI);
             }
 
         }
 
-LOG_SUPER_DEBUG("Initialised SFRD table");
+        LOG_SUPER_DEBUG("Initialised SFRD table");
 
         zp = redshift;
         prev_zp = prev_redshift;
@@ -922,7 +892,7 @@ LOG_SUPER_DEBUG("Initialised SFRD table");
 
             if(redshift_int_Nion_z < 0 || (redshift_int_Nion_z + 1) > (zpp_interp_points_SFR - 1)) {
                 LOG_ERROR("I have overstepped my allocated memory for the interpolation table Nion_z_val");
-                return(2);
+                Throw(ParameterError);
             }
 
             redshift_table_Nion_z = determine_zpp_min + zpp_bin_width*(float)redshift_int_Nion_z;
@@ -1063,7 +1033,7 @@ LOG_SUPER_DEBUG("beginning loop over R_ct");
 
                 if(redshift_int_SFRD < 0 || (redshift_int_SFRD + 1) > (zpp_interp_points_SFR - 1)) {
                     LOG_ERROR("I have overstepped my allocated memory for the interpolation table SFRD_val");
-                    return(2);
+                    Throw(ParameterError);
                 }
 
                 redshift_table_SFRD = determine_zpp_min + zpp_bin_width*(float)redshift_int_SFRD;
@@ -1137,7 +1107,7 @@ LOG_SUPER_DEBUG("beginning loop over R_ct");
 
                 if(zpp_gridpoint1_int < 0 || (zpp_gridpoint1_int + 1) > (zpp_interp_points_SFR - 1)) {
                     LOG_ERROR("I have overstepped my allocated memory for the interpolation table fcoll_R_grid");
-                    return(2);
+                    Throw(ParameterError);
                 }
 
                 zpp_gridpoint1 = determine_zpp_min + zpp_bin_width*(float)zpp_gridpoint1_int;
@@ -1179,11 +1149,6 @@ LOG_SUPER_DEBUG("beginning loop over R_ct");
                 lower_int_limit = FMAX(nu_tau_one_approx(zp, zpp, x_e_ave, filling_factor_of_HI_zp), (astro_params->NU_X_THRESH)*NU_over_EV);
             }
 
-            if(isfinite(lower_int_limit)==0) {
-                LOG_ERROR("lower_int_limit has returned either an infinity or a NaN");
-                return(2);
-            }
-
             if (filling_factor_of_HI_zp < 0) filling_factor_of_HI_zp = 0; // for global evol; nu_tau_one above treats negative (post_reionization) inferred filling factors properly
 
             // set up frequency integral table for later interpolation for the cell's x_e value
@@ -1194,7 +1159,7 @@ LOG_SUPER_DEBUG("beginning loop over R_ct");
 
                 if(isfinite(freq_int_heat_tbl[x_e_ct][R_ct])==0 || isfinite(freq_int_ion_tbl[x_e_ct][R_ct])==0 || isfinite(freq_int_lya_tbl[x_e_ct][R_ct])==0) {
                     LOG_ERROR("One of the frequency interpolation tables has an infinity or a NaN");
-                    return(2);
+                    Throw(ParameterError);
                 }
             }
 
@@ -1251,7 +1216,7 @@ LOG_SUPER_DEBUG("finished looping over R_ct filter steps");
                 }
                 if(table_int_boundexceeded==1) {
                     LOG_ERROR("I have overstepped my allocated memory for one of the interpolation tables of fcoll");
-                    return(2);
+                    Throw(ParameterError);
                 }
             }
             else {
@@ -1282,7 +1247,7 @@ LOG_SUPER_DEBUG("finished looping over R_ct filter steps");
                 for(i=0;i<user_params->N_THREADS;i++) {
                     if(table_int_boundexceeded_threaded[i]==1) {
                         LOG_ERROR("I have overstepped my allocated memory for one of the interpolation tables of fcoll");
-                        return(2);
+                        Throw(ParameterError);
                     }
                 }
             }
@@ -1591,7 +1556,7 @@ LOG_SUPER_DEBUG("looping over box...");
                 for(i=0;i<user_params->N_THREADS;i++) {
                     if(fcoll_int_boundexceeded_threaded[omp_get_thread_num()]==1) {
                         LOG_ERROR("I have overstepped my allocated memory for one of the interpolation tables for the fcoll/nion_splines");
-                        return(2);
+                        Throw(ParameterError);
                     }
                 }
 
@@ -2000,7 +1965,7 @@ LOG_SUPER_DEBUG("looping over box...");
             for(i=0;i<user_params->N_THREADS; i++) {
                 if(table_int_boundexceeded_threaded[i]==1) {
                     LOG_ERROR("I have overstepped my allocated memory for one of the interpolation tables of dfcoll_dz_val");
-                    return(2);
+                    Throw(ParameterError);
                 }
             }
         }
@@ -2008,7 +1973,7 @@ LOG_SUPER_DEBUG("looping over box...");
         for (box_ct=0; box_ct<HII_TOT_NUM_PIXELS; box_ct++){
             if(isfinite(this_spin_temp->Ts_box[box_ct])==0) {
                 LOG_ERROR("Estimated spin temperature is either infinite of NaN!");
-                return(2);
+                Throw(ParameterError);
             }
         }
 

--- a/src/py21cmfast/src/UsefulFunctions.c
+++ b/src/py21cmfast/src/UsefulFunctions.c
@@ -221,7 +221,7 @@ double MtoR(double M){
         return pow( M/(pow(2*PI, 1.5) * cosmo_params_ufunc->OMm * RHOcrit), 1.0/3.0 );
     else // filter not defined
         LOG_ERROR("No such filter = %i. Results are bogus.", global_params.FILTER);
-    return -1;
+    Throw ValueError;
 }
 
 /* R in Mpc, M in Msun */
@@ -233,7 +233,7 @@ double RtoM(double R){
         return pow(2*PI, 1.5) * cosmo_params_ufunc->OMm*RHOcrit * pow(R, 3);
     else // filter not defined
         LOG_ERROR("No such filter = %i. Results are bogus.", global_params.FILTER);
-    return -1;
+    Throw ValueError;
 }
 
 /*
@@ -311,11 +311,11 @@ double dicke(double z){
     }
     else if ( (cosmo_params_ufunc->OMl > (-tiny)) && (fabs(global_params.OMtot-1.0) < tiny) && (fabs(global_params.wl+1) > tiny) ){
         LOG_WARNING("IN WANG.");
-        return -1;
+        Throw ValueError;
     }
 
-    LOG_ERROR("No growth function!!! Output will be fucked up.");
-    return -1;
+    LOG_ERROR("No growth function!");
+    Throw ValueError;
 }
 
 /* function DTDZ returns the value of dt/dz at the redshift parameter z. */
@@ -354,8 +354,8 @@ double ddickedt(double z){
         return ddickdz / dick_0 / dtdz(z);
     }
 
-    LOG_ERROR("No growth function!!! Output will be fucked up.");
-    return -1;
+    LOG_ERROR("No growth function!");
+    Throw ValueError;
 }
 
 /* returns the hubble "constant" (in 1/sec) at z */
@@ -497,10 +497,6 @@ double dtau_e_dz(double z, void *params){
 
         // linearly interpolate in redshift
         xH = p.xH[i-1] + (p.xH[i] - p.xH[i-1])/(p.z[i] - p.z[i-1]) * (z - p.z[i-1]);
-        /*
-         fprintf(stderr, "in taue: Interpolating between xH(%f)=%f and xH(%f)=%f to obtain xH(%f)=%f\n",
-         p.z[i-1], p.xH[i-1], p.z[i], p.xH[i], z, xH);
-         */
         xi = 1.0-xH;
         if (xi<0){
             LOG_WARNING("in taue: funny business xi=%e, changing to 0.", xi);
@@ -524,7 +520,7 @@ double tau_e(float zstart, float zend, float *zarry, float *xHarry, int len){
 
     if (zstart >= zend){
         LOG_ERROR("in tau_e: First parameter must be smaller than the second.\n");
-        return 0;
+        Throw ValueError;
     }
 
     F.function = &dtau_e_dz;

--- a/src/py21cmfast/src/UsefulFunctions.c
+++ b/src/py21cmfast/src/UsefulFunctions.c
@@ -833,3 +833,40 @@ double reionization_feedback(float z, float Gamma_halo_HII, float z_IN){
     return REION_SM13_M0 * pow(HALO_BIAS * Gamma_halo_HII, REION_SM13_A) * pow((1.+z)/10, REION_SM13_B) *
         pow(1 - pow((1.+z)/(1.+z_IN), REION_SM13_C), REION_SM13_D);
 }
+
+
+/*
+    The following functions are simply for testing the exception framework
+*/
+void FunctionThatThrows(){
+    Throw(ParameterError);
+}
+
+int SomethingThatCatches(bool sub_func){
+    // A simple function that catches a thrown error.
+    int status;
+    Try{
+        if(sub_func) FunctionThatThrows();
+        else Throw(ParameterError);
+    }
+    Catch(status){
+        return status;
+    }
+    return 0;
+}
+
+int FunctionThatCatches(bool sub_func, bool pass, double *result){
+    int status;
+    if(!pass){
+        Try{
+            if(sub_func) FunctionThatThrows();
+            else Throw(ParameterError);
+        }
+        Catch(status){
+            LOG_DEBUG("Caught the problem with status %d.", status);
+            return status;
+        }
+    }
+    *result = 5.0;
+    return 0;
+}

--- a/src/py21cmfast/src/bubble_helper_progs.c
+++ b/src/py21cmfast/src/bubble_helper_progs.c
@@ -252,12 +252,7 @@ void check_region(float * box, int dimensions, float Rsq_curr_index, int x, int 
 	else if (z_index>=dimensions) {z_index -= dimensions;}
 
 	// now check
-	//	printf("checking %i, %i, %i\n", x_index, y_index, z_index);
-	//printf("this is index, %llu\n", HII_R_INDEX(x_index, y_index, z_index));
-	//fflush(NULL);
 	if (box[HII_R_INDEX(x_index, y_index, z_index)]){ // untaken pixel (not part of other halo)
-	  //	  printf("in if\n");
-	  // fflush(NULL);
 	  // remember to check all reflections
 	  xsq = pow(x-x_index, 2);
 	  ysq = pow(y-y_index, 2);
@@ -308,10 +303,7 @@ void check_region(float * box, int dimensions, float Rsq_curr_index, int x, int 
 	     ){
 
 	    // we are within the sphere defined by R, so change flag in box array
-	    	    box[HII_R_INDEX(x_index, y_index, z_index)] = 0;
-	    //	    box[HII_R_INDEX(x_index, y_index, z_index)] = 15;
-	    //printf("%i, %i, %i\n", x_index, y_index, z_index);
-		    //		    fflush(NULL);
+	    box[HII_R_INDEX(x_index, y_index, z_index)] = 0;
 	  }
 	}
       }
@@ -332,8 +324,6 @@ void update_in_sphere(float * box, int dimensions, float R, float xf, float yf, 
   int x_index, y_index, z_index, x, y, z;
 
   if (R<0) return;
-  //  printf("in update, dim=%i, R=%f, x=%f, y=%f, z=%f\n", dimensions, R, xf, yf, zf);
-  //fflush(NULL);
   // convert distances to index units
   x = (int) (xf * dimensions + 0.5); // +0.5 for rounding
   y = (int) (yf * dimensions + 0.5);

--- a/src/py21cmfast/src/cexcept.h
+++ b/src/py21cmfast/src/cexcept.h
@@ -1,0 +1,248 @@
+/*===
+cexcept.h 2.0.1 (2008-Jul-19-Sat)
+http://www.nicemice.net/cexcept/
+Adam M. Costello
+http://www.nicemice.net/amc/
+
+An interface for exception-handling in ANSI C (C89 and subsequent ISO
+standards), developed jointly with Cosmin Truta.
+
+    Copyright (c) 2000-2008 Adam M. Costello and Cosmin Truta.
+    This software may be modified only if its author and version
+    information is updated accurately, and may be redistributed
+    only if accompanied by this unaltered notice.  Subject to those
+    restrictions, permission is granted to anyone to do anything
+    with this software.  The copyright holders make no guarantees
+    regarding this software, and are not responsible for any damage
+    resulting from its use.
+
+The cexcept interface is not compatible with and cannot interact
+with system exceptions (like division by zero or memory segmentation
+violation), compiler-generated exceptions (like C++ exceptions), or
+other exception-handling interfaces.
+
+When using this interface across multiple .c files, do not include
+this header file directly.  Instead, create a wrapper header file that
+includes this header file and then invokes the define_exception_type
+macro (see below).  The .c files should then include that header file.
+
+The interface consists of one type, one well-known name, and six macros.
+
+
+define_exception_type(type_name);
+
+    This macro is used like an external declaration.  It specifies
+    the type of object that gets copied from the exception thrower to
+    the exception catcher.  The type_name can be any type that can be
+    assigned to, that is, a non-constant arithmetic type, struct, union,
+    or pointer.  Examples:
+
+        define_exception_type(int);
+
+        enum exception { out_of_memory, bad_arguments, disk_full };
+        define_exception_type(enum exception);
+
+        struct exception { int code; const char *msg; };
+        define_exception_type(struct exception);
+
+    Because throwing an exception causes the object to be copied (not
+    just once, but twice), programmers may wish to consider size when
+    choosing the exception type.
+
+
+struct exception_context;
+
+    This type may be used after the define_exception_type() macro has
+    been invoked.  A struct exception_context must be known to both
+    the thrower and the catcher.  It is expected that there be one
+    context for each thread that uses exceptions.  It would certainly
+    be dangerous for multiple threads to access the same context.
+    One thread can use multiple contexts, but that is likely to be
+    confusing and not typically useful.  The application can allocate
+    this structure in any way it pleases--automatic, static, or dynamic.
+    The application programmer should pretend not to know the structure
+    members, which are subject to change.
+
+
+struct exception_context *the_exception_context;
+
+    The Try/Catch and Throw statements (described below) implicitly
+    refer to a context, using the name the_exception_context.  It is
+    the application's responsibility to make sure that this name yields
+    the address of a mutable (non-constant) struct exception_context
+    wherever those statements are used.  Subject to that constraint, the
+    application may declare a variable of this name anywhere it likes
+    (inside a function, in a parameter list, or externally), and may
+    use whatever storage class specifiers (static, extern, etc) or type
+    qualifiers (const, volatile, etc) it likes.  Examples:
+
+        static struct exception_context
+          * const the_exception_context = &foo;
+
+        { struct exception_context *the_exception_context = bar; ... }
+
+        int blah(struct exception_context *the_exception_context, ...);
+
+        extern struct exception_context the_exception_context[1];
+
+    The last example illustrates a trick that avoids creating a pointer
+    object separate from the structure object.
+
+    The name could even be a macro, for example:
+
+        struct exception_context ec_array[numthreads];
+        #define the_exception_context (ec_array + thread_id)
+
+    Be aware that the_exception_context is used several times by the
+    Try/Catch/Throw macros, so it shouldn't be expensive or have side
+    effects.  The expansion must be a drop-in replacement for an
+    identifier, so it's safest to put parentheses around it.
+
+
+void init_exception_context(struct exception_context *ec);
+
+    For context structures allocated statically (by an external
+    definition or using the "static" keyword), the implicit
+    initialization to all zeros is sufficient, but contexts allocated
+    by other means must be initialized using this macro before they
+    are used by a Try/Catch statement.  It does no harm to initialize
+    a context more than once (by using this macro on a statically
+    allocated context, or using this macro twice on the same context),
+    but a context must not be re-initialized after it has been used by a
+    Try/Catch statement.
+
+
+Try statement
+Catch (expression) statement
+
+    The Try/Catch/Throw macros are capitalized in order to avoid
+    confusion with the C++ keywords, which have subtly different
+    semantics.
+
+    A Try/Catch statement has a syntax similar to an if/else statement,
+    except that the parenthesized expression goes after the second
+    keyword rather than the first.  As with if/else, there are two
+    clauses, each of which may be a simple statement ending with a
+    semicolon or a brace-enclosed compound statement.  But whereas
+    the else clause is optional, the Catch clause is required.  The
+    expression must be a modifiable lvalue (something capable of being
+    assigned to) of the same type (disregarding type qualifiers) that
+    was passed to define_exception_type().
+
+    If a Throw that uses the same exception context as the Try/Catch is
+    executed within the Try clause (typically within a function called
+    by the Try clause), and the exception is not caught by a nested
+    Try/Catch statement, then a copy of the exception will be assigned
+    to the expression, and control will jump to the Catch clause.  If no
+    such Throw is executed, then the assignment is not performed, and
+    the Catch clause is not executed.
+
+    The expression is not evaluated unless and until the exception is
+    caught, which is significant if it has side effects, for example:
+
+        Try foo();
+        Catch (p[++i].e) { ... }
+
+    IMPORTANT: Jumping into or out of a Try clause (for example via
+    return, break, continue, goto, longjmp) is forbidden--the compiler
+    will not complain, but bad things will happen at run-time.  Jumping
+    into or out of a Catch clause is okay, and so is jumping around
+    inside a Try clause.  In many cases where one is tempted to return
+    from a Try clause, it will suffice to use Throw, and then return
+    from the Catch clause.  Another option is to set a flag variable and
+    use goto to jump to the end of the Try clause, then check the flag
+    after the Try/Catch statement.
+
+    IMPORTANT: The values of any non-volatile automatic variables
+    changed within the Try clause are undefined after an exception is
+    caught.  Therefore, variables modified inside the Try block whose
+    values are needed later outside the Try block must either use static
+    storage or be declared with the "volatile" type qualifier.
+
+
+Throw expression;
+
+    A Throw statement is very much like a return statement, except that
+    the expression is required.  Whereas return jumps back to the place
+    where the current function was called, Throw jumps back to the Catch
+    clause of the innermost enclosing Try clause.  The expression must
+    be compatible with the type passed to define_exception_type().  The
+    exception must be caught, otherwise the program may crash.
+
+    Slight limitation:  If the expression is a comma-expression, it must
+    be enclosed in parentheses.
+
+
+Try statement
+Catch_anonymous statement
+
+    When the value of the exception is not needed, a Try/Catch statement
+    can use Catch_anonymous instead of Catch (expression).
+
+
+Everything below this point is for the benefit of the compiler.  The
+application programmer should pretend not to know any of it, because it
+is subject to change.
+
+===*/
+
+
+#ifndef CEXCEPT_H
+#define CEXCEPT_H
+
+
+#include <setjmp.h>
+
+#define define_exception_type(etype) \
+struct exception_context { \
+  jmp_buf *penv; \
+  int caught; \
+  volatile struct { etype etmp; } v; \
+}
+
+/* etmp must be volatile because the application might use automatic */
+/* storage for the_exception_context, and etmp is modified between   */
+/* the calls to setjmp() and longjmp().  A wrapper struct is used to */
+/* avoid warnings about a duplicate volatile qualifier in case etype */
+/* already includes it.                                              */
+
+#define init_exception_context(ec) ((void)((ec)->penv = 0))
+
+#define Try \
+  { \
+    jmp_buf *exception__prev, exception__env; \
+    exception__prev = the_exception_context->penv; \
+    the_exception_context->penv = &exception__env; \
+    if (setjmp(exception__env) == 0) { \
+      do
+
+#define exception__catch(action) \
+      while (the_exception_context->caught = 0, \
+             the_exception_context->caught); \
+    } \
+    else { \
+      the_exception_context->caught = 1; \
+    } \
+    the_exception_context->penv = exception__prev; \
+  } \
+  if (!the_exception_context->caught || action) { } \
+  else
+
+#define Catch(e) exception__catch(((e) = the_exception_context->v.etmp, 0))
+#define Catch_anonymous exception__catch(0)
+
+/* Try ends with do, and Catch begins with while(0) and ends with     */
+/* else, to ensure that Try/Catch syntax is similar to if/else        */
+/* syntax.                                                            */
+/*                                                                    */
+/* The 0 in while(0) is expressed as x=0,x in order to appease        */
+/* compilers that warn about constant expressions inside while().     */
+/* Most compilers should still recognize that the condition is always */
+/* false and avoid generating code for it.                            */
+
+#define Throw \
+  for (;; longjmp(*the_exception_context->penv, 1)) \
+    the_exception_context->v.etmp =
+
+
+#endif /* CEXCEPT_H */

--- a/src/py21cmfast/src/elec_interp.c
+++ b/src/py21cmfast/src/elec_interp.c
@@ -97,13 +97,11 @@ void initialize_interp_arrays()
       sprintf(input_file_name,"%s/%sxi_%1.3f%s",global_params.external_table_path,input_base,x_int_XHII[n_ion],input_tail);
     }
 
-    //    printf("%s\n",input_file_name);
-
     input_file = fopen(input_file_name, mode);
 
     if (input_file == NULL) {
-      fprintf(stderr, "Can't open input file %s!\n",input_file_name);
-      exit(1);
+      LOG_ERROR("Can't open input file %s!",input_file_name);
+      Throw 1;
     }
 
     // Skip first line
@@ -170,31 +168,26 @@ float interp_fheat(float En, float xHII_call)
 
   n_low = locate_energy_index(En);
   n_high = n_low + 1;
-  //  printf("nlow=%d %f\n",n_low,En);
 
   m_xHII_low = locate_xHII_index(xHII_call);
   m_xHII_high = m_xHII_low + 1;
-  //    printf("%f %f %f\n",xHII_call,XHII[m_xHII_low],XHII[m_xHII_high]);
 
   // First linear interpolation in energy
   elow_result = ((x_int_fheat[m_xHII_low][n_high]-x_int_fheat[m_xHII_low][n_low])/
 		 (x_int_Energy[n_high]-x_int_Energy[n_low]));
   elow_result *= (En - x_int_Energy[n_low]);
   elow_result += x_int_fheat[m_xHII_low][n_low];
-  //  printf("elow= %f\n",elow_result);
 
   // Second linear interpolation in energy
   ehigh_result = ((x_int_fheat[m_xHII_high][n_high]-x_int_fheat[m_xHII_high][n_low])/
 		  (x_int_Energy[n_high]-x_int_Energy[n_low]));
   ehigh_result *= (En - x_int_Energy[n_low]);
   ehigh_result += x_int_fheat[m_xHII_high][n_low];
-  //  printf("ehigh= %f\n",ehigh_result);
 
   // Final interpolation over the ionized fraction
   final_result = (ehigh_result - elow_result)/(x_int_XHII[m_xHII_high] - x_int_XHII[m_xHII_low]);
   final_result *= (xHII_call - x_int_XHII[m_xHII_low]);
   final_result += elow_result;
-  //  printf("final= %f\n",final_result);
 
   return final_result;
 }
@@ -235,7 +228,6 @@ float interp_n_Lya(float En, float xHII_call)
 
   m_xHII_low = locate_xHII_index(xHII_call);
   m_xHII_high = m_xHII_low + 1;
-  //    printf("%f %f %f\n",xHII_call,XHII[m_xHII_low],XHII[m_xHII_high]);
 
   // First linear interpolation in energy
   elow_result = ((x_int_n_Lya[m_xHII_low][n_high]-x_int_n_Lya[m_xHII_low][n_low])/
@@ -293,7 +285,6 @@ float interp_nion_HI(float En, float xHII_call)
 
   m_xHII_low = locate_xHII_index(xHII_call);
   m_xHII_high = m_xHII_low + 1;
-  //    printf("%f %f %f\n",xHII_call,XHII[m_xHII_low],XHII[m_xHII_high]);
 
   // First linear interpolation in energy
   elow_result = ((x_int_nion_HI[m_xHII_low][n_high]-x_int_nion_HI[m_xHII_low][n_low])/
@@ -351,7 +342,6 @@ float interp_nion_HeI(float En, float xHII_call)
 
   m_xHII_low = locate_xHII_index(xHII_call);
   m_xHII_high = m_xHII_low + 1;
-  //    printf("%f %f %f\n",xHII_call,XHII[m_xHII_low],XHII[m_xHII_high]);
 
   // First linear interpolation in energy
   elow_result = ((x_int_nion_HeI[m_xHII_low][n_high]-x_int_nion_HeI[m_xHII_low][n_low])/
@@ -409,7 +399,6 @@ float interp_nion_HeII(float En, float xHII_call)
 
   m_xHII_low = locate_xHII_index(xHII_call);
   m_xHII_high = m_xHII_low + 1;
-  //    printf("%f %f %f\n",xHII_call,XHII[m_xHII_low],XHII[m_xHII_high]);
 
   // First linear interpolation in energy
   elow_result = ((x_int_nion_HeII[m_xHII_low][n_high]-x_int_nion_HeII[m_xHII_low][n_low])/

--- a/src/py21cmfast/src/elec_interp.c
+++ b/src/py21cmfast/src/elec_interp.c
@@ -101,7 +101,7 @@ void initialize_interp_arrays()
 
     if (input_file == NULL) {
       LOG_ERROR("Can't open input file %s!",input_file_name);
-      Throw 1;
+      Throw(IOError);
     }
 
     // Skip first line

--- a/src/py21cmfast/src/exceptions.h
+++ b/src/py21cmfast/src/exceptions.h
@@ -1,0 +1,12 @@
+#include "cexcept.h"
+define_exception_type(int);
+extern struct exception_context the_exception_context[1];
+
+struct exception_context the_exception_context[1];
+
+// Our own error codes
+#define SUCCESS 0
+#define IOError 1
+#define GSLError 2
+#define ValueError 3
+#define ParameterError 4

--- a/src/py21cmfast/src/exceptions.h
+++ b/src/py21cmfast/src/exceptions.h
@@ -10,3 +10,6 @@ struct exception_context the_exception_context[1];
 #define GSLError 2
 #define ValueError 3
 #define ParameterError 4
+#define MemoryAllocError 5
+
+#define GSL_ERROR(status) if(status>0) {LOG_ERROR("GSL Error Encountered (Code = %d): %s", status, gsl_strerror(status)); Throw(GSLError);}

--- a/src/py21cmfast/src/heating_helper_progs.c
+++ b/src/py21cmfast/src/heating_helper_progs.c
@@ -1116,27 +1116,20 @@ double nu_tau_one_approx_MINI(double zp, double zpp, double x_e, double HI_filli
     gsl_root_fsolver_set (s, &F, x_lo, x_hi);
 
     // iterate until we guess close enough
-//    if (DEBUG_ON) printf ("%5s [%9s, %9s] %9s %9s\n", "iter", "lower", "upper", "root", "err(est)");
     iter = 0;
     max_iter = 100;
     do{
         iter++;
         status = gsl_root_fsolver_iterate (s);
         r = gsl_root_fsolver_root (s);
-        //      printf("iter%i, r=%e\n", iter, r);
         x_lo = gsl_root_fsolver_x_lower (s);
         x_hi = gsl_root_fsolver_x_upper (s);
         status = gsl_root_test_interval (x_lo, x_hi, 0, relative_error);
-//        if (DEBUG_ON){
-//            printf ("%5d [%.7e, %.7e] %.7e %.7e\n", iter, x_lo, x_hi, r, (x_hi - x_lo)/r);
-//            fflush(NULL);
-//        }
     }
     while (status == GSL_CONTINUE && iter < max_iter);
 
     // deallocate and return
     gsl_root_fsolver_free (s);
-//    if (DEBUG_ON) printf("Root found at %e eV", r/NU_over_EV);
     return r;
 }
 

--- a/src/py21cmfast/src/heating_helper_progs.c
+++ b/src/py21cmfast/src/heating_helper_progs.c
@@ -34,7 +34,6 @@ double get_M_min_ion(float z){
     // check for WDM
     if (global_params.P_CUTOFF && ( MMIN < M_J_WDM()))
         MMIN = M_J_WDM();
-    //  printf("Mmin is %e\n", MMIN);
     return MMIN;
 }
 
@@ -200,8 +199,8 @@ double T_RECFAST(float z, int flag)
         // Read in the recfast data
         sprintf(filename,"%s/%s",global_params.external_table_path,RECFAST_FILENAME);
         if ( !(F=fopen(filename, "r")) ){
-            printf("T_RECFAST: Unable to open file: %s for reading\nAborting\n", filename);
-            return -1;
+            LOG_ERROR("T_RECFAST: Unable to open file: %s for reading.", filename);
+            Throw 1;
         }
 
         for (i=(RECFAST_NPTS-1);i>=0;i--) {
@@ -227,8 +226,8 @@ double T_RECFAST(float z, int flag)
     }
 
     if (z > zt[RECFAST_NPTS-1]) { // Called at z>500! Bail out
-        printf("Called xion_RECFAST with z=%f, bailing out!\n", z);
-        return -1;
+        LOG_ERROR("Called xion_RECFAST with z=%f.", z);
+        Throw 1;
     }
     else { // Do spline
         ans = gsl_spline_eval (spline, z, acc);
@@ -254,8 +253,8 @@ double xion_RECFAST(float z, int flag)
         // Initialize vectors
         sprintf(filename,"%s/%s",global_params.external_table_path,RECFAST_FILENAME);
         if ( !(F=fopen(filename, "r")) ){
-            printf("xion_RECFAST: Unable to open file: %s for reading\nAborting\n", RECFAST_FILENAME);
-            return -1;
+            LOG_ERROR("xion_RECFAST: Unable to open file: %s for reading\nAborting\n", RECFAST_FILENAME);
+            Throw IOError;
         }
 
         for (i=(RECFAST_NPTS-1);i>=0;i--) {
@@ -280,8 +279,8 @@ double xion_RECFAST(float z, int flag)
     }
 
     if (z > zt[RECFAST_NPTS-1]) { // Called at z>500! Bail out
-        printf("Called xion_RECFAST with z=%f, bailing out!\n", z);
-        return -1;
+        LOG_ERROR("Called xion_RECFAST with z=%f", z);
+        Throw ValueError;
     }
     else { // Do spline
         ans = gsl_spline_eval (spline, z, acc);
@@ -400,8 +399,8 @@ double spectral_emissivity(double nu_norm, int flag, int Population)
             // * Read in the data * //
             sprintf(filename,"%s/%s",global_params.external_table_path,STELLAR_SPECTRA_FILENAME);
             if (!(F = fopen(filename, "r"))){
-                printf("spectral_emissivity: Unable to open file: stellar_spectra.dat for reading\nAborting\n");
-                return -1;
+               LOG_ERROR("spectral_emissivity: Unable to open file: stellar_spectra.dat for reading.");
+                Throw IOError;
             }
 
             for (i=1;i<NSPEC_MAX;i++) {
@@ -800,16 +799,6 @@ double integrate_over_nu(double zp, double local_x_e, double lower_int_limit, in
     gsl_function F;
     gsl_integration_workspace * w = gsl_integration_workspace_alloc (1000);
 
-//    if (DEBUG_ON){
-//        printf("integrate over nu, parameters: %f, %f, %e, %i, thread# %i\n", zp, local_x_e, lower_int_limit, FLAG, omp_get_thread_num());
-//    }
-
-    //       if (DO_NOT_COMPARE_NUS)
-    //     lower_int_limit = NU_X_THRESH;
-    //       else
-    //     lower_int_limit = FMAX(nu_tau_one(zp, zpp, x_e, HI_filling_factor_zp), NU_X_THRESH);
-
-
     F.params = &local_x_e;
 
     if (FLAG==0)
@@ -820,10 +809,15 @@ double integrate_over_nu(double zp, double local_x_e, double lower_int_limit, in
         F.function = &integrand_in_nu_lya_integral;
     }
 
-    //    gsl_integration_qag (&F, lower_int_limit, NU_X_MAX, 0, rel_tol, 1000, GSL_INTEG_GAUSS61, w, &result, &error);
-
-    gsl_integration_qag (&F, lower_int_limit, global_params.NU_X_MAX*NU_over_EV, 0, rel_tol, 1000, GSL_INTEG_GAUSS15, w, &result, &error);
+    int status;
+    gsl_set_error_handler_off();
+    status = gsl_integration_qag (&F, lower_int_limit, global_params.NU_X_MAX*NU_over_EV, 0, rel_tol, 1000, GSL_INTEG_GAUSS15, w, &result, &error);
     gsl_integration_workspace_free (w);
+
+    if(status!=0){
+        LOG_ERROR("gsl error with code %d", status);
+        Throw GSLError;
+    }
 
     // if it is the Lya integral, add prefactor
     if (FLAG == 2)
@@ -1011,9 +1005,6 @@ double tauX_approx(double nu, double x_e, double x_e_ave, double zp, double zpp,
     int redshift_int_fcollz;
     float redshift_table_fcollz;
 
-    //     if (DEBUG_ON)
-    //     printf("in taux, parameters are: %e, %e, %f, %f, %e\n", nu, x_e, zp, zpp, HI_filling_factor_zp);
-
     F.function = &tauX_integrand_approx;
     p.nu_0 = nu/(1+zp);
     p.x_e = x_e;
@@ -1044,15 +1035,11 @@ double tauX_approx(double nu, double x_e, double x_e_ave, double zp, double zpp,
         }
     }
 
+    gsl_set_error_handler_off();
 
     F.params = &p;
     gsl_integration_qag (&F, zpp, zp, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
-    //    gsl_integration_qag (&F, zpp, zp, 0, rel_tol,1000, GSL_INTEG_GAUSS61, w, &result, &error);
     gsl_integration_workspace_free (w);
-
-
-    //     if (DEBUG_ON)
-    //     printf("returning from tauX, return value=%e\n", result);
 
     return result;
 }
@@ -1163,13 +1150,8 @@ double nu_tau_one_approx(double zp, double zpp, double x_e, double HI_filling_fa
     double relative_error = 0.02;
     nu_tau_one_params_approx p;
 
-//    if (DEBUG_ON){
-//        printf("in nu tau one, called with parameters: zp=%f, zpp=%f, x_e=%e, HI_filling_at_zp=%e\n", zp, zpp, x_e, HI_filling_factor_zp);
-//    }
-
     // check if too ionized
     if (x_e > 0.9999){
-        //        fprintf(stderr,"Ts.c: WARNING: x_e value is too close to 1 for convergence in nu_tau_one\n");
         return -1;
     }
 
@@ -1177,7 +1159,7 @@ double nu_tau_one_approx(double zp, double zpp, double x_e, double HI_filling_fa
     T = gsl_root_fsolver_brent;
     s = gsl_root_fsolver_alloc(T); // non-derivative based Brent method
     if (!s){
-        printf("Ts.c: Unable to allocate memory in function nu_tau_one!\n");
+        LOG_ERROR("Unable to allocate memory.");
         return -1;
     }
 
@@ -1199,27 +1181,20 @@ double nu_tau_one_approx(double zp, double zpp, double x_e, double HI_filling_fa
     gsl_root_fsolver_set (s, &F, x_lo, x_hi);
 
     // iterate until we guess close enough
-//    if (DEBUG_ON) printf ("%5s [%9s, %9s] %9s %9s\n", "iter", "lower", "upper", "root", "err(est)");
     iter = 0;
     max_iter = 100;
     do{
         iter++;
         status = gsl_root_fsolver_iterate (s);
         r = gsl_root_fsolver_root (s);
-        //      printf("iter%i, r=%e\n", iter, r);
         x_lo = gsl_root_fsolver_x_lower (s);
         x_hi = gsl_root_fsolver_x_upper (s);
         status = gsl_root_test_interval (x_lo, x_hi, 0, relative_error);
-//        if (DEBUG_ON){
-//            printf ("%5d [%.7e, %.7e] %.7e %.7e\n", iter, x_lo, x_hi, r, (x_hi - x_lo)/r);
-//            fflush(NULL);
-//        }
     }
     while (status == GSL_CONTINUE && iter < max_iter);
 
     // deallocate and return
     gsl_root_fsolver_free (s);
-//    if (DEBUG_ON) printf("Root found at %e eV", r/NU_over_EV);
     return r;
 }
 

--- a/src/py21cmfast/src/heating_helper_progs.c
+++ b/src/py21cmfast/src/heating_helper_progs.c
@@ -4,7 +4,7 @@ struct AstroParams *astro_params_hf;
 struct FlagOptions *flag_options_hf;
 
 int n_redshifts_1DTable;
-double zbin_width_1DTable,zmin_1DTable,zmax_1DTable,zbin_width_1DTable;
+double zbin_width_1DTable,zmin_1DTable,zmax_1DTable;
 
 float determine_zpp_min, zpp_bin_width;
 
@@ -1078,22 +1078,18 @@ double nu_tau_one_approx_MINI(double zp, double zpp, double x_e, double HI_filli
     double relative_error = 0.02;
     nu_tau_one_params_approx p;
 
-//    if (DEBUG_ON){
-//        printf("in nu tau one, called with parameters: zp=%f, zpp=%f, x_e=%e, HI_filling_at_zp=%e\n", zp, zpp, x_e, HI_filling_factor_zp);
-//    }
-
     // check if too ionized
     if (x_e > 0.9999){
-        //        fprintf(stderr,"Ts.c: WARNING: x_e value is too close to 1 for convergence in nu_tau_one\n");
-        return -1;
+        LOG_ERROR("x_e value is too close to 1 for convergence.");
+        Throw(ParameterError);
     }
 
     // select solver and allocate memory
     T = gsl_root_fsolver_brent;
     s = gsl_root_fsolver_alloc(T); // non-derivative based Brent method
     if (!s){
-        printf("Ts.c: Unable to allocate memory in function nu_tau_one!\n");
-        return -1;
+        LOG_ERROR("Unable to allocate memory.");
+        Throw(MemoryAllocError);
     }
 
     //check if lower bound has null
@@ -1130,6 +1126,12 @@ double nu_tau_one_approx_MINI(double zp, double zpp, double x_e, double HI_filli
 
     // deallocate and return
     gsl_root_fsolver_free (s);
+
+    if(!isfinite(r)){
+        LOG_ERROR("Value for nu_tau_one_approx_MINI is infinite or NAN");
+        Throw(ParameterError);
+    }
+
     return r;
 }
 
@@ -1145,7 +1147,7 @@ double nu_tau_one_approx(double zp, double zpp, double x_e, double HI_filling_fa
 
     // check if too ionized
     if (x_e > 0.9999){
-        return -1;
+        Throw(ParameterError);
     }
 
     // select solver and allocate memory
@@ -1153,7 +1155,7 @@ double nu_tau_one_approx(double zp, double zpp, double x_e, double HI_filling_fa
     s = gsl_root_fsolver_alloc(T); // non-derivative based Brent method
     if (!s){
         LOG_ERROR("Unable to allocate memory.");
-        return -1;
+        Throw(MemoryAllocError);
     }
 
     //check if lower bound has null
@@ -1188,6 +1190,12 @@ double nu_tau_one_approx(double zp, double zpp, double x_e, double HI_filling_fa
 
     // deallocate and return
     gsl_root_fsolver_free (s);
+
+    if(!isfinite(r)){
+        LOG_ERROR("nu_tau_one_approx is infinite or NAN");
+        Throw(ParameterError);
+    }
+
     return r;
 }
 

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -77,7 +77,7 @@ float *prev_log10_Nion_spline_MINI, *prev_Nion_spline_MINI;
 
 float *xi_SFR,*wi_SFR, *xi_SFR_Xray, *wi_SFR_Xray;
 
-float *Overdense_high_table, *overdense_low_table, *log10_overdense_low_table;
+float *overdense_high_table, *overdense_low_table, *log10_overdense_low_table;
 float **log10_SFRD_z_low_table, **SFRD_z_high_table;
 float **log10_SFRD_z_low_table_MINI, **SFRD_z_high_table_MINI;
 
@@ -90,7 +90,7 @@ double *deriv, *lnM_temp, *deriv_temp;
 double *z_val, *z_X_val, *Nion_z_val, *SFRD_val;
 double *Nion_z_val_MINI, *SFRD_val_MINI;
 
-int initialiseSigmaMInterpTable(float M_Min, float M_Max);
+void initialiseSigmaMInterpTable(float M_Min, float M_Max);
 void freeSigmaMInterpTable();
 void initialiseGL_Nion(int n, float M_Min, float M_Max);
 void initialiseGL_Nion_Xray(int n, float M_Min, float M_Max);
@@ -224,43 +224,58 @@ double TF_CLASS(double k, int flag_int, int flag_dv)
     float trash, currk, currTm, currTv;
     double ans;
     int i;
+    int gsl_status;
     FILE *F;
 
     char filename[500];
     sprintf(filename,"%s/%s",global_params.external_table_path,CLASS_FILENAME);
 
 
-    if (flag_int == 0) {// Initialize vectors and read file
-        if ( !(F=fopen(filename, "r")) ){
-            LOG_ERROR("TF_CLASS: Unable to open file: %s for reading\nAborting\n", filename);
-            return -1;
+    if (flag_int == 0) {  // Initialize vectors and read file
+        if (!(F = fopen(filename, "r"))) {
+            LOG_ERROR("Unable to open file: %s for reading.", filename);
+            Throw(IOError);
         }
 
-//    for (i=(CLASS_LENGTH-1);i>=0;i--) {
-    for (i=0;i<CLASS_LENGTH;i++) {
-      fscanf(F, "%e %e %e ", &currk, &currTm, &currTv);
-      kclass[i] = currk;
-      Tmclass[i] = currTm;
-      Tvclass_vcb[i] = currTv;
-      if(kclass[i]<=kclass[i-1] && i>0){
-      	LOG_WARNING("Tk table not ordered");
-      	LOG_WARNING("k=%.1le kprev=%.1le",kclass[i],kclass[i-1]);
-      }
+        int nscans;
+        for (i = 0; i < CLASS_LENGTH; i++) {
+            nscans = fscanf(F, "%e %e %e ", &currk, &currTm, &currTv);
+            if (nscans != 3) {
+                LOG_ERROR("Reading CLASS Transfer Function failed.");
+                Throw(IOError);
+            }
+            kclass[i] = currk;
+            Tmclass[i] = currTm;
+            Tvclass_vcb[i] = currTv;
+            if (i > 0 && kclass[i] <= kclass[i - 1]) {
+                LOG_WARNING("Tk table not ordered");
+                LOG_WARNING("k=%.1le kprev=%.1le", kclass[i], kclass[i - 1]);
+            }
+        }
+        fclose(F);
+
+
+        LOG_SUPER_DEBUG("Read CLASS Transfer file");
+
+        gsl_set_error_handler_off();
+        // Set up spline table for densities
+        acc_density   = gsl_interp_accel_alloc ();
+        spline_density  = gsl_spline_alloc (gsl_interp_cspline, CLASS_LENGTH);
+        gsl_status = gsl_spline_init(spline_density, kclass, Tmclass, CLASS_LENGTH);
+        GSL_ERROR(gsl_status);
+
+        LOG_SUPER_DEBUG("Generated CLASS Density Spline.");
+
+        //Set up spline table for velocities
+        acc_vcb   = gsl_interp_accel_alloc ();
+        spline_vcb  = gsl_spline_alloc (gsl_interp_cspline, CLASS_LENGTH);
+        gsl_status = gsl_spline_init(spline_vcb, kclass, Tvclass_vcb, CLASS_LENGTH);
+        GSL_ERROR(gsl_status);
+
+        LOG_SUPER_DEBUG("Generated CLASS velocity Spline.");
+        return 0;
     }
-    fclose(F);
-
-    // Set up spline table for densities
-    acc_density   = gsl_interp_accel_alloc ();
-    spline_density  = gsl_spline_alloc (gsl_interp_cspline, CLASS_LENGTH);
-    gsl_spline_init(spline_density, kclass, Tmclass, CLASS_LENGTH);
-
-
-    //Set up spline table for velocities
-    acc_vcb   = gsl_interp_accel_alloc ();
-    spline_vcb  = gsl_spline_alloc (gsl_interp_cspline, CLASS_LENGTH);
-    gsl_spline_init(spline_vcb, kclass, Tvclass_vcb, CLASS_LENGTH);
-
-    if (flag_int == -1) {
+    else if (flag_int == -1) {
         gsl_spline_free (spline_density);
         gsl_interp_accel_free(acc_density);
         gsl_spline_free (spline_vcb);
@@ -270,7 +285,7 @@ double TF_CLASS(double k, int flag_int, int flag_dv)
 
 
     if (k > kclass[CLASS_LENGTH-1]) { // k>kmax
-        LOG_ERROR("Called TF_CLASS with k=%f, larger than kmax!\n", k);
+        LOG_WARNING("Called TF_CLASS with k=%f, larger than kmax! Returning value at kmax.", k);
         if(flag_dv == 0){ // output is density
             return (Tmclass[CLASS_LENGTH]/kclass[CLASS_LENGTH-1]/kclass[CLASS_LENGTH-1]);
         }
@@ -289,7 +304,6 @@ double TF_CLASS(double k, int flag_int, int flag_dv)
             ans=0.0; //neither densities not velocities?
         }
     }
-
 
     return ans/k/k;
     //we have to divide by k^2 to agree with the old-fashioned convention.
@@ -356,7 +370,7 @@ double dsigma_dk(double k, void *params){
     }
     else{
         LOG_ERROR("No such power spectrum defined: %i. Output is bogus.", user_params_ps->POWER_SPECTRUM);
-        p = 0;
+        Throw(ValueError);
     }
     double Radius;
 
@@ -373,7 +387,7 @@ double dsigma_dk(double k, void *params){
     }
     else {
         LOG_ERROR("No such filter: %i. Output is bogus.", global_params.FILTER);
-        w=0;
+        Throw(ValueError);
     }
     return k*k*p*w*w;
 }
@@ -433,6 +447,8 @@ double TFmdm(double k){
 
 void TFset_parameters(){
     double z_drag, R_drag, R_equality, p_c, p_cb, f_c, f_cb, f_nub, k_equality;
+
+    LOG_DEBUG("Setting Transfer Function parameters.");
 
     z_equality = 25000*omhh*pow(theta_cmb, -4) - 1.0;
     k_equality = 0.0746*omhh/(theta_cmb*theta_cmb);
@@ -510,7 +526,7 @@ double power_in_k(double k){
     }
     else{
         LOG_ERROR("No such power spectrum defined: %i. Output is bogus.", user_params_ps->POWER_SPECTRUM);
-        p = 0;
+        Throw(ValueError);
     }
 
 
@@ -533,7 +549,7 @@ double power_in_vcb(double k){
     }
     else{
         LOG_ERROR("Cannot get P_cb unless using CLASS: %i\n Set USE_RELATIVE_VELOCITIES 0 or use CLASS.\n", user_params_ps->POWER_SPECTRUM);
-        p = 0;
+        Throw(ValueError);
     }
 
     return p*TWOPI*PI*sigma_norm*sigma_norm;
@@ -544,24 +560,17 @@ double init_ps(){
     double result, error, lower_limit, upper_limit;
     gsl_function F;
     double rel_tol  = FRACT_FLOAT_ERR*10; //<- relative tolerance
-    gsl_integration_workspace * w
-    = gsl_integration_workspace_alloc (1000);
+    gsl_integration_workspace * w = gsl_integration_workspace_alloc (1000);
     double kstart, kend;
-    int i;
-    double x;
 
     //we start the interpolator if using CLASS:
-      if (user_params_ps->POWER_SPECTRUM == 5){
-          TF_CLASS(1.0, 0, 0);
-      }
-
+    if (user_params_ps->POWER_SPECTRUM == 5){
+        LOG_DEBUG("Setting CLASS Transfer Function inits.");
+        TF_CLASS(1.0, 0, 0);
+    }
 
     // Set cuttoff scale for WDM (eq. 4 in Barkana et al. 2001) in comoving Mpc
     R_CUTOFF = 0.201*pow((cosmo_params_ps->OMm-cosmo_params_ps->OMb)*cosmo_params_ps->hlittle*cosmo_params_ps->hlittle/0.15, 0.15)*pow(global_params.g_x/1.5, -0.29)*pow(global_params.M_WDM, -1.15);
-
-    //  fprintf(stderr, "For M_DM = %.2e keV, R_CUTOFF is: %.2e comoving Mpc\n", M_WDM, R_CUTOFF);
-    //    if (!P_CUTOFF)
-    //    fprintf(stderr, "But you have selected CDM, so this is ignored\n");
 
     omhh = cosmo_params_ps->OMm*cosmo_params_ps->hlittle*cosmo_params_ps->hlittle;
     theta_cmb = T_cmb / 2.7;
@@ -577,7 +586,6 @@ double init_ps(){
     sigma_norm = -1;
 
     double Radius_8;
-//    R = 8.0/cosmo_params_ps->hlittle;
     Radius_8 = 8.0/cosmo_params_ps->hlittle;
 
     if(user_params_ps->POWER_SPECTRUM == 5){
@@ -589,8 +597,10 @@ double init_ps(){
       kend = 350.0/Radius_8;
     }
 
-    lower_limit = kstart;//log(kstart);
-    upper_limit = kend;//log(kend);
+    lower_limit = kstart;
+    upper_limit = kend;
+
+    LOG_DEBUG("Initializing Power Spectrum with lower_limit=%e, upper_limit=%e, rel_tol=%e, radius_8=%g", lower_limit,upper_limit, rel_tol, Radius_8);
 
     F.function = &dsigma_dk;
     F.params = &Radius_8;
@@ -598,20 +608,9 @@ double init_ps(){
                          1000, GSL_INTEG_GAUSS61, w, &result, &error);
     gsl_integration_workspace_free (w);
 
+    LOG_DEBUG("Initialized Power Spectrum.");
+
     sigma_norm = cosmo_params_ps->SIGMA_8/sqrt(result); //takes care of volume factor
-
-    /* initialize the lookup table for erfc */
-    /*
-     for (i=0; i<=ERFC_NPTS; i++){
-     erfc_params[i] = i*ERFC_PARAM_DELTA;
-     log_erfc_table[i] = log(erfcc(erfc_params[i]));
-     }
-     // Set up spline table
-     erfc_acc   = gsl_interp_accel_alloc ();
-     erfc_spline  = gsl_spline_alloc (gsl_interp_cspline, ERFC_NPTS);
-     gsl_spline_init(erfc_spline, erfc_params, log_erfc_table, ERFC_NPTS);
-     */
-
     return R_CUTOFF;
 }
 
@@ -679,7 +678,7 @@ double dsigmasq_dm(double k, void *params){
       }
     else{
         LOG_ERROR("No such power spectrum defined: %i. Output is bogus.", user_params_ps->POWER_SPECTRUM);
-        p = 0;
+        Throw(ValueError);
     }
 
     double Radius;
@@ -705,7 +704,7 @@ double dsigmasq_dm(double k, void *params){
     }
     else {
         LOG_ERROR("No such filter: %i. Output is bogus.", global_params.FILTER);
-        w=0;
+        Throw(ValueError);
     }
 
 //    return k*k*p*2*w*dwdr*drdm * d2fact;
@@ -1080,7 +1079,7 @@ double FgtrM_General(double z, double M){
             LOG_ERROR("gsl integration error occured!");
             LOG_ERROR("lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
             LOG_ERROR("data: z=%e growthf=%e M=%e",z,growthf,M);
-            Throw GSLError;
+            Throw(GSLError);
         }
 
         gsl_integration_workspace_free (w);
@@ -1089,7 +1088,7 @@ double FgtrM_General(double z, double M){
     }
     else {
         LOG_ERROR("Incorrect HMF selected: %i (should be between 0 and 3).", user_params_ps->HMF);
-        Throw 1;
+        Throw(ValueError);
     }
 }
 
@@ -1279,7 +1278,7 @@ double Nion_General_MINI(double z, double M_Min, double MassTurnover, double Mas
     }
     else {
         LOG_ERROR("Incorrect HMF selected: %i (should be between 0 and 3).", user_params_ps->HMF);
-        exit(-1);
+        Throw(ValueError);
     }
 }
 
@@ -1309,9 +1308,11 @@ float erfcc(float x)
 
 double splined_erfc(double x){
     if (x < 0){
-        //    fprintf(stderr, "WARNING: Negative value %e passed to splined_erfc. Returning 1\n", x);
-        return 1;
+        return 1.0;
     }
+
+    // TODO: This could be wrapped in a Try/Catch to try the fast way and if it doesn't
+    // work, use the slow way.
     return erfcc(x); // the interpolation below doesn't seem to be stable in Ts.c
     if (x > ERFC_PARAM_DELTA*(ERFC_NPTS-1))
         return erfcc(x);
@@ -1360,7 +1361,7 @@ void gauleg(float x1, float x2, float x[], float w[], int n)
     }
 }
 
-int initialiseSigmaMInterpTable(float M_Min, float M_Max)
+void initialiseSigmaMInterpTable(float M_Min, float M_Max)
 {
     int i;
     float Mass;
@@ -1382,15 +1383,13 @@ int initialiseSigmaMInterpTable(float M_Min, float M_Max)
     for(i=0;i<NMass;i++) {
         if(isfinite(Mass_InterpTable[i]) == 0 || isfinite(Sigma_InterpTable[i]) == 0 || isfinite(dSigmadm_InterpTable[i])==0) {
             LOG_ERROR("Detected either an infinite or NaN value in initialiseSigmaMInterpTable");
-            return(-1);
+            Throw(ParameterError);
         }
     }
 
     MinMass = log(M_Min);
     mass_bin_width = 1./(NMass-1)*( log(M_Max) - log(M_Min) );
     inv_mass_bin_width = 1./mass_bin_width;
-
-    return(0);
 }
 
 void freeSigmaMInterpTable()
@@ -1405,8 +1404,7 @@ void nrerror(char error_text[])
 {
     LOG_ERROR("Numerical Recipes run-time error...");
     LOG_ERROR("%s",error_text);
-    LOG_ERROR("...now exiting to system...");
-    Throw 1;
+    Throw(MemoryAllocError);
 }
 
 float *vector(long nl, long nh)
@@ -1603,12 +1601,16 @@ float Mass_limit_bisection(float Mmin, float Mmax, float PL, float FRAC){
         x = x1;
     }
     while(iter < max_iter);
+
+    // Got to max_iter without finding a solution.
     LOG_ERROR("Failed to find a mass limit to regulate stellar fraction/escape fraction is between 0 and 1.");
     LOG_ERROR(" The solution does not converge or iterations are not sufficient.");
-    return -1;
+    Throw(ParameterError);
+
+    return(0.0);
 }
 
-int initialise_ComputeLF(int nbins, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params, struct FlagOptions *flag_options) {
+void initialise_ComputeLF(int nbins, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params, struct FlagOptions *flag_options) {
 
     Broadcast_struct_global_PS(user_params,cosmo_params);
     Broadcast_struct_global_UF(user_params,cosmo_params);
@@ -1622,14 +1624,14 @@ int initialise_ComputeLF(int nbins, struct UserParams *user_params, struct Cosmo
 
     init_ps();
 
-    if(initialiseSigmaMInterpTable(0.999*Mhalo_min,1.001*Mhalo_max)!=0) {
-        LOG_ERROR("Detected either an infinite or NaN value in initialiseSigmaMInterpTable from initialise_ComputeLF");
-        return(2);
+    int status;
+    Try initialiseSigmaMInterpTable(0.999*Mhalo_min,1.001*Mhalo_max);
+    Catch(status) {
+        LOG_ERROR("\t...called from initialise_ComputeLF");
+        return(status);
     }
 
     initialised_ComputeLF = true;
-
-    return(0);
 }
 
 void cleanup_ComputeLF(){
@@ -1643,7 +1645,11 @@ void cleanup_ComputeLF(){
 
 int ComputeLF(int nbins, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params,
                struct FlagOptions *flag_options, int component, int NUM_OF_REDSHIFT_FOR_LF, float *z_LF, float *M_TURNs, double *M_uv_z, double *M_h_z, double *log10phi) {
-
+    /*
+        This is an API-level function and thus returns an int status.
+    */
+    int status;
+    Try{ // This try block covers the whole function.
     // This NEEDS to be done every time, because the actual object passed in as
     // user_params, cosmo_params etc. can change on each call, freeing up the memory.
     initialise_ComputeLF(nbins, user_params,cosmo_params,astro_params,flag_options);
@@ -1654,9 +1660,16 @@ int ComputeLF(int nbins, struct UserParams *user_params, struct CosmoParams *cos
     double Mhalo_i, lnMhalo_min, lnMhalo_max, lnMhalo_lo, lnMhalo_hi, dlnM, growthf;
     double f_duty_upper, Mcrit_atom;
     float Fstar, Fstar_temp;
+    double dndm;
+    int gsl_status;
 
+    gsl_set_error_handler_off();
     if (astro_params->ALPHA_STAR < -0.5)
-        LOG_WARNING("ALPHA_STAR is %f, which is unphysical value given the observational LFs.\nAlso, when ALPHA_STAR < -.5, LFs may show a kink. It is recommended to set ALPHA_STAR > -0.5.",astro_params->ALPHA_STAR);
+        LOG_WARNING(
+            "ALPHA_STAR is %f, which is unphysical value given the observational LFs.\n"\
+            "Also, when ALPHA_STAR < -.5, LFs may show a kink. It is recommended to set ALPHA_STAR > -0.5.",
+            astro_params->ALPHA_STAR
+        );
 
     mf = user_params_ps->HMF;
 
@@ -1703,7 +1716,8 @@ int ComputeLF(int nbins, struct UserParams *user_params, struct CosmoParams *cos
             M_uv_z[i + i_z*nbins] = Muv_param[i];
         }
 
-        gsl_spline_init(LF_spline, lnMhalo_param, Muv_param, nbins);
+        gsl_status = gsl_spline_init(LF_spline, lnMhalo_param, Muv_param, nbins);
+        GSL_ERROR(gsl_status);
 
         lnMhalo_lo = log(Mhalo_min);
         lnMhalo_hi = log(Mhalo_max);
@@ -1751,10 +1765,11 @@ int ComputeLF(int nbins, struct UserParams *user_params, struct CosmoParams *cos
                     log10phi[i + i_z*nbins] = log10( dNdM_WatsonFOF_z(z_LF[i_z], growthf, exp(lnMhalo_i)) * exp(-(M_TURNs[i_z]/Mhalo_param[i])) * f_duty_upper / fabs(dMuvdMhalo) );
                 }
                 else{
-                    LOG_ERROR("HMF should be between 0-3... returning error.");
-                    return(2);
+                    LOG_ERROR("HMF should be between 0-3, got %d", mf);
+                    Throw(ValueError);
                 }
-                if (isinf(log10phi[i + i_z*nbins]) || isnan(log10phi[i + i_z*nbins]) || log10phi[i + i_z*nbins] < -30.) log10phi[i + i_z*nbins] = -30.;
+                if (isinf(log10phi[i + i_z*nbins]) || isnan(log10phi[i + i_z*nbins]) || log10phi[i + i_z*nbins] < -30.)
+                    log10phi[i + i_z*nbins] = -30.;
             }
         }
         else {
@@ -1797,40 +1812,42 @@ int ComputeLF(int nbins, struct UserParams *user_params, struct CosmoParams *cos
             deriv_temp[5] = deriv[i_unity + 11];
             deriv_temp[6] = deriv[i_unity + 12];
 
-            gsl_spline_init(deriv_spline, lnM_temp, deriv_temp, nbins_smth);
+            gsl_status = gsl_spline_init(deriv_spline, lnM_temp, deriv_temp, nbins_smth);
+            GSL_ERROR(gsl_status);
 
             for (i=0;i<9;i++){
                 deriv[i_unity + i - 1] = gsl_spline_eval(deriv_spline, lnMhalo_param[i_unity + i - 1], deriv_spline_acc);
             }
-
             for (i=0; i<nbins; i++) {
                 if (component == 1)
                     f_duty_upper = 1.;
                 else
                     f_duty_upper = exp(-(Mhalo_param[i]/Mcrit_atom));
-                if(mf==0) {
-                    log10phi[i + i_z*nbins] = log10( dNdM(z_LF[i_z], Mhalo_param[i]) * exp(-(M_TURNs[i_z]/Mhalo_param[i])) * f_duty_upper / deriv[i] );
-                }
-                else if(mf==1) {
-                    log10phi[i + i_z*nbins] = log10( dNdM_st_interp(growthf, Mhalo_param[i]) * exp(-(M_TURNs[i_z]/Mhalo_param[i])) * f_duty_upper / deriv[i] );
-                }
-                else if(mf==2) {
-                    log10phi[i + i_z*nbins] = log10( dNdM_WatsonFOF(growthf, Mhalo_param[i]) * exp(-(M_TURNs[i_z]/Mhalo_param[i])) * f_duty_upper / deriv[i] );
-                }
-                else if(mf==3) {
-                    log10phi[i + i_z*nbins] = log10( dNdM_WatsonFOF_z(z_LF[i_z], growthf, Mhalo_param[i]) * exp(-(M_TURNs[i_z]/Mhalo_param[i])) * f_duty_upper / deriv[i] );
-                }
+
+                if(mf==0)
+                    dndm = dNdM(z_LF[i_z], Mhalo_param[i]);
+                else if(mf==1)
+                    dndm = dNdM_st_interp(growthf, Mhalo_param[i]);
+                else if(mf==2)
+                    dndm = dNdM_WatsonFOF(growthf, Mhalo_param[i]);
+                else if(mf==3)
+                    dndm = dNdM_WatsonFOF_z(z_LF[i_z], growthf, Mhalo_param[i]);
                 else{
-                    LOG_ERROR("HMF should be between 0-3... returning error.");
-                    return(2);
+                    LOG_ERROR("HMF should be between 0-3, got %d", mf);
+                    Throw(ValueError);
                 }
-                if (isinf(log10phi[i + i_z*nbins]) || isnan(log10phi[i + i_z*nbins]) || log10phi[i + i_z*nbins] < -30.) log10phi[i + i_z*nbins] = -30.;
+                log10phi[i + i_z*nbins] = log10(dndm * exp(-(M_TURNs[i_z]/Mhalo_param[i])) * f_duty_upper / deriv[i]);
+                if (isinf(log10phi[i + i_z*nbins]) || isnan(log10phi[i + i_z*nbins]) || log10phi[i + i_z*nbins] < -30.)
+                    log10phi[i + i_z*nbins] = -30.;
             }
         }
     }
 
 	cleanup_ComputeLF();
-
+    } // End try
+    Catch(status){
+        return status;
+    }
     return(0);
 
 }
@@ -2197,7 +2214,7 @@ float GaussLegendreQuad_Nion(int Type, int n, float growthf, float M2, float sig
     }
 }
 
-int initialise_Nion_General_spline(float z, float min_density, float max_density, float Mmax, float MassTurnover, float Alpha_star, float Alpha_esc, float Fstar10, float Fesc10, float Mlim_Fstar, float Mlim_Fesc){
+void initialise_Nion_General_spline(float z, float min_density, float max_density, float Mmax, float MassTurnover, float Alpha_star, float Alpha_esc, float Fstar10, float Fesc10, float Mlim_Fstar, float Mlim_Fesc){
 
 
     float Mmin = MassTurnover/50.;
@@ -2255,9 +2272,9 @@ int initialise_Nion_General_spline(float z, float min_density, float max_density
     }
 
     for (i=0; i<NSFR_low; i++){
-        if(isfinite(log10_Nion_spline[i])==0) {
+        if(!isfinite(log10_Nion_spline[i])) {
             LOG_ERROR("Detected either an infinite or NaN value in log10_Nion_spline");
-            return(-1);
+            Throw(ParameterError);
         }
     }
 
@@ -2275,16 +2292,14 @@ int initialise_Nion_General_spline(float z, float min_density, float max_density
     }
 
     for(i=0;i<NSFR_high;i++) {
-        if(isfinite(Nion_spline[i])==0) {
+        if(!isfinite(Nion_spline[i])) {
             LOG_ERROR("Detected either an infinite or NaN value in log10_Nion_spline");
-            return(-1);
+            Throw(ParameterError);
         }
     }
-
-    return(0);
 }
 
-int initialise_Nion_General_spline_MINI(float z, float Mcrit_atom, float min_density, float max_density, float Mmax, float Mmin, float log10Mturn_min, float log10Mturn_max, float log10Mturn_min_MINI, float log10Mturn_max_MINI, float Alpha_star, float Alpha_esc, float Fstar10, float Fesc10, float Mlim_Fstar, float Mlim_Fesc, float Fstar7_MINI, float Fesc7_MINI, float Mlim_Fstar_MINI, float Mlim_Fesc_MINI){
+void initialise_Nion_General_spline_MINI(float z, float Mcrit_atom, float min_density, float max_density, float Mmax, float Mmin, float log10Mturn_min, float log10Mturn_max, float log10Mturn_min_MINI, float log10Mturn_max_MINI, float Alpha_star, float Alpha_esc, float Fstar10, float Fesc10, float Mlim_Fstar, float Mlim_Fesc, float Fstar7_MINI, float Fesc7_MINI, float Mlim_Fstar_MINI, float Mlim_Fesc_MINI){
 
     double growthf, sigma2;
     double overdense_large_high = Deltac, overdense_large_low = global_params.CRIT_DENS_TRANSITION*0.999;
@@ -2363,12 +2378,12 @@ int initialise_Nion_General_spline_MINI(float z, float Mcrit_atom, float min_den
         for (j=0; j<NMTURN; j++){
             if(isfinite(log10_Nion_spline[i+j*NSFR_low])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in log10_Nion_spline");
-                return(-1);
+                Throw(ParameterError);
             }
 
             if(isfinite(log10_Nion_spline_MINI[i+j*NSFR_low])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in log10_Nion_spline_MINI");
-                return(-1);
+                Throw(ParameterError);
             }
         }
     }
@@ -2382,16 +2397,21 @@ int initialise_Nion_General_spline_MINI(float z, float Mcrit_atom, float min_den
 #pragma omp for
         for(i=0;i<NSFR_high;i++) {
             for (j=0; j<NMTURN; j++){
-
-                Nion_spline[i+j*NSFR_high] = Nion_ConditionalM(growthf,Mmin,Mmax,sigma2,Deltac,Overdense_spline_SFR[i],
-                                                               Mturns[j],Alpha_star,Alpha_esc,Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc);
+                Nion_spline[i+j*NSFR_high] = Nion_ConditionalM(
+                    growthf,Mmin,Mmax,sigma2,Deltac,Overdense_spline_SFR[i],
+                    Mturns[j],Alpha_star,Alpha_esc,Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc
+                );
 
                 if(Nion_spline[i+j*NSFR_high]<0.) {
                     Nion_spline[i+j*NSFR_high]=pow(10.,-40.0);
                 }
 
-                Nion_spline_MINI[i+j*NSFR_high] = Nion_ConditionalM_MINI(growthf,Mmin,Mmax,sigma2,Deltac,Overdense_spline_SFR[i],
-                                                            Mturns_MINI[j],Mcrit_atom,Alpha_star,Alpha_esc,Fstar7_MINI,Fesc7_MINI,Mlim_Fstar_MINI,Mlim_Fesc_MINI);
+                Nion_spline_MINI[i+j*NSFR_high] = Nion_ConditionalM_MINI(
+                    growthf,Mmin,Mmax,sigma2,Deltac,Overdense_spline_SFR[i],
+                    Mturns_MINI[j],Mcrit_atom,Alpha_star,Alpha_esc,Fstar7_MINI,Fesc7_MINI,
+                    Mlim_Fstar_MINI,Mlim_Fesc_MINI
+                );
+
 
                 if(Nion_spline_MINI[i+j*NSFR_high]<0.) {
                     Nion_spline_MINI[i+j*NSFR_high]=pow(10.,-40.0);
@@ -2404,20 +2424,18 @@ int initialise_Nion_General_spline_MINI(float z, float Mcrit_atom, float min_den
         for (j=0; j<NMTURN; j++){
             if(isfinite(Nion_spline[i+j*NSFR_high])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in Nion_spline");
-                return(-1);
+                Throw(ParameterError);
             }
 
             if(isfinite(Nion_spline_MINI[i+j*NSFR_high])==0) {
-                LOG_ERROR("Detected either an infinite or NaN value in Nion_spline_MINI");
-                return(-1);
+               LOG_ERROR("Detected either an infinite or NaN value in Nion_spline_MINI");
+                Throw(ParameterError);
             }
         }
     }
-
-    return(0);
 }
 
-int initialise_Nion_General_spline_MINI_prev(float z, float Mcrit_atom, float min_density, float max_density, float Mmax, float Mmin, float log10Mturn_min, float log10Mturn_max, float log10Mturn_min_MINI, float log10Mturn_max_MINI, float Alpha_star, float Alpha_esc, float Fstar10, float Fesc10, float Mlim_Fstar, float Mlim_Fesc, float Fstar7_MINI, float Fesc7_MINI, float Mlim_Fstar_MINI, float Mlim_Fesc_MINI){
+void initialise_Nion_General_spline_MINI_prev(float z, float Mcrit_atom, float min_density, float max_density, float Mmax, float Mmin, float log10Mturn_min, float log10Mturn_max, float log10Mturn_min_MINI, float log10Mturn_max_MINI, float Alpha_star, float Alpha_esc, float Fstar10, float Fesc10, float Mlim_Fstar, float Mlim_Fesc, float Fstar7_MINI, float Fesc7_MINI, float Mlim_Fstar_MINI, float Mlim_Fesc_MINI){
 
     double growthf, sigma2;
     double overdense_large_high = Deltac, overdense_large_low = global_params.CRIT_DENS_TRANSITION*0.999;
@@ -2496,12 +2514,12 @@ int initialise_Nion_General_spline_MINI_prev(float z, float Mcrit_atom, float mi
         for (j=0; j<NMTURN; j++){
             if(isfinite(prev_log10_Nion_spline[i+j*NSFR_low])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in prev_log10_Nion_spline");
-                return(-1);
+                Throw(ParameterError);
             }
 
             if(isfinite(prev_log10_Nion_spline_MINI[i+j*NSFR_low])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in prev_log10_Nion_spline_MINI");
-                return(-1);
+                Throw(ParameterError);
             }
         }
     }
@@ -2523,6 +2541,7 @@ int initialise_Nion_General_spline_MINI_prev(float z, float Mcrit_atom, float mi
                     prev_Nion_spline[i+j*NSFR_high]=pow(10.,-40.0);
                 }
 
+
                 prev_Nion_spline_MINI[i+j*NSFR_high] = Nion_ConditionalM_MINI(growthf,Mmin,Mmax,sigma2,Deltac,\
                                                                     prev_Overdense_spline_SFR[i],Mturns_MINI[j],Mcrit_atom,Alpha_star,\
                                                                     Alpha_esc,Fstar7_MINI,Fesc7_MINI,Mlim_Fstar_MINI,Mlim_Fesc_MINI);
@@ -2530,29 +2549,31 @@ int initialise_Nion_General_spline_MINI_prev(float z, float Mcrit_atom, float mi
                 if(prev_Nion_spline_MINI[i+j*NSFR_high]<0.) {
                     prev_Nion_spline_MINI[i+j*NSFR_high]=pow(10.,-40.0);
                 }
+
+
             }
         }
     }
 
     for(i=0;i<NSFR_high;i++) {
         for (j=0; j<NMTURN; j++){
-
             if(isfinite(prev_Nion_spline[i+j*NSFR_high])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in prev_Nion_spline");
-                return(-1);
+                Throw(ParameterError);
             }
 
             if(isfinite(prev_Nion_spline_MINI[i+j*NSFR_high])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in prev_Nion_spline_MINI");
-                return(-1);
+                Throw(ParameterError);
             }
         }
     }
-
-    return(0);
 }
 
-int initialise_Nion_Ts_spline(int Nbin, float zmin, float zmax, float MassTurn, float Alpha_star, float Alpha_esc, float Fstar10, float Fesc10){
+void initialise_Nion_Ts_spline(
+    int Nbin, float zmin, float zmax, float MassTurn, float Alpha_star, float Alpha_esc,
+    float Fstar10, float Fesc10
+){
     int i;
     float Mmin = MassTurn/50., Mmax = global_params.M_MAX_INTEGRAL;
     float Mlim_Fstar, Mlim_Fesc;
@@ -2575,14 +2596,15 @@ int initialise_Nion_Ts_spline(int Nbin, float zmin, float zmax, float MassTurn, 
     for (i=0; i<Nbin; i++){
         if(isfinite(Nion_z_val[i])==0) {
             LOG_ERROR("Detected either an infinite or NaN value in Nion_z_val");
-            return(-1);
+            Throw(ParameterError);
         }
     }
-
-    return(0);
 }
 
-int initialise_Nion_Ts_spline_MINI(int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_esc, float Fstar10, float Fesc10, float Fstar7_MINI, float Fesc7_MINI){
+void initialise_Nion_Ts_spline_MINI(
+    int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_esc, float Fstar10,
+    float Fesc10, float Fstar7_MINI, float Fesc7_MINI
+){
     int i,j;
     float Mmin = global_params.M_MIN_INTEGRAL, Mmax = global_params.M_MAX_INTEGRAL;
     float Mlim_Fstar, Mlim_Fesc, Mlim_Fstar_MINI, Mlim_Fesc_MINI, Mcrit_atom_val;
@@ -2620,23 +2642,21 @@ int initialise_Nion_Ts_spline_MINI(int Nbin, float zmin, float zmax, float Alpha
         if(isfinite(Nion_z_val[i])==0) {
             i = Nbin;
             LOG_ERROR("Detected either an infinite or NaN value in Nion_z_val");
-            return(-1);
+            Throw(ParameterError);
         }
 
         for (j=0; j<NMTURN; j++){
             if(isfinite(Nion_z_val_MINI[i+j*Nbin])==0){
                 j = NMTURN;
                 LOG_ERROR("Detected either an infinite or NaN value in Nion_z_val_MINI");
-                return(-1);
+                Throw(ParameterError);
             }
         }
     }
-
-    return(0);
 }
 
 
-int initialise_SFRD_spline(int Nbin, float zmin, float zmax, float MassTurn, float Alpha_star, float Fstar10){
+void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float MassTurn, float Alpha_star, float Fstar10){
     int i;
     float Mmin = MassTurn/50., Mmax = global_params.M_MAX_INTEGRAL;
     float Mlim_Fstar;
@@ -2658,14 +2678,12 @@ int initialise_SFRD_spline(int Nbin, float zmin, float zmax, float MassTurn, flo
     for (i=0; i<Nbin; i++){
         if(isfinite(SFRD_val[i])==0) {
             LOG_ERROR("Detected either an infinite or NaN value in SFRD_val");
-            return(-1);
+            Throw(ParameterError);
         }
     }
-
-    return(0);
 }
 
-int initialise_SFRD_spline_MINI(int Nbin, float zmin, float zmax, float Alpha_star, float Fstar10, float Fstar7_MINI){
+void initialise_SFRD_spline_MINI(int Nbin, float zmin, float zmax, float Alpha_star, float Fstar10, float Fstar7_MINI){
     int i,j;
     float Mmin = global_params.M_MIN_INTEGRAL, Mmax = global_params.M_MAX_INTEGRAL;
     float Mlim_Fstar, Mlim_Fstar_MINI, Mcrit_atom_val;
@@ -2702,39 +2720,30 @@ int initialise_SFRD_spline_MINI(int Nbin, float zmin, float zmax, float Alpha_st
         if(isfinite(SFRD_val[i])==0) {
             i = Nbin;
             LOG_ERROR("Detected either an infinite or NaN value in SFRD_val");
-            return(-1);
+            Throw(ParameterError);
         }
 
         for (j=0; j<NMTURN; j++){
             if(isfinite(SFRD_val_MINI[i+j*Nbin])==0) {
                 j = NMTURN;
                 LOG_ERROR("Detected either an infinite or NaN value in SFRD_val_MINI");
-                return(-1);
+                Throw(ParameterError);
             }
         }
     }
-
-
-    return(0);
 }
 
-int initialise_SFRD_Conditional_table(int Nfilter, float min_density[], float max_density[], float growthf[], float R[], float MassTurnover, float Alpha_star, float Fstar10){
+void initialise_SFRD_Conditional_table(
+    int Nfilter, float min_density[], float max_density[], float growthf[], float R[],
+    float MassTurnover, float Alpha_star, float Fstar10
+){
 
     double overdense_val;
     double overdense_large_high = Deltac, overdense_large_low = global_params.CRIT_DENS_TRANSITION;
     double overdense_small_high, overdense_small_low;
 
     overdense_low_table = calloc(NSFR_low,sizeof(double));
-    Overdense_high_table = calloc(NSFR_high,sizeof(double));
-
-//    int larger;
-//
-//    if(NSFR_low >= NSFR_high) {
-//        larger = NSFR_low;
-//    }
-//    else {
-//        larger = NSFR_high;
-//    }
+    overdense_high_table = calloc(NSFR_high,sizeof(double));
 
     float Mmin,Mmax,Mlim_Fstar,sigma2;
     int i,j,k,i_tot;
@@ -2750,7 +2759,7 @@ int initialise_SFRD_Conditional_table(int Nfilter, float min_density[], float ma
     Mmin = log(Mmin);
 
     for (i=0; i<NSFR_high;i++) {
-        Overdense_high_table[i] = overdense_large_low + (float)i/((float)NSFR_high-1.)*(overdense_large_high - overdense_large_low);
+        overdense_high_table[i] = overdense_large_low + (float)i/((float)NSFR_high-1.)*(overdense_large_high - overdense_large_low);
     }
 
     float MassBinLow;
@@ -2803,55 +2812,42 @@ int initialise_SFRD_Conditional_table(int Nfilter, float min_density[], float ma
 
         for (i=0; i<NSFR_low; i++){
             if(isfinite(log10_SFRD_z_low_table[j][i])==0) {
-                //                j = Nfilter;
-                //                i = larger;
                 LOG_ERROR("Detected either an infinite or NaN value in log10_SFRD_z_low_table");
-                return(-1);
+                Throw(ParameterError);
             }
         }
 
-#pragma omp parallel shared(SFRD_z_high_table,growthf,Mmin,Mmax,sigma2,Overdense_high_table,MassTurnover,Alpha_star,Fstar10,Mlim_Fstar) private(i) num_threads(user_params_ps->N_THREADS)
+#pragma omp parallel shared(SFRD_z_high_table,growthf,Mmin,Mmax,sigma2,overdense_high_table,MassTurnover,Alpha_star,Fstar10,Mlim_Fstar) private(i) num_threads(user_params_ps->N_THREADS)
         {
 #pragma omp for
             for(i=0;i<NSFR_high;i++) {
 
-                SFRD_z_high_table[j][i] = Nion_ConditionalM(growthf[j],Mmin,Mmax,sigma2,Deltac,Overdense_high_table[i],MassTurnover,Alpha_star,0.,Fstar10,1.,Mlim_Fstar,0.);
+                SFRD_z_high_table[j][i] = Nion_ConditionalM(growthf[j],Mmin,Mmax,sigma2,Deltac,overdense_high_table[i],MassTurnover,Alpha_star,0.,Fstar10,1.,Mlim_Fstar,0.);
                 SFRD_z_high_table[j][i] *= pow(10., 10.0);
             }
         }
 
         for(i=0;i<NSFR_high;i++) {
             if(isfinite(SFRD_z_high_table[j][i])==0) {
-                //                j = Nfilter;
-                //                i = larger;
                 LOG_ERROR("Detected either an infinite or NaN value in SFRD_z_high_table");
-                return(-1);
+                Throw(ParameterError);
             }
         }
 
     }
-
-    return(0);
-
 }
 
-int initialise_SFRD_Conditional_table_MINI(int Nfilter, float min_density[], float max_density[], float growthf[], float R[], float Mcrit_atom[], float Alpha_star, float Fstar10, float Fstar7_MINI){
+void initialise_SFRD_Conditional_table_MINI(
+    int Nfilter, float min_density[], float max_density[], float growthf[], float R[],
+    float Mcrit_atom[], float Alpha_star, float Fstar10, float Fstar7_MINI
+){
 
     double overdense_val;
     double overdense_large_high = Deltac, overdense_large_low = global_params.CRIT_DENS_TRANSITION;
     double overdense_small_high, overdense_small_low;
 
     overdense_low_table = calloc(NSFR_low,sizeof(double));
-    Overdense_high_table = calloc(NSFR_high,sizeof(double));
-
-//    int larger;
-//
-//    if(NSFR_low >= NSFR_high) {
-//        larger = NSFR_low;
-//    }
-//    else {
-//        larger = NSFR_high;
-//    }
+    overdense_high_table = calloc(NSFR_high,sizeof(double));
 
     float Mmin,Mmax,Mlim_Fstar,sigma2,Mlim_Fstar_MINI;
     int i,j,k,i_tot;
@@ -2873,7 +2869,7 @@ int initialise_SFRD_Conditional_table_MINI(int Nfilter, float min_density[], flo
     Mmin = log(Mmin);
 
     for (i=0; i<NSFR_high;i++) {
-        Overdense_high_table[i] = overdense_large_low + (float)i/((float)NSFR_high-1.)*(overdense_large_high - overdense_large_low);
+        overdense_high_table[i] = overdense_large_low + (float)i/((float)NSFR_high-1.)*(overdense_large_high - overdense_large_low);
     }
 
     float MassBinLow;
@@ -2937,25 +2933,25 @@ int initialise_SFRD_Conditional_table_MINI(int Nfilter, float min_density[], flo
         for (i=0; i<NSFR_low; i++){
             if(isfinite(log10_SFRD_z_low_table[j][i])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in log10_SFRD_z_low_table");
-                return(-1);
+                Throw(ParameterError);
             }
 
             for (k=0; k<NMTURN; k++){
                 if(isfinite(log10_SFRD_z_low_table_MINI[j][i+k*NSFR_low])==0) {
                     LOG_ERROR("Detected either an infinite or NaN value in log10_SFRD_z_low_table_MINI");
-                    return(-1);
+                    Throw(ParameterError);
                 }
             }
         }
 
-#pragma omp parallel shared(SFRD_z_high_table,growthf,Mmin,Mmax,sigma2,Overdense_high_table,Mcrit_atom,Alpha_star,Fstar10,\
+#pragma omp parallel shared(SFRD_z_high_table,growthf,Mmin,Mmax,sigma2,overdense_high_table,Mcrit_atom,Alpha_star,Fstar10,\
                             Mlim_Fstar,SFRD_z_high_table_MINI,MassTurnover,Fstar7_MINI,Mlim_Fstar_MINI) \
                     private(i,k) num_threads(user_params_ps->N_THREADS)
         {
 #pragma omp for
             for(i=0;i<NSFR_high;i++) {
 
-                SFRD_z_high_table[j][i] = Nion_ConditionalM(growthf[j],Mmin,Mmax,sigma2,Deltac,Overdense_high_table[i],\
+                SFRD_z_high_table[j][i] = Nion_ConditionalM(growthf[j],Mmin,Mmax,sigma2,Deltac,overdense_high_table[i],\
                                                             Mcrit_atom[j],Alpha_star,0.,Fstar10,1.,Mlim_Fstar,0.);
                 if (SFRD_z_high_table[j][i] < 1e-50){
                     SFRD_z_high_table[j][i] = 1e-50;
@@ -2965,7 +2961,7 @@ int initialise_SFRD_Conditional_table_MINI(int Nfilter, float min_density[], flo
 
                 for (k=0; k<NMTURN; k++){
                     SFRD_z_high_table_MINI[j][i+k*NSFR_high] = Nion_ConditionalM_MINI(growthf[j],Mmin,Mmax,sigma2,Deltac,\
-                                                                    Overdense_high_table[i],MassTurnover[k],Mcrit_atom[j],\
+                                                                    overdense_high_table[i],MassTurnover[k],Mcrit_atom[j],\
                                                                     Alpha_star,0.,Fstar7_MINI,1.,Mlim_Fstar_MINI, 0.);
 
                     if (SFRD_z_high_table_MINI[j][i+k*NSFR_high] < 1e-50){
@@ -2978,20 +2974,17 @@ int initialise_SFRD_Conditional_table_MINI(int Nfilter, float min_density[], flo
         for(i=0;i<NSFR_high;i++) {
             if(isfinite(SFRD_z_high_table[j][i])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in SFRD_z_high_table");
-                return(-1);
+                Throw(ParameterError);
             }
 
             for (k=0; k<NMTURN; k++){
                 if(isfinite(SFRD_z_high_table_MINI[j][i+k*NSFR_high])==0) {
                     LOG_ERROR("Detected either an infinite or NaN value in SFRD_z_high_table_MINI");
-                    return(-1);
+                    Throw(ParameterError);
                 }
             }
         }
     }
-
-    return(0);
-
 }
 
 // The volume filling factor at a given redshift, Q(z), or find redshift at a given Q, z(Q).
@@ -3014,6 +3007,13 @@ int initialise_SFRD_Conditional_table_MINI(int Nfilter, float min_density[], flo
 int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cosmo_params,
                          struct AstroParams *astro_params, struct FlagOptions *flag_options)
 {
+
+    /*
+        This is an API-level function for initialising the photon conservation.
+    */
+
+    int status;
+    Try{  // this try wraps the whole function.
     Broadcast_struct_global_PS(user_params,cosmo_params);
     Broadcast_struct_global_UF(user_params,cosmo_params);
     init_ps();
@@ -3033,6 +3033,7 @@ int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cos
     int Nmax = 2000; // This is the number of step, enough with 'da = 2e-3'. If 'da' is reduced, this number should be checked.
     int cnt, nbin, i, istart;
     int fail_condition, not_mono_increasing, num_fails;
+    int gsl_status;
 
     z_arr = calloc(Nmax,sizeof(double));
     Q_arr = calloc(Nmax,sizeof(double));
@@ -3156,7 +3157,7 @@ int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cos
         else {
             num_fails += 1;
             if(num_fails>10) {
-                LOG_ERROR("Failed too many times. Exit out!");
+                LOG_ERROR("Failed too many times.");
                 Throw ParameterError;
             }
         }
@@ -3177,68 +3178,84 @@ int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cos
 
     Q_at_z_spline_acc = gsl_interp_accel_alloc ();
     Q_at_z_spline = gsl_spline_alloc (gsl_interp_cspline, nbin);
-//    Q_at_z_spline = gsl_spline_alloc (gsl_interp_linear, nbin);
 
     for (i=0; i<nbin; i++){
         z_Q[i] = z_arr[cnt-i];
         Q_value[i] = Q_arr[cnt-i];
     }
 
-    gsl_spline_init(Q_at_z_spline, z_Q, Q_value, nbin);
+    gsl_set_error_handler_off();
+    gsl_status = gsl_spline_init(Q_at_z_spline, z_Q, Q_value, nbin);
+    GSL_ERROR(gsl_status);
+
     Zmin = z_Q[0];
     Zmax = z_Q[nbin-1];
     Qmin = Q_value[nbin-1];
     Qmax = Q_value[0];
 
-    // initialise interploation z as a function of Q
+    // initialise interpolation z as a function of Q
     double *Q_z = calloc(nbin,sizeof(double));
     double *z_value = calloc(nbin,sizeof(double));
 
     z_at_Q_spline_acc = gsl_interp_accel_alloc ();
-//    z_at_Q_spline = gsl_spline_alloc (gsl_interp_cspline, nbin);
     z_at_Q_spline = gsl_spline_alloc (gsl_interp_linear, nbin);
     for (i=0; i<nbin; i++){
         Q_z[i] = Q_value[nbin-1-i];
         z_value[i] = z_Q[nbin-1-i];
     }
 
-    gsl_spline_init(z_at_Q_spline, Q_z, z_value, nbin);
+    gsl_status = gsl_spline_init(z_at_Q_spline, Q_z, z_value, nbin);
+    GSL_ERROR(gsl_status);
 
     free(z_arr);
     free(Q_arr);
 
     LOG_DEBUG("Initialised PhotonCons.");
+    } // End of try
+    Catch(status){
+        return status;
+    }
+
     return(0);
 }
 
 // Function to construct the spline for the calibration curve of the photon non-conservation
-int PhotonCons_Calibration(double *z_estimate, double *xH_estimate, int NSpline)
-{
-
-    if(xH_estimate[NSpline-1] > 0.0 && xH_estimate[NSpline-2] > 0.0 && xH_estimate[NSpline-3] > 0.0 && xH_estimate[0] <= global_params.PhotonConsStart) {
-        initialise_NFHistory_spline(z_estimate,xH_estimate,NSpline);
+int PhotonCons_Calibration(double *z_estimate, double *xH_estimate, int NSpline){
+    int status;
+    Try{
+        if(xH_estimate[NSpline-1] > 0.0 && xH_estimate[NSpline-2] > 0.0 && xH_estimate[NSpline-3] > 0.0 && xH_estimate[0] <= global_params.PhotonConsStart) {
+            initialise_NFHistory_spline(z_estimate,xH_estimate,NSpline);
+        }
     }
-
+    Catch(status){
+        return status;
+    }
     return(0);
 }
 
 // Function callable from Python to know at which redshift to start sampling the calibration curve (to minimise function calls)
-double ComputeZstart_PhotonCons() {
-
+int ComputeZstart_PhotonCons(double *zstart) {
+    int status;
     double temp;
 
-    if((1.-global_params.PhotonConsStart) > Qmax) {
-        // It is possible that reionisation never even starts
-        // Just need to arbitrarily set a high redshift to perform the algorithm
-        temp = 20.;
+    Try{
+        if((1.-global_params.PhotonConsStart) > Qmax) {
+            // It is possible that reionisation never even starts
+            // Just need to arbitrarily set a high redshift to perform the algorithm
+            temp = 20.;
+        }
+        else {
+            z_at_Q(1. - global_params.PhotonConsStart,&(temp));
+        // Multiply the result by 10 per-cent to fix instances when this isn't high enough
+            temp *= 1.1;
+        }
     }
-    else {
-        z_at_Q(1. - global_params.PhotonConsStart,&(temp));
-	// Multiply the result by 10 per-cent to fix instances when this isn't high enough
-        temp *= 1.1;
+    Catch(status){
+        return(status); // Use the status to determine if something went wrong.
     }
 
-    return(temp);
+    *zstart = temp;
+    return(0);
 }
 
 
@@ -3518,12 +3535,18 @@ void determine_deltaz_for_photoncons() {
     deltaz_spline_for_photoncons_acc = gsl_interp_accel_alloc ();
     deltaz_spline_for_photoncons = gsl_spline_alloc (gsl_interp_linear, N_NFsamples + N_extrapolated + 1);
 
-    gsl_spline_init(deltaz_spline_for_photoncons, NeutralFractions, deltaz, N_NFsamples + N_extrapolated + 1);
+    gsl_set_error_handler_off();
+    int gsl_status;
+    gsl_status = gsl_spline_init(deltaz_spline_for_photoncons, NeutralFractions, deltaz, N_NFsamples + N_extrapolated + 1);
+    GSL_ERROR(gsl_status);
 
 }
 
 
-float adjust_redshifts_for_photoncons(struct AstroParams *astro_params, struct FlagOptions *flag_options, float *redshift, float *stored_redshift, float *absolute_delta_z) {
+float adjust_redshifts_for_photoncons(
+    struct AstroParams *astro_params, struct FlagOptions *flag_options, float *redshift,
+    float *stored_redshift, float *absolute_delta_z
+) {
 
     int i, new_counter;
     double temp;
@@ -3624,8 +3647,14 @@ float adjust_redshifts_for_photoncons(struct AstroParams *astro_params, struct F
                 new_counter += 1;
             }
             if(new_counter > 5) {
-		LOG_WARNING("The photon non-conservation correction has employed an extrapolation for\n for more than 5 consecutive snapshots. This can be unstable, thus please check resultant history. Parameters are:\n");
-		writeAstroParams(flag_options, astro_params);
+                LOG_WARNING(
+                    "The photon non-conservation correction has employed an extrapolation for\n"\
+                    "more than 5 consecutive snapshots. This can be unstable, thus please check "\
+                    "resultant history. Parameters are:\n"
+                );
+                #if LOG_LEVEL >= LOG_WARNING
+                    writeAstroParams(flag_options, astro_params);
+                #endif
             }
 
             // Now adjust the final delta_z by some amount to smooth if over successive steps
@@ -3675,10 +3704,12 @@ void z_at_Q(double Q, double *splined_value){
     float returned_value;
 
     if (Q < Qmin) {
-        fprintf(stderr,"The minimum value of Q is %.4e\n Aborting...\n",Qmin);
+        LOG_ERROR("The minimum value of Q is %.4e",Qmin);
+        Throw(ParameterError);
     }
     else if (Q > Qmax) {
-        fprintf(stderr,"The maximum value of Q is %.4e\n Reionization ends at ~%.4f\n Aborting...\n",Qmax,Zmin);
+        LOG_ERROR("The maximum value of Q is %.4e. Reionization ends at ~%.4f.",Qmax,Zmin);
+        Throw(ParameterError);
     }
     else {
         returned_value = gsl_spline_eval(z_at_Q_spline, Q, z_at_Q_spline_acc);
@@ -3746,13 +3777,17 @@ void initialise_NFHistory_spline(double *redshifts, double *NF_estimate, int NSp
 //    NFHistory_spline = gsl_spline_alloc (gsl_interp_cspline, (counter+1));
     NFHistory_spline = gsl_spline_alloc (gsl_interp_linear, (counter+1));
 
-    gsl_spline_init(NFHistory_spline, nf_vals, z_vals, (counter+1));
+    gsl_set_error_handler_off();
+    int gsl_status;
+    gsl_status = gsl_spline_init(NFHistory_spline, nf_vals, z_vals, (counter+1));
+    GSL_ERROR(gsl_status);
 
     z_NFHistory_spline_acc = gsl_interp_accel_alloc ();
 //    z_NFHistory_spline = gsl_spline_alloc (gsl_interp_cspline, (counter+1));
     z_NFHistory_spline = gsl_spline_alloc (gsl_interp_linear, (counter+1));
 
-    gsl_spline_init(z_NFHistory_spline, z_vals, nf_vals, (counter+1));
+    gsl_status = gsl_spline_init(z_NFHistory_spline, z_vals, nf_vals, (counter+1));
+    GSL_ERROR(gsl_status);
 }
 
 
@@ -3770,8 +3805,10 @@ void NFHist_at_z(double z, double *splined_value){
     *splined_value = returned_value;
 }
 
-int ObtainPhotonConsData(double *z_at_Q_data, double *Q_data, int *Ndata_analytic, double *z_cal_data, double *nf_cal_data, int *Ndata_calibration,
-                         double *PhotonCons_NFdata, double *PhotonCons_deltaz, int *Ndata_PhotonCons) {
+int ObtainPhotonConsData(
+    double *z_at_Q_data, double *Q_data, int *Ndata_analytic, double *z_cal_data,
+    double *nf_cal_data, int *Ndata_calibration,
+    double *PhotonCons_NFdata, double *PhotonCons_deltaz, int *Ndata_PhotonCons) {
 
     int i;
 

--- a/src/py21cmfast/src/recombinations.c
+++ b/src/py21cmfast/src/recombinations.c
@@ -52,11 +52,9 @@ double splined_recombination_rate(double z_eff, double gamma12_bg){
 
   // check out of bounds
   if ( z_ct < 0 ){ // out of array bounds
-//    fprintf(stderr, "WARNING: splined_recombination_rate: effective redshift %g is outside of array bouds\n", z_eff);
     z_ct = 0;
   }
   else if (z_ct  >= RR_Z_NPTS){
-//    fprintf(stderr, "WARNING: splined_recombination_rate: effective redshift %g is outside of array bouds\n", z_eff);
     z_ct = RR_Z_NPTS-1;
   }
 
@@ -145,8 +143,6 @@ double MHR_rr (double lnD, void *params){
     alpha = alpha_B(p.T4*1e4);
   else
     alpha = alpha_A(p.T4*1e4);
-
-  //  fprintf(stderr, "%g\t%g\t%g\t%g\t%g\n", n_H, PDelta, alpha, x_e, D);
 
   return n_H * PDelta * alpha * x_e * x_e * del * del;//note extra D since we are integrating over lnD
 }

--- a/src/py21cmfast/src/recombinations.c
+++ b/src/py21cmfast/src/recombinations.c
@@ -62,7 +62,7 @@ double splined_recombination_rate(double z_eff, double gamma12_bg){
     return 0;
   }
   else if (lnGamma >= (RR_lnGamma_min + RR_DEL_lnGamma * ( RR_lnGamma_NPTS - 1 )) ){
-//    fprintf(stderr, "WARNING: splined_recombination_rate: Gamma12 of %g is outside of interpolation array\n", gamma12_bg);
+    LOG_WARNING("splined_recombination_rate: Gamma12 of %g is outside of interpolation array", gamma12_bg);
     lnGamma =  RR_lnGamma_min + RR_DEL_lnGamma * ( RR_lnGamma_NPTS - 1 ) - FRACT_FLOAT_ERR;
   }
 
@@ -74,9 +74,9 @@ void init_MHR(){
   float z, gamma;
 
   // first initialize the MHR parameter look up tables
-  init_C_MHR(); /*initializes the lookup table for the C paremeter in MHR00 model*/
-  init_beta_MHR(); /*initializes the lookup table for the beta paremeter in MHR00 model*/
-  init_A_MHR(); /*initializes the lookup table for the A paremeter in MHR00 model*/
+  init_C_MHR(); /*initializes the lookup table for the C parameter in MHR00 model*/
+  init_beta_MHR(); /*initializes the lookup table for the beta parameter in MHR00 model*/
+  init_A_MHR(); /*initializes the lookup table for the A parameter in MHR00 model*/
 
   // now the recombination rate look up tables
   for (z_ct=0; z_ct < RR_Z_NPTS; z_ct++){

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,24 @@
+import pytest
+
+from py21cmfast.c_21cmfast import ffi
+from py21cmfast.c_21cmfast import lib
+from py21cmfast.wrapper import PARAMETERERROR
+from py21cmfast.wrapper import ParameterError
+from py21cmfast.wrapper import _call_c_simple
+
+
+@pytest.mark.parametrize("subfunc", [True, False])
+def test_basic(subfunc):
+    status = lib.SomethingThatCatches(subfunc)
+    assert status == PARAMETERERROR
+
+
+@pytest.mark.parametrize("subfunc", [True, False])
+def test_simple(subfunc):
+    with pytest.raises(ParameterError):
+        _call_c_simple(lib.FunctionThatCatches, subfunc, False)
+
+
+def test_pass():
+    answer = _call_c_simple(lib.FunctionThatCatches, True, True)
+    assert answer == 5.0

--- a/tests/test_initial_conditions.py
+++ b/tests/test_initial_conditions.py
@@ -1,6 +1,7 @@
 """
 Various tests of the initial_conditions() function and InitialConditions class.
 """
+from multiprocessing import cpu_count
 
 import pytest
 
@@ -12,7 +13,9 @@ from py21cmfast import wrapper
 @pytest.fixture(scope="module")  # call this fixture once for all tests in this module
 def basic_init_box():
     return wrapper.initial_conditions(
-        regenerate=True, write=False, user_params=wrapper.UserParams(HII_DIM=35)
+        regenerate=True,
+        write=False,
+        user_params=wrapper.UserParams(HII_DIM=35, BOX_LEN=70),
     )
 
 
@@ -31,16 +34,17 @@ def test_box_shape(basic_init_box):
     assert basic_init_box.cosmo_params == wrapper.CosmoParams()
 
 
-def test_modified_cosmo():
+def test_modified_cosmo(basic_init_box):
     """Test using a modified cosmology"""
-    cosmo = wrapper.CosmoParams(sigma_8=0.9)
+    cosmo = wrapper.CosmoParams(SIGMA_8=0.9)
     ic = wrapper.initial_conditions(
         cosmo_params=cosmo,
         regenerate=True,
         write=False,
-        user_params={"HII_DIM": 35, "BOX_LEN": 70},
+        user_params=basic_init_box.user_params,
     )
 
+    assert ic.cosmo_params != basic_init_box.cosmo_params
     assert ic.cosmo_params == cosmo
     assert ic.cosmo_params.SIGMA_8 == cosmo.SIGMA_8
 
@@ -73,6 +77,7 @@ def test_relvels():
             BOX_LEN=300,
             POWER_SPECTRUM=5,
             USE_RELATIVE_VELOCITIES=True,
+            N_THREADS=cpu_count(),  # To make this one a bit faster.
         ),
     )
 

--- a/tests/test_integration_features.py
+++ b/tests/test_integration_features.py
@@ -87,7 +87,6 @@ def test_power_spectra_lightcone(redshift, kwargs, tmpdir):
             # Note that if zprime_step_factor is set in kwargs, it will over-ride this.
             k, p, lc = prd.produce_lc_power_spectra(redshift, **kwargs)
 
-    print(os.listdir(tmpdir))
     assert np.allclose(power, p, atol=1e-5, rtol=5e-3)
     assert np.allclose(xHI, lc.global_xHI, atol=1e-5, rtol=1e-3)
     assert np.allclose(Tb, lc.global_brightness_temp, atol=1e-5, rtol=1e-3)


### PR DESCRIPTION
This PR adds exception handling to C. 

The basic premise is that any non-API function (i.e. any function that's not in `21cmFAST.h`) should never just return an int to signal that it broke. Instead, it should do a `Throw <exception_kind>;`. 
The new `cexception.h` file includes the `Throw` macro. If this happens within a `Try {} Catch {}` block, the execurtion will jump to the `Catch` (at any level of the call stack). So these really are like `Try; Except; Raise` in Python. 

Any API-level function in C should be pretty much globally wrapped in a `Try Catch`, and if the `Catch` is activated, should return the error code to Python, which will then deal with it accordingly.

Closes #16.

This will go a long way to solving issues like #16 . In fact, this may solve that issue entirely, though I'd like @BradGreig to have a look first and see if something wrong is not happening in the code. If it is just that we don't expect those parameters ever to work, then this fixes that issue.