### PR TITLE
docs: ensure matplotlib is installed for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,10 @@ class Mock(MagicMock):
         return MagicMock()
 
 
-MOCK_MODULES = ['py21cmfast.c_21cmfast', 'matplotlib', 'matplotlib.pyplot', 'click', 'tqdm', 'pyyaml', 'scipy', 'scipy.interpolate', 'h5py', 'cached_property']
+MOCK_MODULES = [
+    'py21cmfast.c_21cmfast', 'click', 'tqdm', 'pyyaml',
+    'scipy', 'scipy.interpolate', 'h5py', 'cached_property'
+]
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 import py21cmfast

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -10,5 +10,6 @@ dependencies:
   - sphinx>=1.3
   - astropy  # need this here, because we base classes off it (and docs need that).
   - pyyaml
+  - matplotlib
   - pip:
     - sphinx-rtd-theme


### PR DESCRIPTION
This PR fixes a few issues raised by @adampbeardsley in relation to documentation:

One page links here, which is broken: https://21cmfast.readthedocs.io/en/latest/reference/_autosummary/py21cmfast.inputs.html

And this page looks like it should have more to it?
https://21cmfast.readthedocs.io/en/latest/reference/py21cmfast.html

Looks like the builds are failing:
https://readthedocs.org/projects/21cmfast/builds/11176485/

This fixes all of those issues.