### PR TITLE
fix: only raise error on non-available table-path when using it

### DIFF
--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -291,7 +291,7 @@ class GlobalParams(StructInstanceWrapper):
 
         self._table_path = Path.home() / ".21cmfast"
         EXTERNALTABLES = ffi.new("char[]", str(self._table_path).encode())
-        self._external_table_path = EXTERNALTABLES
+        self.external_table_path = EXTERNALTABLES
 
     @property
     def external_table_path(self):
@@ -302,6 +302,10 @@ class GlobalParams(StructInstanceWrapper):
                 f"Try re-installing 21cmFAST. "
             )
         return self._external_table_path
+
+    @external_table_path.setter
+    def external_table_path(self, val):
+        self._external_table_path = val
 
     @contextlib.contextmanager
     def use(self, **kwargs):


### PR DESCRIPTION
This PR attempts to fix the currently broken readthedocs builds.
They are breaking because no ~/.21cmfast directory can be made
on RTD, and the code errors on import when this is the case.
This fixes this -- by only erroring when trying to *use* stuff
in that directory, rather than just on import.