### PR TITLE
Config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Added
   transfer functions, but in case:  A_s=2.100e-9, n_s=0.9649, z_reio = 11.357)
 * New ``user_params`` option ``USE_RELATIVE_VELOCITIES``, which produces initial relative
   velocity cubes (option implemented, but not the actual computation yet).
+* Configuration management.
 
 Changed
 ~~~~~~~

--- a/docs/faqs/misc.rst
+++ b/docs/faqs/misc.rst
@@ -10,3 +10,33 @@ can be difficult. However, one has the option of using the standard library
 `faulthandler <https://docs.python.org/3/library/faulthandler.html>`_. Specifying
 ``-X faulthandler`` when invoking Python will cause a minimal traceback to be printed
 to ``stderr`` if a segfault occurs.
+
+Configuring 21cmFAST
+--------------------
+``21cmFAST`` has a configuration file located at ``~/.21cmfast/config.yml``. This file
+specifies some options to use in a rather global sense, especially to do with I/O.
+You can directly edit this file to change how ``21cmFAST`` behaves for you across
+sessions.
+For any particular function call, any of the options may be overwritten by supplying
+arguments to the function itself.
+To set the configuration for a particular session, you can also set the global `config`
+instance, for example::
+
+    >>> import py21cmfast as p21
+    >>> p21.config['regenerate'] = True
+    >>> p21.run_lightcone(...)
+
+All functions that use the `regenerate` keyword will now use the value you've set in the
+config. Sometimes, you may want to be a little more careful -- perhaps you want to change
+the configuration for a set of calls, but have it change back to the defaults after that.
+We provide a context manager to do this::
+
+    >>> with p21.config.use(regenerate=True):
+    >>>     p21.run_lightcone()
+    >>>     print(p21.config['regenerate'])  # prints "True"
+    >>> print(p21.config['regenerate'])  # prints "False"
+
+To make the current configuration permanent, simply use the ``write`` method::
+
+    >>> p21.config['direc'] = 'my_own_cache'
+    >>> p21.config.write()

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def _safe_copy_tree(src, dst, safe=None):
 
 
 # Copy the user data into the config directory.
-# We *don't* want to overwrite the confi file that is already there, because maybe the user
+# We *don't* want to overwrite the config file that is already there, because maybe the user
 # has changed the configuration, and that would destroy it!
 _safe_copy_tree(join(pkgdir, "user_data"), cfgdir, safe="config.yml")
 # ======================================================================================

--- a/src/py21cmfast/__init__.py
+++ b/src/py21cmfast/__init__.py
@@ -33,6 +33,6 @@ from .wrapper import spin_temperature
 configure_logging()
 
 try:
-    _mkdir(path.expanduser(config["boxdir"]))
+    _mkdir(path.expanduser(config["direc"]))
 except FileExistsError:
     pass

--- a/src/py21cmfast/_cfg.py
+++ b/src/py21cmfast/_cfg.py
@@ -1,8 +1,89 @@
 """Open and read the configuration file."""
+import contextlib
+import copy
+import warnings
 from os import path
 
 from . import yaml
 
-# Global Options
-with open(path.expanduser(path.join("~", ".21cmfast", "config.yml"))) as f:
-    config = yaml.load(f)
+
+class ConfigurationError(Exception):
+    """An error with the config file."""
+
+    pass
+
+
+class Config(dict):
+    """Simple over-ride of dict that adds a context manager."""
+
+    _defaults = {"direc": "~/21cmFAST-cache", "regenerate": False, "write": True}
+
+    _aliases = {"direc": ("boxdir",)}
+
+    def __init__(self, *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        # Ensure the keys that got read in are the right keys for the current version
+        do_write = False
+        for k, v in self._defaults.items():
+            if k not in self:
+                if k not in self._aliases:
+                    warnings.warn("Your configuration file is out of date. Updating...")
+                    do_write = True
+                    self[k] = v
+
+                else:
+                    for alias in self._aliases[k]:
+                        if alias in self:
+                            do_write = True
+                            warnings.warn(
+                                "Your configuration file has old key '{}' which has been re-named '{}'. Updating...".format(
+                                    alias, k
+                                )
+                            )
+                            self[k] = self[alias]
+                            del self[alias]
+                    if not do_write:
+                        raise ConfigurationError(
+                            "The configuration file has key '{}' which is not known to 21cmFAST.".format(
+                                alias
+                            )
+                        )
+
+        if do_write:
+            self.write()
+
+    @contextlib.contextmanager
+    def use(self, **kwargs):
+        """Context manager for using certain configuration options for a set time."""
+        backup = self.copy()
+        for k, v in kwargs.items():
+            self[k] = v
+        yield self
+        for k in kwargs:
+            self[k] = backup[k]
+
+    def write(self, fname=None):
+        """Write current configuration to file to make it permanent."""
+        fname = fname or self.file_name
+        with open(fname, "w") as fl:
+            yaml.dump(self._as_dict(), fl)
+
+    def _as_dict(self):
+        """The plain dict defining the instance."""
+        return {k: v for k, v in self.items()}
+
+    @classmethod
+    def load(cls, file_name):
+        """Create a Config object from a config file."""
+        cls.file_name = file_name
+        with open(file_name, "r") as fl:
+            config = yaml.load(fl)
+        return cls(config)
+
+
+config = Config.load(path.expanduser(path.join("~", ".21cmfast", "config.yml")))
+
+# Keep an original copy around
+default_config = copy.deepcopy(config)

--- a/src/py21cmfast/_utils.py
+++ b/src/py21cmfast/_utils.py
@@ -399,7 +399,7 @@ class OutputStruct(StructWrapper):
         return self._fname_skeleton.format(seed=self.random_seed)
 
     def _get_fname(self, direc=None):
-        direc = direc or path.expanduser(config["boxdir"])
+        direc = direc or path.expanduser(config["direc"])
         return path.join(direc, self.filename)
 
     def _find_file_without_seed(self, direc):
@@ -427,7 +427,7 @@ class OutputStruct(StructWrapper):
         # First, if appropriate, find a file without specifying seed.
         # Need to do this first, otherwise the seed will be chosen randomly upon
         # choosing a filename!
-        direc = direc or path.expanduser(config["boxdir"])
+        direc = direc or path.expanduser(config["direc"])
 
         if not self._random_seed:
             f = self._find_file_without_seed(direc)
@@ -513,7 +513,7 @@ class OutputStruct(StructWrapper):
             )
 
         try:
-            direc = direc or path.expanduser(config["boxdir"])
+            direc = direc or path.expanduser(config["direc"])
             fname = path.join(direc, fname) if fname else self._get_fname(direc)
             with h5py.File(fname, "w") as f:
                 # Save input parameters to the file

--- a/src/py21cmfast/_utils.py
+++ b/src/py21cmfast/_utils.py
@@ -399,7 +399,7 @@ class OutputStruct(StructWrapper):
         return self._fname_skeleton.format(seed=self.random_seed)
 
     def _get_fname(self, direc=None):
-        direc = direc or path.expanduser(config["direc"])
+        direc = path.expanduser(direc or config["direc"])
         return path.join(direc, self.filename)
 
     def _find_file_without_seed(self, direc):
@@ -427,7 +427,7 @@ class OutputStruct(StructWrapper):
         # First, if appropriate, find a file without specifying seed.
         # Need to do this first, otherwise the seed will be chosen randomly upon
         # choosing a filename!
-        direc = direc or path.expanduser(config["direc"])
+        direc = path.expanduser(direc or config["direc"])
 
         if not self._random_seed:
             f = self._find_file_without_seed(direc)
@@ -513,7 +513,7 @@ class OutputStruct(StructWrapper):
             )
 
         try:
-            direc = direc or path.expanduser(config["direc"])
+            direc = path.expanduser(direc or config["direc"])
             fname = path.join(direc, fname) if fname else self._get_fname(direc)
             with h5py.File(fname, "w") as f:
                 # Save input parameters to the file

--- a/src/py21cmfast/cache_tools.py
+++ b/src/py21cmfast/cache_tools.py
@@ -50,7 +50,7 @@ def readbox(*, direc=None, fname=None, hsh=None, kind=None, seed=None, load_data
     ValueError :
         If either ``fname`` is not supplied, or both ``kind`` and ``hsh`` are not supplied.
     """
-    direc = direc or path.expanduser(config["boxdir"])
+    direc = direc or path.expanduser(config["direc"])
 
     # We either need fname, or hsh and kind.
     if not fname and not (hsh and kind):
@@ -149,7 +149,7 @@ def list_datasets(*, direc=None, kind=None, hsh=None, seed=None):
     parts: tuple of strings
         The (kind, hsh, seed) of the data set.
     """
-    direc = direc or path.expanduser(config["boxdir"])
+    direc = direc or path.expanduser(config["direc"])
 
     kind = kind or "*"
     hsh = hsh or "*"
@@ -209,7 +209,7 @@ def clear_cache(**kwargs):
     kwargs :
         All options passed through to :func:`query_cache`.
     """
-    direc = kwargs.get("direc", path.expanduser(config["boxdir"]))
+    direc = kwargs.get("direc", path.expanduser(config["direc"]))
     number = 0
     for fname, cls in query_cache(show=False, **kwargs):
         if kwargs.get("show", True):

--- a/src/py21cmfast/cli.py
+++ b/src/py21cmfast/cli.py
@@ -666,7 +666,7 @@ def _query(direc=None, kind=None, md5=None, seed=None, clear=False):
             print()
 
         else:
-            direc = direc or path.expanduser(_cfg.config["boxdir"])
+            direc = direc or path.expanduser(_cfg.config["direc"])
             remove(path.join(direc, file))
 
 

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -321,7 +321,7 @@ class UserParams(StructWithDefaults):
         2: Watson (Watson FOF)
         3: Watson-z (Watson FOF-z)
     USE_RELATIVE_VELOCITIES: int, optional
-        Flag to decide whether to use relative velocities, default True.
+        Flag to decide whether to use relative velocities.
         If True, POWER_SPECTRUM is automatically set to 5. Default False.
     POWER_SPECTRUM: int or str, optional
         Determines which power spectrum to use, default EH (unless `USE_RELATIVE_VELOCITIES`

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -331,7 +331,7 @@ class UserParams(StructWithDefaults):
         2: EFSTATHIOU
         3: PEEBLES
         4: WHITE
-        5: CLASS (single output)
+        5: CLASS (single cosmology)
     """
 
     _ffi = ffi

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -314,7 +314,7 @@ def _call_c_func(fnc, obj, direc, *args, write=True):
 
 def _get_config_options(direc, regenerate, write):
     return (
-        config["direc"] if direc is None else direc,
+        os.path.expanduser(config["direc"] if direc is None else direc),
         config["regenerate"] if regenerate is None else regenerate,
         config["write"] if write is None else write,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+from os import path
+
+import pytest
+
+import yaml
+
+import py21cmfast as p21
+from py21cmfast._cfg import Config
+
+
+def test_config_context(tmpdirec):
+    direc = tmpdirec.mkdir("config_test_dir")
+    with p21.config.use(direc=direc, write=True):
+        init = p21.initial_conditions(user_params={"HII_DIM": 30})
+
+    assert path.exists(path.join(direc.strpath, init.filename))
+    assert "config_test_dir" not in p21.config["direc"]
+
+
+def test_config_write(tmpdirec):
+    direc = tmpdirec.mkdir("config_write_dir")
+
+    with p21.config.use(direc=direc):
+        p21.config.write(path.join(direc, "config.yml"))
+
+    with open(path.join(direc, "config.yml")) as fl:
+        new_config = yaml.load(fl, Loader=yaml.FullLoader)
+
+    # Test adding new kind of string alias
+    new_config["boxdir"] = new_config["direc"]
+    del new_config["direc"]
+
+    with open(path.join(direc, "config.yml"), "w") as fl:
+        yaml.dump(new_config, fl)
+
+    with pytest.warns(UserWarning):
+        new_config = Config.load(path.join(direc, "config.yml"))
+
+    assert "boxdir" not in new_config
+    assert "direc" in new_config
+
+    with open(path.join(direc, "config.yml")) as fl:
+        new_config = yaml.load(fl, Loader=yaml.FullLoader)
+
+    assert "boxdir" not in new_config
+    assert "direc" in new_config

--- a/user_data/config.yml
+++ b/user_data/config.yml
@@ -1,1 +1,3 @@
-boxdir: ~/21CMMC_Boxes
+direc: ~/21cmFAST-cache
+regenerate: false
+write: true


### PR DESCRIPTION
A lot of changes to implement configuration management. The way it works is documented in the `misc.rst` file, but basically, you can set global changes to the config (stuff like where the cache is), or use a context manager, i.e. do stuff like 

```python
with p21.config.use(direc="my_new_cache"):
    p21.run_coeval(...)
```

This will set the option back to the default after exiting from the context. You can also write the config back to file to make it permanent.

Close #10 

This is branched off the `doc-updates` branch, so let's get that pulled in before we try to pull this in.