### PR TITLE
fix: make function prototypes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v3.0.2
+------
+
+Fixed
+-----
+* Added prototype functions to enable compilation for some standard compilers on MacOS.
+
 v3.0.1
 ------
 Modifications to the internal code structure of 21cmFAST

--- a/src/py21cmfast/__init__.py
+++ b/src/py21cmfast/__init__.py
@@ -1,5 +1,5 @@
 """The py21cmfast package."""
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 # This just ensures that the default directory for boxes is created.
 from os import mkdir as _mkdir

--- a/src/py21cmfast/src/FindHaloes.c
+++ b/src/py21cmfast/src/FindHaloes.c
@@ -10,6 +10,11 @@
 
 int check_halo(char * in_halo, struct UserParams *user_params, float R, int x, int y, int z, int check_type);
 int pixel_in_halo(struct UserParams *user_params, int x, int x_index, int y, int y_index, int z, int z_index, float Rsq_curr_index );
+void init_halo_coords(struct HaloField *halos, int n_halos);
+void free_halo_field(struct HaloField *halos);
+void init_hmf(struct HaloField *halos);
+void trim_hmf(struct HaloField *halos);
+
 
 int ComputeHaloField(float redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params,
                      struct AstroParams *astro_params, struct FlagOptions *flag_options,
@@ -341,6 +346,7 @@ LOG_DEBUG("Halo Masses: %e %e %e %e", halos->halo_masses[0], halos->halo_masses[
     return(0);
 
 }
+
 
 
 // Function check_halo combines the original two functions overlap_halo and update_in_halo


### PR DESCRIPTION
This PR just puts some function prototypes into `FindHaloes.c` which is necessary apparently to compile on default MacOSX compilers. This is mostly necessary to get the `conda` package working (https://github.com/conda-forge/staged-recipes/pull/11809)