### PR TITLE
v3.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,20 @@
 Changelog
 =========
 
-dev
+v3.0.3
 ------
+
 Added
 ~~~~~
 * ``coeval_callback`` and ``coeval_callback_redshifts`` flags to the ``run_lightcone``.
   Gives the ability to run arbitrary code on ``Coeval`` boxes.
+* JOSS paper!
+* ``get_fields`` classmethod on all output classes, so that one can easily figure out
+  what fields are computed (and available) for that class.
+
+Fixed
+~~~~~
+* Only raise error on non-available ``external_table_path`` when actually going to use it.
 
 v3.0.2
 ------

--- a/src/py21cmfast/__init__.py
+++ b/src/py21cmfast/__init__.py
@@ -1,5 +1,5 @@
 """The py21cmfast package."""
-__version__ = "3.0.2"
+__version__ = "3.0.3"
 
 # This just ensures that the default directory for boxes is created.
 from os import mkdir as _mkdir


### PR DESCRIPTION
This PR is to bump the version to v3.0.3, which will align
with the JOSS paper.

Unfortunately, this is *not* quite compatible with semantic versioning -- we've added two small features since v3.0.2,
which means we should be going to v3.1.0. However, in this case, since the features are small and aren't API breaking,
and since we need to make a new release for the JOSS paper, I think this is reasonable. These kinds of conundrums will
be averted in the future by a better branching scheme.