### PR TITLE
Add note about gcc version

### DIFF
--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -12,7 +12,8 @@ The C libraries required are:
 * `gsl`
 * `fftw` (compiled with floating-point enabled, and `--enable-shared`)
 * `openmp`
-* A C-compiler with compatibility with the `-fopenmp` flag.
+* A C-compiler with compatibility with the `-fopenmp` flag. **Note:** it seems that on
+  OSX, if using `gcc`, you will need `v4.9.4+`.
 
 As it turns out, though these are fairly common libraries, getting them installed in a
 way that `21cmFAST` understands on various operating systems can be slightly non-trivial.

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -2000,7 +2000,7 @@ def run_coeval(
         if singleton:
             coevals = coevals[0]
 
-        logger.debug("Returning from Coeval".format(os.getpid()))
+        logger.debug("Returning from Coeval")
 
         return coevals
 


### PR DESCRIPTION
Just adds a note to the INSTALLATION.rst about minimum gcc version. We can't force this dependency in `setup.py` at all, so I think this is the extent of what we can do.