### PR TITLE
Expand photoncons range

### DIFF
--- a/src/py21cmfast/src/Globals.h
+++ b/src/py21cmfast/src/Globals.h
@@ -31,6 +31,7 @@ struct GlobalParams{
     float PhotonConsStart;
     float PhotonConsEnd;
     float PhotonConsAsymptoteTo;
+    float PhotonConsEndCalibz;
 
     int HEAT_FILTER;
     double CLUMPING_FACTOR;
@@ -98,6 +99,7 @@ extern struct GlobalParams global_params = {
     .PhotonConsStart = 0.995,
     .PhotonConsEnd = 0.3,
     .PhotonConsAsymptoteTo = 0.01,
+    .PhotonConsEndCalibz = 5.0,
 
     .HEAT_FILTER = 0,
     .CLUMPING_FACTOR = 2.,

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -154,6 +154,10 @@ LOG_SUPER_DEBUG("defined parameters");
         adjust_redshifts_for_photoncons(astro_params,flag_options,&redshift,&stored_redshift,&absolute_delta_z);
 LOG_DEBUG("PhotonCons data:");
 LOG_DEBUG("original redshift=%f, updated redshift=%f delta-z = %f", stored_redshift, redshift, absolute_delta_z);
+        if(isfinite(redshift)==0 || isfinite(absolute_delta_z)==0) {
+            LOG_ERROR("Updated photon non-conservation redshift is either infinite or NaN!");
+            Throw(ParameterError);
+        }
     }
 
     Splined_Fcoll = 0.;
@@ -513,14 +517,14 @@ LOG_SUPER_DEBUG("sigma table has been initialised");
     }
 
     if(isfinite(box->mean_f_coll)==0) {
-        LOG_ERROR("Mean collapse fraction is either finite or NaN!");
+        LOG_ERROR("Mean collapse fraction is either infinite or NaN!");
         Throw(ParameterError);
     }
 LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll: %e", box->mean_f_coll);
 
     if (flag_options->USE_MINI_HALOS){
         if(isfinite(box->mean_f_coll_MINI)==0) {
-            LOG_ERROR("Mean collapse fraction of MINI is either finite or NaN!");
+            LOG_ERROR("Mean collapse fraction of MINI is either infinite or NaN!");
             Throw(ParameterError);
         }
 LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll_MINI: %e", box->mean_f_coll_MINI);
@@ -1371,7 +1375,7 @@ LOG_DEBUG("prev_min_density=%f, prev_max_density=%f, prev_overdense_small_min=%f
                                 //    box->Fcoll[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)] = previous_ionize_box->Fcoll[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)];
                                 f_coll += box->Fcoll[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)];
                                 if(isfinite(f_coll)==0) {
-                                    LOG_ERROR("f_coll is either finite or NaN!(%d,%d,%d)%g,%g,%g,%g,%g,%g,%g,%g,%g",\
+                                    LOG_ERROR("f_coll is either infinite or NaN!(%d,%d,%d)%g,%g,%g,%g,%g,%g,%g,%g,%g",\
                                             x,y,z,curr_dens,prev_dens,previous_ionize_box->Fcoll[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)],\
                                             Splined_Fcoll, prev_Splined_Fcoll, curr_dens, prev_dens, \
                                             log10_Mturnover, *((float *)log10_Mturnover_filtered + HII_R_FFT_INDEX(x,y,z)));
@@ -1391,7 +1395,7 @@ LOG_DEBUG("prev_min_density=%f, prev_max_density=%f, prev_overdense_small_min=%f
                                 //    box->Fcoll_MINI[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)] = previous_ionize_box->Fcoll_MINI[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)];
                                 f_coll_MINI += box->Fcoll_MINI[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)];
                                 if(isfinite(f_coll_MINI)==0) {
-                                    LOG_ERROR("f_coll_MINI is either finite or NaN!(%d,%d,%d)%g,%g,%g,%g,%g,%g,%g",\
+                                    LOG_ERROR("f_coll_MINI is either infinite or NaN!(%d,%d,%d)%g,%g,%g,%g,%g,%g,%g",\
                                               x,y,z,curr_dens, prev_dens, previous_ionize_box->Fcoll_MINI[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)],\
                                               Splined_Fcoll_MINI, prev_Splined_Fcoll_MINI, log10_Mturnover_MINI,\
                                               *((float *)log10_Mturnover_MINI_filtered + HII_R_FFT_INDEX(x,y,z)));
@@ -1433,7 +1437,7 @@ LOG_DEBUG("prev_min_density=%f, prev_max_density=%f, prev_overdense_small_min=%f
             f_coll /= (double) HII_TOT_NUM_PIXELS;
 
             if(isfinite(f_coll_MINI)==0) {
-                LOG_ERROR("f_coll_MINI is either finite or NaN!");
+                LOG_ERROR("f_coll_MINI is either infinite or NaN!");
                 Throw(ParameterError);
             }
 

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -3026,7 +3026,7 @@ int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cos
     //     (2) With the fiducial parameter set,
     //     the difference for the redshift where the reionization end (Q = 1) is ~0.2 % compared with accurate calculation.
     float ION_EFF_FACTOR,M_MIN,M_MIN_z0,M_MIN_z1,Mlim_Fstar, Mlim_Fesc;
-    double a_start = 0.03, a_end = 1./(1. + 5.0); // Scale factors of 0.03 and 0.17 correspond to redshifts of ~32 and ~5.0, respectively.
+    double a_start = 0.03, a_end = 1./(1. + global_params.PhotonConsEndCalibz); // Scale factors of 0.03 and 0.17 correspond to redshifts of ~32 and ~5.0, respectively.
     double C_HII = 3., T_0 = 2e4;
     double reduce_ratio = 1.003;
     double Q0,Q1,Nion0,Nion1,Trec,da,a,z0,z1,zi,dadt,ans,delta_a,zi_prev,Q1_prev;

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -3555,6 +3555,15 @@ float adjust_redshifts_for_photoncons(
 
     LOG_DEBUG("Adjusting redshifts for photon cons.");
 
+    if(*redshift < global_params.PhotonConsEndCalibz) {
+        LOG_ERROR(
+            "You have passed a redshift (z = %f) that is lower than the enpoint of the photon non-conservation correction "\
+            "(global_params.PhotonConsEndCalibz = %f). If this behaviour is desired then set global_params.PhotonConsEndCalibz "\
+            "to a value lower than z = %f.",*redshift,global_params.PhotonConsEndCalibz,*redshift
+                  );
+        Throw(ParameterError);
+    }
+
     // Determine the neutral fraction (filling factor) of the analytic calibration expression given the current sampled redshift
     Q_at_z(*redshift, &(temp));
     required_NF = 1.0 - (float)temp;

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -1858,18 +1858,6 @@ def run_coeval(
             else:
                 redshift = [p.redshift for p in perturb]
 
-        if flag_options.PHOTON_CONS:
-            calibrate_photon_cons(
-                user_params,
-                cosmo_params,
-                astro_params,
-                flag_options,
-                init_box,
-                regenerate,
-                write,
-                direc,
-            )
-
         if not hasattr(redshift, "__len__"):
             singleton = True
             redshift = [redshift]
@@ -1901,6 +1889,35 @@ def run_coeval(
         # don't double-up with scrolling ones.
         redshifts += redshift
         redshifts = sorted(set(redshifts), reverse=True)
+
+        if (
+            flag_options.PHOTON_CONS
+            and np.amin(redshifts) < global_params.PhotonConsEndCalibz
+        ):
+            raise ValueError(
+                """
+                The final (lowest) redshift (z = %g) is lower than the endpoint of the photon
+                non-conservation correction (global_params.PhotonConsEndCalibz = %g). If this behaviour
+                is desired then set global_params.PhotonConsEndCalibz to a value lower than z = %g.
+                """
+                % (
+                    np.amin(redshifts),
+                    global_params.PhotonConsEndCalibz,
+                    np.amin(redshifts),
+                )
+            )
+
+        if flag_options.PHOTON_CONS:
+            calibrate_photon_cons(
+                user_params,
+                cosmo_params,
+                astro_params,
+                flag_options,
+                init_box,
+                regenerate,
+                write,
+                direc,
+            )
 
         ib_tracker = [0] * len(redshift)
         bt = [0] * len(redshift)
@@ -2136,6 +2153,40 @@ def run_lightcone(
                 "TsBox quantity found in lightcone_quantities or global_quantities, but not running spin_temp!"
             )
 
+        redshift = configure_redshift(redshift, perturb)
+
+        max_redshift = (
+            global_params.Z_HEAT_MAX
+            if (
+                flag_options.INHOMO_RECO
+                or flag_options.USE_TS_FLUCT
+                or max_redshift is None
+            )
+            else max_redshift
+        )
+
+        # Get the redshift through which we scroll and evaluate the ionization field.
+        scrollz = _logscroll_redshifts(
+            redshift, global_params.ZPRIME_STEP_FACTOR, max_redshift
+        )
+
+        if (
+            flag_options.PHOTON_CONS
+            and np.amin(scrollz) < global_params.PhotonConsEndCalibz
+        ):
+            raise ValueError(
+                """
+                The final (lowest) redshift (z = %g) is lower than the endpoint of the photon non-conservation
+                correction (global_params.PhotonConsEndCalibz = %g). If this behaviour is desired then set
+                global_params.PhotonConsEndCalibz to a value lower than z = %g.
+                """
+                % (
+                    np.amin(scrollz),
+                    global_params.PhotonConsEndCalibz,
+                    np.amin(scrollz),
+                )
+            )
+
         if init_box is None:  # no need to get cosmo, user params out of it.
             init_box = initial_conditions(
                 user_params=user_params,
@@ -2145,8 +2196,6 @@ def run_lightcone(
                 direc=direc,
                 random_seed=random_seed,
             )
-
-        redshift = configure_redshift(redshift, perturb)
 
         if perturb is None:
             # The perturb field that we get here is at the *final* redshift,
@@ -2159,16 +2208,6 @@ def run_lightcone(
                 write=write,
             )
 
-        max_redshift = (
-            global_params.Z_HEAT_MAX
-            if (
-                flag_options.INHOMO_RECO
-                or flag_options.USE_TS_FLUCT
-                or max_redshift is None
-            )
-            else max_redshift
-        )
-
         if flag_options.PHOTON_CONS:
             calibrate_photon_cons(
                 user_params,
@@ -2180,11 +2219,6 @@ def run_lightcone(
                 write,
                 direc,
             )
-
-        # Get the redshift through which we scroll and evaluate the ionization field.
-        scrollz = _logscroll_redshifts(
-            redshift, global_params.ZPRIME_STEP_FACTOR, max_redshift
-        )
 
         d_at_redshift, lc_distances, n_lightcone = _setup_lightcone(
             cosmo_params,

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -2506,7 +2506,7 @@ def calibrate_photon_cons(
         logger.info("Calculating photon conservation zstart")
         z = _calc_zstart_photon_cons()
 
-        while z > 5.0:
+        while z > global_params.PhotonConsEndCalibz:
 
             # Determine the ionisation box with recombinations, spin temperature etc.
             # turned off.

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -1895,16 +1895,13 @@ def run_coeval(
             and np.amin(redshifts) < global_params.PhotonConsEndCalibz
         ):
             raise ValueError(
+                f"""
+                You have passed a redshift (z = {np.amin(redshifts)}) that is lower than the endpoint
+                of the photon non-conservation correction
+                (global_params.PhotonConsEndCalibz = {global_params.PhotonConsEndCalibz}).
+                If this behaviour is desired then set global_params.PhotonConsEndCalibz to a value lower than
+                z = {np.amin(redshifts)}.
                 """
-                The final (lowest) redshift (z = %g) is lower than the endpoint of the photon
-                non-conservation correction (global_params.PhotonConsEndCalibz = %g). If this behaviour
-                is desired then set global_params.PhotonConsEndCalibz to a value lower than z = %g.
-                """
-                % (
-                    np.amin(redshifts),
-                    global_params.PhotonConsEndCalibz,
-                    np.amin(redshifts),
-                )
             )
 
         if flag_options.PHOTON_CONS:
@@ -2175,16 +2172,13 @@ def run_lightcone(
             and np.amin(scrollz) < global_params.PhotonConsEndCalibz
         ):
             raise ValueError(
+                f"""
+                You have passed a redshift (z = {np.amin(scrollz)}) that is lower than the endpoint
+                of the photon non-conservation correction
+                (global_params.PhotonConsEndCalibz = {global_params.PhotonConsEndCalibz}).
+                If this behaviour is desired then set global_params.PhotonConsEndCalibz to a value lower than
+                z = {np.amin(scrollz)}.
                 """
-                The final (lowest) redshift (z = %g) is lower than the endpoint of the photon non-conservation
-                correction (global_params.PhotonConsEndCalibz = %g). If this behaviour is desired then set
-                global_params.PhotonConsEndCalibz to a value lower than z = %g.
-                """
-                % (
-                    np.amin(scrollz),
-                    global_params.PhotonConsEndCalibz,
-                    np.amin(scrollz),
-                )
             )
 
         if init_box is None:  # no need to get cosmo, user params out of it.


### PR DESCRIPTION
This is in response to #144. I have added in the ability for the user to modify the end-point of the photon non-conservation correction calibration. Additionally, added in errors to `run_coeval` and `run_lightcone` to catch this condition as soon as possible.

As discussed in #144, I have added this functionality to `global_params` because it will be very rare for the user to ever need this behaviour.

@steven-murray, I have tagged you to make sure the errors to catch this condition I added make sense (or if there is a better way).