### PR TITLE
Fix failing to do photon_cons when reading init from cache

### DIFF
--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -392,15 +392,10 @@ double sigma_z0(double M){
       kend = 350.0/R;
     }
 
-
-
-
     lower_limit = kstart;//log(kstart);
     upper_limit = kend;//log(kend);
 
     F.function = &dsigma_dk;
-    //  gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS61, w, &result, &error);
-    //    gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS41, w, &result, &error);
     gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
     gsl_integration_workspace_free (w);
     return sigma_norm * sqrt(result);
@@ -2159,10 +2154,9 @@ int initialise_SFRD_Conditional_table(int Nfilter, float min_density[], float ma
 int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cosmo_params,
                          struct AstroParams *astro_params, struct FlagOptions *flag_options)
 {
-
     Broadcast_struct_global_PS(user_params,cosmo_params);
     Broadcast_struct_global_UF(user_params,cosmo_params);
-
+    init_ps();
     //     To solve differentail equation, uses Euler's method.
     //     NOTE:
     //     (1) With the fiducial parameter set,
@@ -2190,7 +2184,6 @@ int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cos
         M_MIN = astro_params->M_TURN/50.;
         Mlim_Fstar = Mass_limit_bisection(M_MIN, 1e16, astro_params->ALPHA_STAR, astro_params->F_STAR10);
         Mlim_Fesc = Mass_limit_bisection(M_MIN, 1e16, astro_params->ALPHA_ESC, astro_params->F_ESC10);
-
         initialiseSigmaMInterpTable(M_MIN,1e20);
     }
     else {
@@ -2243,7 +2236,6 @@ int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cos
                                                 Mlim_Fstar, Mlim_Fesc);
             }
             else {
-
                 //set the minimum source mass
                 if (astro_params->ION_Tvir_MIN < 9.99999e3) { // neutral IGM
                     M_MIN_z0 = TtoM(z0, astro_params->ION_Tvir_MIN, 1.22);

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -2397,6 +2397,7 @@ def calibrate_photon_cons(
         neutral_fraction_photon_cons = []
 
         # Initialise the analytic expression for the reionisation history
+        logger.debug("About to start photon conservation correction")
         _init_photon_conservation_correction(
             user_params=user_params,
             cosmo_params=cosmo_params,
@@ -2406,6 +2407,7 @@ def calibrate_photon_cons(
 
         # Determine the starting redshift to start scrolling through to create the
         # calibration reionisation history
+        logger.debug("Calculating photon conservation zstart")
         z = _calc_zstart_photon_cons()
 
         while z > 5.0:
@@ -2451,6 +2453,7 @@ def calibrate_photon_cons(
         neutral_fraction_photon_cons = np.array(neutral_fraction_photon_cons[::-1])
 
         # Construct the spline for the calibration curve
+        logger.debug("Calibrating photon conservation correction")
         _calibrate_photon_conservation_correction(
             redshifts_estimate=z_for_photon_cons,
             nf_estimate=neutral_fraction_photon_cons,


### PR DESCRIPTION
Fixes #109 

Simple fix that the `init_ps` function wasn't being called when reading from cache, since initial conditions weren't being run.

It was hardish to locate, but will get easier once #64 is merged. 

It does bring up the point that there are some of these high-level global initialisation routines which we have to think more carefully about. My fix here was to run `init_ps` for every time we initialise photon cons, but that re-runs things that sometimes don't need to be. We've also run in to this error a few times when code's added, because it's very easy to forget that a function is dependent on `init_ps` having already been run, and assume that it has been.

@BradGreig any ideas?

Let's pull this fix in ASAP.