### PR TITLE
Contributing

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,9 +10,9 @@ Bug reports/Feature Requests/Feedback/Questions
 It is incredibly helpful to us when users report bugs, unexpected behaviour, or request
 features. You can do the following:
 
-    * `Report a bug <https://github.com/21cmFAST/21cmFAST/issues/new?template=bug_report.md>`
-    * `Request a Feature <https://github.com/21cmFAST/21cmFAST/issues/new?template=feature_request.md>`
-    * `Ask a Question <https://github.com/21cmFAST/21cmFAST/issues/new?template=question.md>`
+    * `Report a bug <https://github.com/21cmFAST/21cmFAST/issues/new?template=bug_report.md>`_
+    * `Request a Feature <https://github.com/21cmFAST/21cmFAST/issues/new?template=feature_request.md>`_
+    * `Ask a Question <https://github.com/21cmFAST/21cmFAST/issues/new?template=question.md>`_
 
 When doing any of these, please try to be as succinct, but detailed, as possible, and use
 a "Minimum Working Example" whenever applicable.
@@ -20,22 +20,25 @@ a "Minimum Working Example" whenever applicable.
 Documentation improvements
 ==========================
 
-21cmFAST could always use more documentation, whether as part of the
-official 21cmFAST docs, in docstrings, or even on the web in blog posts,
-articles, and such.
+``21cmFAST`` could always use more documentation, whether as part of the
+official ``21cmFAST`` docs, in docstrings, or even on the web in blog posts,
+articles, and such. If you do the latter, take the time to let us know about it!
 
 Development
 ===========
 
-This is an abbreviated guide to contributing, focusing on the discrete steps to take.
-See https://21cmfast.readthedocs.org/en/latest/notes_for_developers for more details.
+This is an abbreviated guide to getting started with development of ``21cmFAST``,
+focusing on the discrete high-level steps to take. See our
+`notes for developers <https://21cmfast.readthedocs.org/en/latest/notes_for_developers>`_
+for more details about how to get around the ``21cmFAST`` codebase and other
+technical details.
 
-There are two avenues for you to develop `21cmFAST`. If you plan on making significant
-changes, and working with `21cmFAST` for a long period of time, please consider
+There are two avenues for you to develop ``21cmFAST``. If you plan on making significant
+changes, and working with ``21cmFAST`` for a long period of time, please consider
 becoming a member of the 21cmFAST GitHub organisation (by emailing any of the owners
 or admins). You may develop as a member or as a non-member.
 
-The difference between members and non-members only applies to the first two steps
+The difference between members and non-members only applies to the first step
 of the development process.
 
 Note that it is highly recommended to work in an isolated python environment with
@@ -44,27 +47,50 @@ pre-commit hooks will run that enforce the ``black`` coding style. If you do not
 install these requirements, you must manually run black before committing your changes,
 otherwise your changes will likely fail continuous integration.
 
-As a member:
+As a *member*:
 
 1. Clone the repo::
 
     git clone git@github.com:21cmFAST/21cmFAST.git
 
-As a non-member:
+As a *non-member*:
 
 1. First fork `21cmFAST <https://github.com/21cmFAST/21cmFAST>`_
    (look for the "Fork" button), then clone the fork locally::
 
     git clone git@github.com:your_name_here/21cmFAST.git
 
-The following steps are the same for both members and non-members:
+The following steps are the same for both *members* and *non-members*:
 
-2. Create a branch for local development::
+2. Install a fresh new isolated environment. This can be either a basic ``virtualenv``
+   or a ``conda`` env (suggested). So either::
+
+       virtualenv ~/21cmfast
+       source ~/21cmfast/bin/activate
+
+   or::
+
+       conda create -n 21cmfast python=3
+       conda activate 21cmfast
+
+3. Install the *development* requirements for the project. If using the basic `virtualenv`::
+
+    pip install -r requirements_dev.txt
+
+   or if using `conda` (suggested)::
+
+    conda env update -f environment.yml
+
+4. Install pre-commit hooks::
+
+    pre-commit install
+
+3. Create a branch for local development::
 
     git checkout -b name-of-your-bugfix-or-feature
 
-   Now you can make your changes locally. **Note: you _must_ do this step. If you
-   make changes on master, you will _not_ be able to push them, as a member**.
+   Now you can make your changes locally. **Note: as a member, you _must_ do this step. If you
+   make changes on master, you will _not_ be able to push them**.
 
 3. When you're done making changes, run all the checks, doc builder and spell checker
    with `tox <http://tox.readthedocs.io/en/latest/install.html>`_ one command::
@@ -76,6 +102,11 @@ The following steps are the same for both members and non-members:
     git add .
     git commit -m "Your detailed description of your changes."
     git push origin name-of-your-bugfix-or-feature
+
+   Note that if the commit step fails due to a pre-commit hook, *most likely* the act
+   of running the hook itself has already fixed the error. Try doing the `add` and
+   `commit` again (up, up, enter). If it's still complaining, manually fix the errors
+   and do the same again.
 
 5. Submit a pull request through the GitHub website.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -85,19 +85,19 @@ The following steps are the same for both *members* and *non-members*:
 
     pre-commit install
 
-3. Create a branch for local development::
+5. Create a branch for local development::
 
     git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally. **Note: as a member, you _must_ do this step. If you
    make changes on master, you will _not_ be able to push them**.
 
-3. When you're done making changes, run all the checks, doc builder and spell checker
+6. When you're done making changes, run all the checks, doc builder and spell checker
    with `tox <http://tox.readthedocs.io/en/latest/install.html>`_ one command::
 
     tox
 
-4. Commit your changes and push your branch to GitHub::
+7. Commit your changes and push your branch to GitHub::
 
     git add .
     git commit -m "Your detailed description of your changes."
@@ -108,7 +108,7 @@ The following steps are the same for both *members* and *non-members*:
    `commit` again (up, up, enter). If it's still complaining, manually fix the errors
    and do the same again.
 
-5. Submit a pull request through the GitHub website.
+8. Submit a pull request through the GitHub website.
 
 Pull Request Guidelines
 -----------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,7 +89,7 @@ The following steps are the same for both *members* and *non-members*:
 
     git checkout -b name-of-your-bugfix-or-feature
 
-   Now you can make your changes locally. **Note: as a member, you _must_ do this step. If you
+   Now you can make your changes locally. **Note: as a member, you _must_ do step 5. If you
    make changes on master, you will _not_ be able to push them**.
 
 6. When you're done making changes, run all the checks, doc builder and spell checker

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,9 +10,9 @@ Bug reports/Feature Requests/Feedback/Questions
 It is incredibly helpful to us when users report bugs, unexpected behaviour, or request
 features. You can do the following:
 
-    * `Report a bug <https://github.com/21cmFAST/21cmFAST/issues/new?template=bug_report.md>`_
-    * `Request a Feature <https://github.com/21cmFAST/21cmFAST/issues/new?template=feature_request.md>`_
-    * `Ask a Question <https://github.com/21cmFAST/21cmFAST/issues/new?template=question.md>`_
+* `Report a bug <https://github.com/21cmFAST/21cmFAST/issues/new?template=bug_report.md>`_
+* `Request a Feature <https://github.com/21cmFAST/21cmFAST/issues/new?template=feature_request.md>`_
+* `Ask a Question <https://github.com/21cmFAST/21cmFAST/issues/new?template=question.md>`_
 
 When doing any of these, please try to be as succinct, but detailed, as possible, and use
 a "Minimum Working Example" whenever applicable.
@@ -24,8 +24,8 @@ Documentation improvements
 official ``21cmFAST`` docs, in docstrings, or even on the web in blog posts,
 articles, and such. If you do the latter, take the time to let us know about it!
 
-Development
-===========
+High-Level Steps for Development
+================================
 
 This is an abbreviated guide to getting started with development of ``21cmFAST``,
 focusing on the discrete high-level steps to take. See our

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,1 +1,2 @@
 .. include:: ../CONTRIBUTING.rst
+.. include:: notes_for_developers.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,6 @@ Contents
    tutorials
    reference/index
    contributing
-   notes_for_developers
    authors
    changelog
 

--- a/docs/notes_for_developers.rst
+++ b/docs/notes_for_developers.rst
@@ -1,16 +1,11 @@
-====================
-Notes For Developers
-====================
+Developer Documentation
+=======================
 
-If you are new to developing 21cmFAST, please read the :ref:`contributing:Contributing`
-section first, which outlines the general concepts for contributing to development.
+If you are new to developing ``21cmFAST``, please read the :ref:`contributing:Contributing`
+section *first*, which outlines the general concepts for contributing to development,
+and provides a step-by-step walkthrough for getting setup.
 This page lists some more detailed notes which may be helpful through the
 development process.
-
-Note that when developing, we recommend using an isolated python environment, and
-installing all requirements as follows::
-
-    $ pip install -r requirements_dev.txt
 
 Compiling for debugging
 -----------------------

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -116,3 +116,5 @@ dependencies:
   - h5py
   - jupyter
   - nb_conda
+  - pip:
+      - pre-commit


### PR DESCRIPTION
This PR makes the `CONTRIBUTING.rst` a bit better. 
Now it leads the new developer through the exact process required to get setup (and also serves as a good memory-jog for us others). It also points directly to the developer documentation for more details (those docs also link back the to the contributing). 

I figure it would be good to get @andreimesinger to have a quick read through, as someone who hasn't used the new setup very much, to see if it makes sense and suggest changes.

Fixes #65 