### PR TITLE
Fix issue with first box and add test

### DIFF
--- a/src/py21cmfast/_utils.py
+++ b/src/py21cmfast/_utils.py
@@ -290,7 +290,7 @@ class OutputStruct(StructWrapper):
 
     _TYPEMAP = {"float32": "float *", "float64": "double *", "int32": "int *"}
 
-    def __init__(self, *, random_seed=None, init=False, **kwargs):
+    def __init__(self, *, random_seed=None, init=False, dummy=False, **kwargs):
         super().__init__()
 
         self.filled = False
@@ -312,6 +312,8 @@ class OutputStruct(StructWrapper):
                 "%s received the following unexpected arguments: %s"
                 % (self.__class__.__name__, list(kwargs.keys()))
             )
+
+        self.dummy = dummy
 
         if init:
             self._init_cstruct()
@@ -369,7 +371,7 @@ class OutputStruct(StructWrapper):
 
     def __call__(self):
         """Initialize/allocate a fresh C struct in memory and return it."""
-        if not self.arrays_initialized:
+        if not self.arrays_initialized and not self.dummy:
             self._init_cstruct()
 
         return self._cstruct

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -114,7 +114,7 @@ int ComputeIonizedBox(float redshift, float prev_redshift, struct UserParams *us
                        struct PerturbedField *perturbed_field, struct IonizedBox *previous_ionize_box,
                        struct TsBox *spin_temp, struct IonizedBox *box);
 
-int ComputeBrightnessTemp(float redshift, int saturated_limit, struct UserParams *user_params, struct CosmoParams *cosmo_params,
+int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params,
                            struct AstroParams *astro_params, struct FlagOptions *flag_options,
                            struct TsBox *spin_temp, struct IonizedBox *ionized_box,
                            struct PerturbedField *perturb_field, struct BrightnessTemp *box);

--- a/src/py21cmfast/src/BrightnessTemperatureBox.c
+++ b/src/py21cmfast/src/BrightnessTemperatureBox.c
@@ -1,7 +1,7 @@
 
 // Re-write of find_HII_bubbles.c for being accessible within the MCMC
 
-int ComputeBrightnessTemp(float redshift, int saturated_limit, struct UserParams *user_params, struct CosmoParams *cosmo_params,
+int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params,
                            struct AstroParams *astro_params, struct FlagOptions *flag_options,
                            struct TsBox *spin_temp, struct IonizedBox *ionized_box,
                            struct PerturbedField *perturb_field, struct BrightnessTemp *box) {

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -1400,7 +1400,7 @@ def brightness_temperature(
         raise ValueError("both ionized_box and perturbed_field must be specified.")
 
     if spin_temp is None:
-        if ionized_box.flag_options["USE_TS_FLUCT"]:
+        if ionized_box.flag_options.USE_TS_FLUCT:
             raise ValueError(
                 "You have USE_TS_FLUCT=True, but have not provided a spin_temp!"
             )

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -1232,7 +1232,10 @@ def spin_temperature(
             redshift = (
                 previous_spin_temp.redshift + 1
             ) / global_params.ZPRIME_STEP_FACTOR - 1
-
+        else:
+            raise ValueError(
+                "Either the redshift, perturbed_field or previous_spin_temp must be given."
+            )
     user_params = UserParams(user_params)
     cosmo_params = CosmoParams(cosmo_params)
     flag_options = FlagOptions(flag_options)
@@ -1246,12 +1249,6 @@ def spin_temperature(
         global_params.Z_HEAT_MAX = z_heat_max
     if z_step_factor is not None:
         global_params.ZPRIME_STEP_FACTOR = z_step_factor
-
-    # If there is still no redshift, raise error.
-    if redshift is None:
-        raise ValueError(
-            "Either the redshift, perturbed_field or previous_spin_temp must be given."
-        )
 
     box = TsBox(
         first_box=((1 + redshift) * global_params.ZPRIME_STEP_FACTOR - 1)
@@ -1319,7 +1316,13 @@ def spin_temperature(
     # Create appropriate previous_spin_temp
     if not isinstance(previous_spin_temp, TsBox):
         if prev_z > global_params.Z_HEAT_MAX or prev_z is None:
-            previous_spin_temp = TsBox(redshift=0)
+            previous_spin_temp = TsBox(
+                redshift=global_params.Z_HEAT_MAX,
+                user_params=init_boxes.user_params,
+                cosmo_params=init_boxes.cosmo_params,
+                astro_params=astro_params,
+                flag_options=flag_options,
+            )
         else:
             previous_spin_temp = spin_temperature(
                 init_boxes=init_boxes,
@@ -1344,10 +1347,7 @@ def spin_temperature(
             direc=direc,
         )
 
-    if previous_spin_temp is None:
-        previous_spin_temp = TsBox(redshift=0)
-
-        # Run the C Code
+    # Run the C Code
     return _call_c_func(
         lib.ComputeTsBox,
         box,
@@ -1400,10 +1400,13 @@ def brightness_temperature(
         raise ValueError("both ionized_box and perturbed_field must be specified.")
 
     if spin_temp is None:
-        saturated_limit = True
-        spin_temp = TsBox(redshift=0)
-    else:
-        saturated_limit = False
+        if ionized_box.flag_options["USE_TS_FLUCT"]:
+            raise ValueError(
+                "You have USE_TS_FLUCT=True, but have not provided a spin_temp!"
+            )
+
+        # Make an unused dummy box.
+        spin_temp = TsBox(redshift=0, dummy=True)
 
     box = BrightnessTemp(
         user_params=ionized_box.user_params,
@@ -1419,7 +1422,6 @@ def brightness_temperature(
         box,
         direc,
         ionized_box.redshift,
-        saturated_limit,
         ionized_box.user_params,
         ionized_box.cosmo_params,
         ionized_box.astro_params,

--- a/tests/test_spin_temp.py
+++ b/tests/test_spin_temp.py
@@ -1,0 +1,26 @@
+import py21cmfast as p21c
+
+
+def test_first_box():
+    """Tests whether the first_box idea works for spin_temp.
+    This test was breaking before we set the z_heat_max box to actually get
+    the correct dimensions (before it was treated as a dummy).
+    """
+    initial_conditions = p21c.initial_conditions(
+        user_params=p21c.UserParams(HII_DIM=100, BOX_LEN=100, DIM=200),
+        random_seed=1,
+        write=False,
+    )
+
+    perturbed_field = p21c.perturb_field(
+        redshift=29.0, init_boxes=initial_conditions, write=False
+    )
+
+    spin_temp = p21c.spin_temperature(
+        perturbed_field=perturbed_field,
+        z_step_factor=1.05,
+        z_heat_max=30.0,
+        write=False,
+    )
+
+    assert spin_temp.redshift == 29.0


### PR DESCRIPTION
Fixes #59 .

The issue was that the passed `TsBox` at `Z_HEAT_MAX` was not expected to be used -- therefore it was being set at a very minimal level, and its initialization used default `user_params`. If the dimensions were smaller than those actually being used, it would error due to invalid write. 

This is fixed here, and I added a test. I also added the ability to have proper "dummy" boxes that don't get initialized at all if they're not used, to conserve memory. 

This will be merged into `doc-updates` (it was branched off that).  