### PR TITLE
Some fixes for the external tables

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
-include README.rst user_data/* CHANGELOG.rst build_cffi.py LICENSE
+include README.rst CHANGELOG.rst build_cffi.py LICENSE
 recursive-include src *
+recursive-include user_data *

--- a/src/py21cmfast/__init__.py
+++ b/src/py21cmfast/__init__.py
@@ -1,5 +1,5 @@
 """The py21cmfast package."""
-__version__ = "3.0.0.dev5"
+__version__ = "3.0.0.dev6"
 
 # This just ensures that the default directory for boxes is created.
 from os import mkdir as _mkdir

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -268,10 +268,14 @@ class GlobalParams(StructInstanceWrapper):
     def __init__(self, wrapped, ffi):
         super().__init__(wrapped, ffi)
 
-        EXTERNALTABLES = ffi.new(
-            "char[]", path.join(path.expanduser("~"), ".21cmfast").encode()
-        )
+        table_path = path.join(path.expanduser("~"), ".21cmfast")
+        EXTERNALTABLES = ffi.new("char[]", table_path.encode())
         self.external_table_path = EXTERNALTABLES
+
+        if not path.exists(table_path):
+            raise IOError(
+                f"Found no user data directory for 21cmFAST! Should be at {table_path}"
+            )
 
     @contextlib.contextmanager
     def use(self, **kwargs):


### PR DESCRIPTION
This fixes issues that we're having with 21CMMC (see eg. https://github.com/21cmfast/21CMMC/pull/27) where it's not finding the external_tables. Turns out the error is due to the `MANIFEST.in` not recursively including the files. This doesn't error for 21cmFAST's Travis,  since it directly installs them from the repo, but it does error for 21cmMC, because it installs from PyPI (and the files are not being included in the dist that gets uploaded to PyPI). 

It also adds a little test to ensure that the user data folder properly exists and spit out a nicer error than that reported from the C.