### PR TITLE
Readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,12 +12,13 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
+conda:
+  environment: docs/environment.yaml
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.7
   system_packages: true
   install:
-    - requirements: requirements_dev.txt
-    - requirements: docs/requirements.txt
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,10 +15,9 @@ formats: all
 conda:
   environment: docs/environment.yaml
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optionally set the version of Python and requirements required to build the docs
+# We don't install 21cmFAST -- we just load it into the path in conf.py, and mock
+# out the C stuff.
 python:
   version: 3.7
   system_packages: true
-  install:
-    - method: pip
-      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,11 +13,11 @@ sphinx:
 formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
-# We basically "mock" any imports that are not absolutely necessary, and so don't
-# need to install much (not even hera_sim!)
 python:
-  version: 3.6
+  version: 3.7
   system_packages: true
   install:
     - requirements: requirements_dev.txt
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/build_cffi.py
+++ b/build_cffi.py
@@ -1,6 +1,5 @@
 """Build the C code with CFFI."""
 import os
-from pathlib import Path
 
 from cffi import FFI
 

--- a/build_cffi.py
+++ b/build_cffi.py
@@ -51,23 +51,6 @@ for k, v in os.environ.items():
     elif "lib" in k.lower():
         library_dirs += [v]
 
-# Try to use conda environment
-use_conda = int(os.environ.get("USE_CONDA", -1))
-if use_conda != 0:
-    python = Path(os.popen("which python").read())
-    inc = python.parent.parent / "include"
-    lib = python.parent.parent / "lib"
-    if inc.exists():
-        if use_conda > 0:
-            include_dirs.insert(0, str(inc))
-        else:
-            include_dirs.append(str(inc))
-    if lib.exists():
-        if use_conda > 0:
-            library_dirs.insert(0, str(lib))
-        else:
-            library_dirs.append(str(lib))
-
 
 # =================================================================
 

--- a/build_cffi.py
+++ b/build_cffi.py
@@ -1,5 +1,6 @@
 """Build the C code with CFFI."""
 import os
+from pathlib import Path
 
 from cffi import FFI
 
@@ -49,6 +50,24 @@ for k, v in os.environ.items():
         include_dirs += [v]
     elif "lib" in k.lower():
         library_dirs += [v]
+
+# Try to use conda environment
+use_conda = int(os.environ.get("USE_CONDA", -1))
+if use_conda != 0:
+    python = Path(os.popen("which python").read())
+    inc = python.parent.parent / "include"
+    lib = python.parent.parent / "lib"
+    if inc.exists():
+        if use_conda > 0:
+            include_dirs.insert(0, str(inc))
+        else:
+            include_dirs.append(str(inc))
+    if lib.exists():
+        if use_conda > 0:
+            library_dirs.insert(0, str(lib))
+        else:
+            library_dirs.append(str(lib))
+
 
 # =================================================================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,9 +5,9 @@ from __future__ import unicode_literals
 import os
 import sys
 from unittest.mock import MagicMock
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath("../"))
-
+sys.path.insert(0, str(Path(__file__).absolute().parent.parent / 'src'))
 
 class Mock(MagicMock):
     """Make a Mock so that a package doesn't have to actually exist."""
@@ -18,8 +18,11 @@ class Mock(MagicMock):
         return MagicMock()
 
 
-MOCK_MODULES = ["c_21cmfast"]
+MOCK_MODULES = ['py21cmfast.c_21cmfast', 'matplotlib', 'matplotlib.pyplot', 'click', 'tqdm', 'pyyaml', 'scipy', 'scipy.interpolate', 'h5py', 'cached_property']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
+import py21cmfast
+#import py21cmfast.cache_tools
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -50,10 +53,10 @@ numpydoc_show_class_members = False
 source_suffix = ".rst"
 master_doc = "index"
 project = "21cmFAST"
-year = "2019"
+year = "2020"
 author = "The 21cmFAST collaboration"
 copyright = "{0}, {1}".format(year, author)
-version = release = "0.1.0"
+version = release = py21cmfast.__version__
 templates_path = ["templates"]
 
 pygments_style = "trac"

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -1,0 +1,22 @@
+name: 21cmfast
+
+channels:
+  - defaults
+  - conda-forge
+
+dependencies:
+  - ipython
+  - nbsphinx
+  - numpydoc
+  - sphinx-rtd-theme
+  - sphinx>=1.3
+  - click
+  - tqdm
+  - numpy
+  - pyyaml
+  - cffi>=1.0
+  - scipy
+  - astropy>=2.0
+  - h5py>=2.8.0
+  - pip:
+    - cached_property

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -1,14 +1,12 @@
-name: 21cmfast
-
 channels:
   - defaults
   - conda-forge
 
 dependencies:
+  - pip
   - ipython
   - nbsphinx
   - numpydoc
-  - sphinx-rtd-theme
   - sphinx>=1.3
   - click
   - tqdm
@@ -20,3 +18,4 @@ dependencies:
   - h5py>=2.8.0
   - pip:
     - cached_property
+    - sphinx-rtd-theme

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -8,16 +8,7 @@ dependencies:
   - nbsphinx
   - numpydoc
   - sphinx>=1.3
-  - click
-  - tqdm
-  - numpy
+  - astropy  # need this here, because we base classes off it (and docs need that).
   - pyyaml
-  - cffi>=1.0
-  - scipy
-  - astropy>=2.0
-  - h5py>=2.8.0
-  - fftw
-  - gsl
   - pip:
-    - cached_property
     - sphinx-rtd-theme

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -16,6 +16,8 @@ dependencies:
   - scipy
   - astropy>=2.0
   - h5py>=2.8.0
+  - fftw
+  - gsl
   - pip:
     - cached_property
     - sphinx-rtd-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-ipython
-nbsphinx
-numpydoc
-sphinx-rtd-theme
-sphinx>=1.3

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -8,6 +8,7 @@ The following introductory tutorials will help you get started with ``21cmFAST``
 
    tutorials/coeval_cubes
    tutorials/lightcones
+   tutorials/mini-halos
 
 If you've covered the tutorials and still have questions about "how to do stuff" in
 ``21cmFAST``, consult the FAQs:

--- a/src/py21cmfast/__init__.py
+++ b/src/py21cmfast/__init__.py
@@ -10,7 +10,6 @@ from . import inputs
 from . import outputs
 from . import plotting
 from . import wrapper
-
 from ._cfg import config
 from ._logging import configure_logging
 from .cache_tools import query_cache

--- a/src/py21cmfast/__init__.py
+++ b/src/py21cmfast/__init__.py
@@ -6,6 +6,7 @@ from os import mkdir as _mkdir
 from os import path
 
 from . import cache_tools
+from . import plotting
 from ._cfg import config
 from ._logging import configure_logging
 from .cache_tools import query_cache

--- a/src/py21cmfast/_cfg.py
+++ b/src/py21cmfast/_cfg.py
@@ -44,12 +44,19 @@ class Config(dict):
                             )
                             self[k] = self[alias]
                             del self[alias]
-                    if not do_write:
-                        raise ConfigurationError(
-                            "The configuration file has key '{}' which is not known to 21cmFAST.".format(
-                                alias
-                            )
+                            break
+                    else:
+                        warnings.warn(
+                            "Your configuration file is out of date. Updating..."
                         )
+                        do_write = True
+                        self[k] = v
+
+        for k, v in self.items():
+            if k not in self._defaults:
+                raise ConfigurationError(
+                    f"The configuration file has key '{alias}' which is not known to 21cmFAST."
+                )
 
         if do_write and write:
             self.write()

--- a/src/py21cmfast/_cfg.py
+++ b/src/py21cmfast/_cfg.py
@@ -20,7 +20,7 @@ class Config(dict):
 
     _aliases = {"direc": ("boxdir",)}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, write=True, **kwargs):
 
         super().__init__(*args, **kwargs)
 
@@ -51,7 +51,7 @@ class Config(dict):
                             )
                         )
 
-        if do_write:
+        if do_write and write:
             self.write()
 
     @contextlib.contextmanager
@@ -78,9 +78,12 @@ class Config(dict):
     def load(cls, file_name):
         """Create a Config object from a config file."""
         cls.file_name = file_name
-        with open(file_name, "r") as fl:
-            config = yaml.load(fl)
-        return cls(config)
+        if path.exists(file_name):
+            with open(file_name, "r") as fl:
+                config = yaml.load(fl)
+                return cls(config)
+        else:
+            return cls(write=False)
 
 
 config = Config.load(path.expanduser(path.join("~", ".21cmfast", "config.yml")))


### PR DESCRIPTION
Fixes issues with compilation of the docs on readthedocs. See compiled docs here: https://21cmfast.readthedocs.io/en/readthedocs.
Fixes #136 

Also fixes a small bug in the `Config` class in which if `21cmFAST` was imported without installing it (i.e. this is what the readthedocs build does -- adds the directory to the PYTHONPATH to import it), it wouldn't find the config file. Now it does not _need_ that file -- it is based on defaults in the class itself if the file is not found.