### PR TITLE
Fix wisdoms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ data/
 pip-wheel-metadata/py21cmfast\.dist-info/
 .nfs*
 docs/tutorials/*.h5
+valgrind*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,12 @@ Fixed
 ~~~~~
 * Bug in 2LPT when `USE_RELATIVE_VELOCITIES=True` [Issue #191, PR #192]
 * Error raised when redshifts are not in ascending order [Issue #176, PR #177]
+* Errors when ``USE_FFTW_WISDOM`` is used on some systems [Issue #174, PR #199]
 
+Internals
+~~~~~~~~~
+
+* Added ``dft.c``, which makes doing all the cubic FFTs a lot easier and more consistent. [PR #199]
 
 v3.0.3
 ------

--- a/docs/notes_for_developers.rst
+++ b/docs/notes_for_developers.rst
@@ -149,7 +149,12 @@ Valgrind will likely run very slowly, and sometimes  you will know already which
 tests are those which may have problems, or are relevant to your particular changes.
 To run these::
 
-    $ valgrind --tool=memcheck --track-origins=yes --leak-check=full --suppressions=devel/valgrind-suppress-all-but-c.supp pytest -v tests/<test_file>::<test_func>
+    $ PYTHONMALLOC=malloc valgrind --tool=memcheck --track-origins=yes --leak-check=full --suppressions=devel/valgrind-suppress-all-but-c.supp pytest -v tests/<test_file>::<test_func> > valgrind.out 2>&1
+
+Note that we also routed the stderr output to a file, which is useful because it can be
+quite voluminous. There is a python script, `devel/filter_valgrind.py` which can be run
+over the output (`valgrind.out` in the above command) to filter it down to only have
+stuff from 21cmfast in it.
 
 Producing Integration Test Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -290,8 +290,11 @@ class GlobalParams(StructInstanceWrapper):
         super().__init__(wrapped, ffi)
 
         self._table_path = Path.home() / ".21cmfast"
-        EXTERNALTABLES = ffi.new("char[]", str(self._table_path).encode())
-        self.external_table_path = EXTERNALTABLES
+        external_tables = ffi.new("char[]", str(self._table_path).encode())
+        self.external_table_path = external_tables
+        self.wisdoms_path = ffi.new(
+            "char[]", str(self._table_path / "wisdoms").encode()
+        )
 
     @property
     def external_table_path(self):
@@ -306,6 +309,23 @@ class GlobalParams(StructInstanceWrapper):
     @external_table_path.setter
     def external_table_path(self, val):
         self._external_table_path = val
+
+    @property
+    def wisdoms_path(self):
+        """An ffi char pointer to the path to which external tables are kept."""
+        if not self._table_path.exists():
+            raise IOError(
+                f"Found no user data directory for 21cmFAST! Should be at {self._table_path}."
+                f"Try re-installing 21cmFAST. "
+            )
+        if not (self._table_path / "wisdoms").exists():
+            (self._table_path / "wisdoms").mkdir()
+
+        return self._wisdom_path
+
+    @wisdoms_path.setter
+    def wisdoms_path(self, val):
+        self._wisdom_path = val
 
     @contextlib.contextmanager
     def use(self, **kwargs):
@@ -327,10 +347,9 @@ class GlobalParams(StructInstanceWrapper):
                 raise ValueError(
                     "{} is not a valid parameter of global_params".format(k)
                 )
-            else:
-                key = this_attr_upper[k.upper()]
-                prev[key] = getattr(self, key)
-                setattr(self, key, val)
+            key = this_attr_upper[k.upper()]
+            prev[key] = getattr(self, key)
+            setattr(self, key, val)
 
         yield
 
@@ -460,6 +479,12 @@ class UserParams(StructWithDefaults):
 
     _hmf_models = ["PS", "ST", "WATSON", "WATSON-Z"]
     _power_models = ["EH", "BBKS", "EFSTATHIOU", "PEEBLES", "WHITE", "CLASS"]
+
+    @property
+    def HII_DIM(self):
+        """Number of cells for the low-res box along a principal axis. Must be even."""
+        if self._HII_DIM % 2:
+            raise ValueError("HII_DIM must be even!")
 
     @property
     def DIM(self):

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -481,12 +481,6 @@ class UserParams(StructWithDefaults):
     _power_models = ["EH", "BBKS", "EFSTATHIOU", "PEEBLES", "WHITE", "CLASS"]
 
     @property
-    def HII_DIM(self):
-        """Number of cells for the low-res box along a principal axis. Must be even."""
-        if self._HII_DIM % 2:
-            raise ValueError("HII_DIM must be even!")
-
-    @property
     def DIM(self):
         """Number of cells for the high-res box (sampling ICs) along a principal axis."""
         return self._DIM or 3 * self.HII_DIM

--- a/src/py21cmfast/src/BrightnessTemperatureBox.c
+++ b/src/py21cmfast/src/BrightnessTemperatureBox.c
@@ -119,25 +119,7 @@ int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct
 
         memcpy(vel_gradient, v, sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
 
-        if(user_params->USE_FFTW_WISDOM) {
-            // Check to see if the wisdom exists, create it if it doesn't
-            sprintf(wisdom_filename,"real_to_complex_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->HII_DIM,user_params->N_THREADS);
-            if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)vel_gradient, (fftwf_complex *)vel_gradient, FFTW_WISDOM_ONLY);
-                fftwf_execute(plan);
-            }
-            else {
-                LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-                Throw(FileError);
-            }
-        }
-        else {
-            plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                         (float *)vel_gradient, (fftwf_complex *)vel_gradient, FFTW_ESTIMATE);
-            fftwf_execute(plan);
-        }
-        fftwf_destroy_plan(plan);
+        dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, vel_gradient);
 
 #pragma omp parallel shared(vel_gradient) private(n_x,n_y,n_z,k_x,k_y,k_z) num_threads(user_params->N_THREADS)
         {
@@ -164,25 +146,7 @@ int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct
             }
         }
 
-        if(user_params->USE_FFTW_WISDOM) {
-            // Check to see if the wisdom exists, create it if it doesn't
-            sprintf(wisdom_filename,"complex_to_real_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->HII_DIM,user_params->N_THREADS);
-            if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-                plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (fftwf_complex *)vel_gradient, (float *)vel_gradient, FFTW_WISDOM_ONLY);
-                fftwf_execute(plan);
-            }
-            else {
-                LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-                Throw(FileError);
-            }
-        }
-        else {
-            plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                         (fftwf_complex *)vel_gradient, (float *)vel_gradient, FFTW_ESTIMATE);
-            fftwf_execute(plan);
-        }
-        fftwf_destroy_plan(plan);
+        dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, vel_gradient);
 
         // now add the velocity correction to the delta_T maps (only used for T_S >> T_CMB case).
         max_v_deriv = fabs(global_params.MAX_DVDR*H);

--- a/src/py21cmfast/src/BrightnessTemperatureBox.c
+++ b/src/py21cmfast/src/BrightnessTemperatureBox.c
@@ -22,11 +22,6 @@ int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct
     ave = 0.;
 
     omp_set_num_threads(user_params->N_THREADS);
-    fftwf_init_threads();
-    fftwf_plan_with_nthreads(user_params->N_THREADS);
-    fftwf_cleanup_threads();
-
-    fftwf_plan plan;
 
     float *v = (float *) calloc(HII_TOT_FFT_NUM_PIXELS,sizeof(float));
     float *vel_gradient = (float *) calloc(HII_TOT_FFT_NUM_PIXELS,sizeof(float));

--- a/src/py21cmfast/src/FindHaloes.c
+++ b/src/py21cmfast/src/FindHaloes.c
@@ -39,12 +39,7 @@ LOG_DEBUG("redshift=%f", redshift);
         Broadcast_struct_global_UF(user_params,cosmo_params);
 
         omp_set_num_threads(user_params->N_THREADS);
-        fftwf_init_threads();
-        fftwf_plan_with_nthreads(user_params->N_THREADS);
-        fftwf_cleanup_threads();
 
-        char wisdom_filename[500];
-        fftwf_plan plan;
         fftwf_complex *density_field, *density_field_saved;
 
         float growth_factor, R, delta_m, dm, dlnm, M, Delta_R, delta_crit;

--- a/src/py21cmfast/src/FindHaloes.c
+++ b/src/py21cmfast/src/FindHaloes.c
@@ -110,27 +110,7 @@ LOG_DEBUG("Begin Initialisation");
             }
         }
 
-        // Now need to convert the real space density to Fourier space
-        if(user_params->USE_FFTW_WISDOM) {
-            // Check to see if the wisdom exists, create it if it doesn't
-            sprintf(wisdom_filename,"real_to_complex_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->DIM,user_params->N_THREADS);
-            if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-                plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                             (float *)density_field, (fftwf_complex *)density_field, FFTW_WISDOM_ONLY);
-                fftwf_execute(plan);
-
-            }
-            else {
-                LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-                Throw(FileError);
-            }
-        }
-        else {
-            plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                         (float *)density_field, (fftwf_complex *)density_field, FFTW_ESTIMATE);
-            fftwf_execute(plan);
-        }
-        fftwf_destroy_plan(plan);
+        dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, density_field);
 
         // save a copy of the k-space density field
         memcpy(density_field_saved, density_field, sizeof(fftwf_complex)*KSPACE_NUM_PIXELS);
@@ -188,25 +168,7 @@ LOG_DEBUG("Haloes too rare for M = %e! Skipping...", M);
             filter_box(density_field, 0, global_params.HALO_FILTER, R);
 
             // do the FFT to get delta_m box
-            if(user_params->USE_FFTW_WISDOM) {
-                // Check to see if the wisdom exists, create it if it doesn't
-                sprintf(wisdom_filename,"complex_to_real_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->DIM,user_params->N_THREADS);
-                if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                 (fftwf_complex *)density_field, (float *)density_field, FFTW_WISDOM_ONLY);
-                    fftwf_execute(plan);
-                }
-                else {
-                    LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-                    Throw(FileError);
-                }
-            }
-            else {
-                plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                             (fftwf_complex *)density_field, (float *)density_field, FFTW_ESTIMATE);
-                fftwf_execute(plan);
-            }
-            fftwf_destroy_plan(plan);
+            dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, density_field);
 
             // *****************  BEGIN OPTIMIZATION ***************** //
             // to optimize speed, if the filter size is large (switch to collapse fraction criteria later)

--- a/src/py21cmfast/src/GenerateICs.c
+++ b/src/py21cmfast/src/GenerateICs.c
@@ -23,6 +23,7 @@
 #include "logger.h"
 #include "Constants.h"
 #include "Globals.h"
+#include "indexing.c"
 #include "UsefulFunctions.c"
 #include "ps.c"
 #include "dft.c"
@@ -125,9 +126,6 @@ int ComputeInitialConditions(
     gsl_rng_set(rseed, random_seed);
 
     omp_set_num_threads(user_params->N_THREADS);
-    fftwf_init_threads();
-    fftwf_plan_with_nthreads(user_params->N_THREADS);
-    fftwf_cleanup_threads();
 
     switch(user_params->PERTURB_ON_HIGH_RES) {
         case 0:

--- a/src/py21cmfast/src/GenerateICs.c
+++ b/src/py21cmfast/src/GenerateICs.c
@@ -25,6 +25,7 @@
 #include "Globals.h"
 #include "UsefulFunctions.c"
 #include "ps.c"
+#include "dft.c"
 #include "PerturbField.c"
 #include "bubble_helper_progs.c"
 #include "elec_interp.c"
@@ -35,6 +36,7 @@
 #include "BrightnessTemperatureBox.c"
 #include "FindHaloes.c"
 #include "PerturbHaloField.c"
+
 
 
 void adj_complex_conj(fftwf_complex *HIRES_box, struct UserParams *user_params, struct CosmoParams *cosmo_params){
@@ -108,10 +110,6 @@ int ComputeInitialConditions(
     // Do each time to avoid Python garbage collection issues
     Broadcast_struct_global_PS(user_params,cosmo_params);
     Broadcast_struct_global_UF(user_params,cosmo_params);
-
-    fftwf_plan plan;
-
-    char wisdom_filename[500];
 
     unsigned long long ct;
     int n_x, n_y, n_z, i, j, k, ii, thread_num, dimension;
@@ -280,26 +278,8 @@ int ComputeInitialConditions(
     memcpy(HIRES_box_saved, HIRES_box, sizeof(fftwf_complex)*KSPACE_NUM_PIXELS);
 
     // FFT back to real space
-    if(user_params->USE_FFTW_WISDOM) {
-        // Check to see if the wisdom exists, create it if it doesn't
-        sprintf(wisdom_filename,"complex_to_real_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->DIM,user_params->N_THREADS);
-        if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-            plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                         (fftwf_complex *)HIRES_box, (float *)HIRES_box, FFTW_WISDOM_ONLY);
-            fftwf_execute(plan);
-        }
-        else {
-            LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-            Throw(FileError);
-        }
-    }
-    else {
-        plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                     (fftwf_complex *)HIRES_box, (float *)HIRES_box, FFTW_ESTIMATE);
-        fftwf_execute(plan);
-    }
-    fftwf_destroy_plan(plan);
-
+    int stat = dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box);
+    if(stat>0) Throw(stat);
     LOG_DEBUG("FFT'd hires boxes.");
 
 #pragma omp parallel shared(boxes,HIRES_box) private(i,j,k) num_threads(user_params->N_THREADS)
@@ -325,17 +305,7 @@ int ComputeInitialConditions(
         }
 
         // FFT back to real space
-        if(user_params->USE_FFTW_WISDOM) {
-            plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                             (fftwf_complex *)HIRES_box, (float *)HIRES_box, FFTW_WISDOM_ONLY);
-            fftwf_execute(plan);
-        }
-        else {
-            plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                         (fftwf_complex *)HIRES_box, (float *)HIRES_box, FFTW_ESTIMATE);
-            fftwf_execute(plan);
-        }
-        fftwf_destroy_plan(plan);
+        dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box);
 
         // Renormalise the FFT'd box (sample the high-res box if we are perturbing on the low-res grid)
 #pragma omp parallel shared(boxes,HIRES_box,f_pixel_factor) private(i,j,k) num_threads(user_params->N_THREADS)
@@ -359,26 +329,10 @@ int ComputeInitialConditions(
     if(user_params->USE_RELATIVE_VELOCITIES){
         //note we do NOT filter our boxes first, in order to keep the total number of boxes small.
 
-        for(ii=0;ii<3;ii++) {
-            if(user_params->USE_FFTW_WISDOM) {
-                if(ii==0) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                         (fftwf_complex *)HIRES_box_vcb_x, (float *)HIRES_box_vcb_x, FFTW_WISDOM_ONLY); }
-                if(ii==1) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                         (fftwf_complex *)HIRES_box_vcb_y, (float *)HIRES_box_vcb_y, FFTW_WISDOM_ONLY); }
-                if(ii==2) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                         (fftwf_complex *)HIRES_box_vcb_z, (float *)HIRES_box_vcb_z, FFTW_WISDOM_ONLY); }
-            }
-            else {
-                if(ii==0) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                         (fftwf_complex *)HIRES_box_vcb_x, (float *)HIRES_box_vcb_x, FFTW_ESTIMATE); }
-                if(ii==1) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                         (fftwf_complex *)HIRES_box_vcb_y, (float *)HIRES_box_vcb_y, FFTW_ESTIMATE); }
-                if(ii==2) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                         (fftwf_complex *)HIRES_box_vcb_z, (float *)HIRES_box_vcb_z, FFTW_ESTIMATE); }
-            }
-            fftwf_execute(plan);
-            fftwf_destroy_plan(plan);
-        }
+        dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box_vcb_x);
+        dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box_vcb_y);
+        dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box_vcb_z);
+
 
         // sample the UNfiltered velocity box and save it to python
 #pragma omp parallel shared(boxes,HIRES_box_vcb_x,HIRES_box_vcb_y,HIRES_box_vcb_z) private(i,j,k,vcb_x,vcb_y,vcb_z) num_threads(user_params->N_THREADS)
@@ -399,39 +353,9 @@ int ComputeInitialConditions(
         // Only filter the relative velocities if we are perturbing on the low-resolution grid
         if(!user_params->PERTURB_ON_HIGH_RES) {
 
-            if(user_params->USE_FFTW_WISDOM) {
-
-                sprintf(wisdom_filename,"real_to_complex_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->DIM,user_params->N_THREADS);
-                if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-                    plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                 (float *)HIRES_box_vcb_x, (fftwf_complex *)HIRES_box_vcb_x, FFTW_WISDOM_ONLY);
-                    fftwf_execute(plan);
-                }
-                else {
-                    LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-                    Throw(FileError);
-                }
-
-                plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                             (float *)HIRES_box_vcb_y, (fftwf_complex *)HIRES_box_vcb_y, FFTW_WISDOM_ONLY);
-                fftwf_execute(plan);
-                plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                             (float *)HIRES_box_vcb_z, (fftwf_complex *)HIRES_box_vcb_z, FFTW_WISDOM_ONLY);
-                fftwf_execute(plan);
-
-            }
-            else {
-                for(ii=0;ii<3;ii++) {
-                    if(ii==0) { plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                             (float *)HIRES_box_vcb_x, (fftwf_complex *)HIRES_box_vcb_x, FFTW_ESTIMATE); }
-                    if(ii==1) { plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                             (float *)HIRES_box_vcb_y, (fftwf_complex *)HIRES_box_vcb_y, FFTW_ESTIMATE); }
-                    if(ii==2) { plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                             (float *)HIRES_box_vcb_z, (fftwf_complex *)HIRES_box_vcb_z, FFTW_ESTIMATE); }
-                    fftwf_execute(plan);
-                }
-            }
-            fftwf_destroy_plan(plan);
+            dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box_vcb_x);
+            dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box_vcb_y);
+            dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box_vcb_z);
 
             //and filter each box:
             if (user_params->DIM != user_params->HII_DIM){
@@ -441,32 +365,9 @@ int ComputeInitialConditions(
             }
 
             //and transform back to real space
-            if(user_params->USE_FFTW_WISDOM) {
-                // FFTW Wisdom will already be in memory
-                for(ii=0;ii<3;ii++) {
-                    if(ii==0) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                             (fftwf_complex *)HIRES_box_vcb_x, (float *)HIRES_box_vcb_x, FFTW_WISDOM_ONLY); }
-                    if(ii==1) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                             (fftwf_complex *)HIRES_box_vcb_y, (float *)HIRES_box_vcb_y, FFTW_WISDOM_ONLY); }
-                    if(ii==2) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                             (fftwf_complex *)HIRES_box_vcb_z, (float *)HIRES_box_vcb_z, FFTW_WISDOM_ONLY); }
-
-                    fftwf_execute(plan);
-                    fftwf_destroy_plan(plan);
-                }
-            }
-            else {
-                for(ii=0;ii<3;ii++) {
-                    if(ii==0) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                             (fftwf_complex *)HIRES_box_vcb_x, (float *)HIRES_box_vcb_x, FFTW_ESTIMATE); }
-                    if(ii==1) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                             (fftwf_complex *)HIRES_box_vcb_y, (float *)HIRES_box_vcb_y, FFTW_ESTIMATE); }
-                    if(ii==2) { plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                             (fftwf_complex *)HIRES_box_vcb_z, (float *)HIRES_box_vcb_z, FFTW_ESTIMATE); }
-                    fftwf_execute(plan);
-                    fftwf_destroy_plan(plan);
-                }
-            }
+            dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box_vcb_x);
+            dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box_vcb_y);
+            dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box_vcb_z);
 
             //to save into a lowres box
 #pragma omp parallel shared(boxes,HIRES_box_vcb_x,HIRES_box_vcb_y,HIRES_box_vcb_z,f_pixel_factor) private(i,j,k,vcb_x,vcb_y,vcb_z) num_threads(user_params->N_THREADS)
@@ -555,16 +456,7 @@ int ComputeInitialConditions(
             }
         }
 
-        if(user_params->USE_FFTW_WISDOM) {
-            plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                         (fftwf_complex *)HIRES_box, (float *)HIRES_box, FFTW_WISDOM_ONLY);
-        }
-        else {
-            plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                         (fftwf_complex *)HIRES_box, (float *)HIRES_box, FFTW_ESTIMATE);
-        }
-        fftwf_execute(plan);
-        fftwf_destroy_plan(plan);
+        dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box);
 
         // now sample to lower res
         // now sample the filtered box
@@ -692,11 +584,7 @@ int ComputeInitialConditions(
                     }
                 }
 
-                // Now we can generate the real phi_1[i,j]
-                plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                             (fftwf_complex *)phi_1[PHI_INDEX(i, j)], (float *)phi_1[PHI_INDEX(i, j)], FFTW_ESTIMATE);
-                fftwf_execute(plan);
-                fftwf_destroy_plan(plan);
+                dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, phi_1[PHI_INDEX(i, j)]);
             }
         }
 
@@ -742,37 +630,14 @@ int ComputeInitialConditions(
         }
 
         // Perform FFTs
-        if(user_params->USE_FFTW_WISDOM) {
-            // Check to see if wisdom exists, if not create it
-            if (user_params->USE_RELATIVE_VELOCITIES) {
-                // if this is true, we have already created the wisdom and its in memory
-                plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM, (float *) HIRES_box,
-                                             (fftwf_complex *) HIRES_box, FFTW_WISDOM_ONLY);
-            } else {
-                sprintf(wisdom_filename, "real_to_complex_DIM%d_NTHREADS%d.fftwf_wisdom", user_params->DIM,
-                        user_params->N_THREADS);
-                if (fftwf_import_wisdom_from_filename(wisdom_filename) != 0) {
-                    plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                                 (float *) HIRES_box, (fftwf_complex *) HIRES_box, FFTW_WISDOM_ONLY);
-                } else {
-                    LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-                    Throw(FileError);
-                }
-            }
-        }
-        else {
-            plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                         (float *)HIRES_box, (fftwf_complex *)HIRES_box, FFTW_ESTIMATE);
-        }
-        fftwf_execute(plan);
-        fftwf_destroy_plan(plan);
+        dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box);
 
         memcpy(HIRES_box_saved, HIRES_box, sizeof(fftwf_complex)*KSPACE_NUM_PIXELS);
 
-        // Now we can store the content of box in a back-up file
+        // Now we can store the content of box in a back-up array
         // Then we can generate the gradients of phi_2 (eq. D13b and D9)
 
-        // ***** Write out back-up k-box RHS eq. D13b ***** //
+        // ***** Store back-up k-box RHS eq. D13b ***** //
 
         // For each component, we generate the velocity field (same as the ZA part)
 
@@ -836,17 +701,7 @@ int ComputeInitialConditions(
                 }
             }
 
-            if(user_params->USE_FFTW_WISDOM) {
-                // This wisdom has already been created and in memory
-                plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                             (fftwf_complex *)HIRES_box, (float *)HIRES_box, FFTW_WISDOM_ONLY);
-            }
-            else {
-                plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                             (fftwf_complex *)HIRES_box, (float *)HIRES_box, FFTW_ESTIMATE);
-            }
-            fftwf_execute(plan);
-            fftwf_destroy_plan(plan);
+            dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->DIM, user_params->N_THREADS, HIRES_box);
 
             // now sample to lower res
             // now sample the filtered box
@@ -930,123 +785,6 @@ int ComputeInitialConditions(
     }
     gsl_rng_free(rseed);
     LOG_DEBUG("Cleaned Up.");
-    } // End of Try{}
-
-    Catch(status){
-        return(status);
-    }
-    return(0);
-}
-
-int CreateFFTWWisdoms(struct UserParams *user_params, struct CosmoParams *cosmo_params) {
-
-    int status;
-
-    Try{ // This Try wraps the entire function so we don't indent.
-
-        // Put this check here to minimise checks on Python side
-        if(user_params->USE_FFTW_WISDOM) {
-            Broadcast_struct_global_UF(user_params,cosmo_params);
-
-            fftwf_plan plan;
-
-            char wisdom_filename[500];
-
-            int i,j,k;
-
-            omp_set_num_threads(user_params->N_THREADS);
-            fftwf_init_threads();
-            fftwf_plan_with_nthreads(user_params->N_THREADS);
-            fftwf_cleanup_threads();
-
-            // allocate array for the k-space and real-space boxes
-            fftwf_complex *HIRES_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*KSPACE_NUM_PIXELS);
-            fftwf_complex *LOWRES_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
-
-#pragma omp parallel shared(HIRES_box) private(i,j,k) num_threads(user_params->N_THREADS)
-            {
-#pragma omp for
-                for (i=0; i<user_params->DIM; i++){
-                    for (j=0; j<user_params->DIM; j++){
-                        for (k=0; k<=MIDDLE; k++){
-                            HIRES_box[C_INDEX(i, j, k)] = 0.0;
-                        }
-                    }
-                }
-            }
-
-#pragma omp parallel shared(LOWRES_box) private(i,j,k) num_threads(user_params->N_THREADS)
-            {
-#pragma omp for
-                for (i=0; i<user_params->HII_DIM; i++){
-                    for (j=0; j<user_params->HII_DIM; j++){
-                        for (k=0; k<=HII_MIDDLE; k++){
-                            LOWRES_box[HII_C_INDEX(i, j, k)] = 0.0;
-                        }
-                    }
-                }
-            }
-
-            sprintf(wisdom_filename,"real_to_complex_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->DIM,user_params->N_THREADS);
-            if(fftwf_import_wisdom_from_filename(wisdom_filename)==0) {
-                // Going to need to construct an FFTW_Wisdom for this box
-                plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                             (float *)HIRES_box, (fftwf_complex *)HIRES_box, FFTW_PATIENT);
-                fftwf_execute(plan);
-
-                // Store the wisdom for later use
-                fftwf_export_wisdom_to_filename(wisdom_filename);
-                fftwf_destroy_plan(plan);
-            }
-
-            sprintf(wisdom_filename,"complex_to_real_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->DIM,user_params->N_THREADS);
-            if(fftwf_import_wisdom_from_filename(wisdom_filename)==0) {
-
-                // Going to need to construct an FFTW_Wisdom for this box
-                plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
-                                             (float *)HIRES_box, (fftwf_complex *)HIRES_box, FFTW_PATIENT);
-                fftwf_execute(plan);
-
-                // Store the wisdom for later use
-                fftwf_export_wisdom_to_filename(wisdom_filename);
-                fftwf_destroy_plan(plan);
-            }
-
-            sprintf(wisdom_filename,"real_to_complex_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->HII_DIM,user_params->N_THREADS);
-            if(fftwf_import_wisdom_from_filename(wisdom_filename)==0) {
-
-                // Going to need to construct an FFTW_Wisdom for this box
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)LOWRES_box, (fftwf_complex *)LOWRES_box, FFTW_PATIENT);
-                fftwf_execute(plan);
-
-                // Store the wisdom for later use
-                fftwf_export_wisdom_to_filename(wisdom_filename);
-                fftwf_destroy_plan(plan);
-            }
-
-            sprintf(wisdom_filename,"complex_to_real_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->HII_DIM,user_params->N_THREADS);
-            if(fftwf_import_wisdom_from_filename(wisdom_filename)==0) {
-
-                // Going to need to construct an FFTW_Wisdom for this box
-                plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)LOWRES_box, (fftwf_complex *)LOWRES_box, FFTW_PATIENT);
-                fftwf_execute(plan);
-
-                // Store the wisdom for later use
-                fftwf_export_wisdom_to_filename(wisdom_filename);
-                fftwf_destroy_plan(plan);
-            }
-
-            fftwf_cleanup_threads();
-            fftwf_cleanup();
-            fftwf_forget_wisdom();
-
-            // deallocate
-            fftwf_free(HIRES_box);
-            fftwf_free(LOWRES_box);
-        }
-
     } // End of Try{}
 
     Catch(status){

--- a/src/py21cmfast/src/Globals.h
+++ b/src/py21cmfast/src/Globals.h
@@ -72,6 +72,7 @@ struct GlobalParams{
     int FILTER;
 
     char *external_table_path;
+    char *wisdoms_path;
     float R_BUBBLE_MIN;
     float M_MIN_INTEGRAL;
     float M_MAX_INTEGRAL;

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -45,12 +45,6 @@ int ComputeIonizedBox(float redshift, float prev_redshift, struct UserParams *us
     Broadcast_struct_global_UF(user_params,cosmo_params);
 
     omp_set_num_threads(user_params->N_THREADS);
-    fftwf_init_threads();
-    fftwf_plan_with_nthreads(user_params->N_THREADS);
-    fftwf_cleanup_threads();
-
-    char wisdom_filename[500];
-    fftwf_plan plan;
 
     // Other parameters used in the code
     int i,j,k,x,y,z, LAST_FILTER_STEP, first_step_R, short_completely_ionised,i_halo;

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -650,104 +650,30 @@ LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll_MINI: %e", box->mean_f
             }
         }
 
-        if (user_params->USE_FFTW_WISDOM) {
-            // Check to see if the wisdom exists, create it if it doesn't
-            sprintf(wisdom_filename, "real_to_complex_DIM%d_NTHREADS%d.fftwf_wisdom", user_params->HII_DIM,
-                    user_params->N_THREADS);
-            if (fftwf_import_wisdom_from_filename(wisdom_filename) != 0) {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *) deltax_unfiltered, (fftwf_complex *) deltax_unfiltered,FFTW_WISDOM_ONLY);
-                fftwf_execute(plan);
-                fftwf_destroy_plan(plan);
-            } else {
-                LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-                Throw(FileError);
-            }
-        } else {
-            plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                         (float *) deltax_unfiltered, (fftwf_complex *) deltax_unfiltered,FFTW_ESTIMATE);
-            fftwf_execute(plan);
-            fftwf_destroy_plan(plan);
-        }
+        dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, deltax_unfiltered);
 
         LOG_SUPER_DEBUG("FFTs performed");
 
         if(flag_options->USE_MINI_HALOS){
-            if(user_params->USE_FFTW_WISDOM) {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)prev_deltax_unfiltered, (fftwf_complex *)prev_deltax_unfiltered, FFTW_WISDOM_ONLY);
-            }
-            else {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)prev_deltax_unfiltered, (fftwf_complex *)prev_deltax_unfiltered, FFTW_ESTIMATE);
-            }
-            fftwf_execute(plan);
-            fftwf_destroy_plan(plan);
-
-            if(user_params->USE_FFTW_WISDOM) {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)log10_Mturnover_MINI_unfiltered, (fftwf_complex *)log10_Mturnover_MINI_unfiltered, FFTW_WISDOM_ONLY);
-            }
-            else {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)log10_Mturnover_MINI_unfiltered, (fftwf_complex *)log10_Mturnover_MINI_unfiltered, FFTW_ESTIMATE);
-            }
-            fftwf_execute(plan);
-            fftwf_destroy_plan(plan);
-
-            if(user_params->USE_FFTW_WISDOM) {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)log10_Mturnover_unfiltered, (fftwf_complex *)log10_Mturnover_unfiltered, FFTW_WISDOM_ONLY);
-            }
-            else {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)log10_Mturnover_unfiltered, (fftwf_complex *)log10_Mturnover_unfiltered, FFTW_ESTIMATE);
-            }
-            fftwf_execute(plan);
-            fftwf_destroy_plan(plan);
+            dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, prev_deltax_unfiltered);
+            dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, log10_Mturnover_MINI_unfiltered);
+            dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, log10_Mturnover_unfiltered);
+            LOG_SUPER_DEBUG("MINI HALO ffts performed");
         }
 
         if (flag_options->USE_HALO_FIELD){
-            if(user_params->USE_FFTW_WISDOM) {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)M_coll_unfiltered, (fftwf_complex *)M_coll_unfiltered, FFTW_WISDOM_ONLY);
-            }
-            else {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)M_coll_unfiltered, (fftwf_complex *)M_coll_unfiltered, FFTW_ESTIMATE);
-            }
-            fftwf_execute(plan);
-            fftwf_destroy_plan(plan);
+            dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, M_coll_unfiltered);
+            LOG_SUPER_DEBUG("HALO_FIELD ffts performed");
         }
 
         if(flag_options->USE_TS_FLUCT) {
-            if(user_params->USE_FFTW_WISDOM) {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)xe_unfiltered, (fftwf_complex *)xe_unfiltered, FFTW_WISDOM_ONLY);
-            }
-            else {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)xe_unfiltered, (fftwf_complex *)xe_unfiltered, FFTW_ESTIMATE);
-            }
-            fftwf_execute(plan);
-            fftwf_destroy_plan(plan);
-
+            dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, xe_unfiltered);
+            LOG_SUPER_DEBUG("Ts ffts performed");
         }
-        LOG_SUPER_DEBUG("more ffts performed");
 
 
         if (flag_options->INHOMO_RECO) {
-            if (user_params->USE_FFTW_WISDOM) {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *) N_rec_unfiltered, (fftwf_complex *) N_rec_unfiltered,
-                                             FFTW_WISDOM_ONLY);
-            } else {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *) N_rec_unfiltered, (fftwf_complex *) N_rec_unfiltered,
-                                             FFTW_ESTIMATE);
-            }
-            fftwf_execute(plan);
-            fftwf_destroy_plan(plan);
+            dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, N_rec_unfiltered);
         }
 
         // remember to add the factor of VOLUME/TOT_NUM_PIXELS when converting from
@@ -854,95 +780,24 @@ LOG_ULTRA_DEBUG("while loop for until RtoM(R)=%f reaches M_MIN=%f", RtoM(R), M_M
             }
 
             // Perform FFTs
-            if (user_params->USE_FFTW_WISDOM) {
-                // Check to see if the wisdom exists, create it if it doesn't
-                sprintf(wisdom_filename, "complex_to_real_DIM%d_NTHREADS%d.fftwf_wisdom", user_params->HII_DIM,
-                        user_params->N_THREADS);
-                if (fftwf_import_wisdom_from_filename(wisdom_filename) != 0) {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *) deltax_filtered, (float *) deltax_filtered,FFTW_WISDOM_ONLY);
-                    fftwf_execute(plan);
-                    fftwf_destroy_plan(plan);
-                } else {
-                    LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-                    Throw(FileError);
-                }
-            } else {
-                plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (fftwf_complex *) deltax_filtered, (float *) deltax_filtered,FFTW_ESTIMATE);
-                fftwf_execute(plan);
-                fftwf_destroy_plan(plan);
-            }
+            dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, deltax_filtered);
 
             if(flag_options->USE_MINI_HALOS){
-                if(user_params->USE_FFTW_WISDOM) {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *)prev_deltax_filtered, (float *)prev_deltax_filtered, FFTW_WISDOM_ONLY);
-                }
-                else {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *)prev_deltax_filtered, (float *)prev_deltax_filtered, FFTW_ESTIMATE);
-                }
-                fftwf_execute(plan);
-                fftwf_destroy_plan(plan);
-
-                if(user_params->USE_FFTW_WISDOM) {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *)log10_Mturnover_MINI_filtered, (float *)log10_Mturnover_MINI_filtered, FFTW_WISDOM_ONLY);
-                }
-                else {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *)log10_Mturnover_MINI_filtered, (float *)log10_Mturnover_MINI_filtered, FFTW_ESTIMATE);
-                }
-                fftwf_execute(plan);
-                fftwf_destroy_plan(plan);
-
-                if(user_params->USE_FFTW_WISDOM) {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *)log10_Mturnover_filtered, (float *)log10_Mturnover_filtered, FFTW_WISDOM_ONLY);
-                }
-                else {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *)log10_Mturnover_filtered, (float *)log10_Mturnover_filtered, FFTW_ESTIMATE);
-                }
-                fftwf_execute(plan);
-                fftwf_destroy_plan(plan);
+                dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, prev_deltax_filtered);
+                dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, log10_Mturnover_MINI_filtered);
+                dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, log10_Mturnover_filtered);
             }
 
             if (flag_options->USE_HALO_FIELD) {
-                if (user_params->USE_FFTW_WISDOM) {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *)M_coll_filtered, (float *)M_coll_filtered, FFTW_WISDOM_ONLY);
-                } else {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *)M_coll_filtered, (float *)M_coll_filtered, FFTW_ESTIMATE);
-                }
-                fftwf_execute(plan);
-                fftwf_destroy_plan(plan);
+                dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, M_coll_filtered);
             }
 
             if (flag_options->USE_TS_FLUCT) {
-                if (user_params->USE_FFTW_WISDOM) {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *) xe_filtered, (float *) xe_filtered,FFTW_WISDOM_ONLY);
-                } else {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *) xe_filtered, (float *) xe_filtered, FFTW_ESTIMATE);
-                }
-                fftwf_execute(plan);
-                fftwf_destroy_plan(plan);
+                dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, xe_filtered);
             }
 
             if (flag_options->INHOMO_RECO) {
-                if (user_params->USE_FFTW_WISDOM) {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *) N_rec_filtered, (float *) N_rec_filtered,FFTW_WISDOM_ONLY);
-                } else {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *) N_rec_filtered, (float *) N_rec_filtered,FFTW_ESTIMATE);
-                }
-                fftwf_execute(plan);
-                fftwf_destroy_plan(plan);
+                dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, N_rec_filtered);
             }
 
             // Check if this is the last filtering scale.  If so, we don't need deltax_unfiltered anymore.

--- a/src/py21cmfast/src/PerturbField.c
+++ b/src/py21cmfast/src/PerturbField.c
@@ -22,15 +22,9 @@ int ComputePerturbField(
     Broadcast_struct_global_UF(user_params,cosmo_params);
 
     omp_set_num_threads(user_params->N_THREADS);
-    fftwf_init_threads();
-    fftwf_plan_with_nthreads(user_params->N_THREADS);
-    fftwf_cleanup_threads();
-
-    char wisdom_filename[500];
 
     fftwf_complex *HIRES_density_perturb, *HIRES_density_perturb_saved;
     fftwf_complex *LOWRES_density_perturb, *LOWRES_density_perturb_saved;
-    fftwf_plan plan;
 
     float growth_factor, displacement_factor_2LPT, init_growth_factor, init_displacement_factor_2LPT, xf, yf, zf;
     float mass_factor, dDdt, f_pixel_factor, velocity_displacement_factor, velocity_displacement_factor_2LPT;

--- a/src/py21cmfast/src/PerturbField.c
+++ b/src/py21cmfast/src/PerturbField.c
@@ -117,7 +117,6 @@ int ComputePerturbField(
                             *((float *)HIRES_density_perturb + R_FFT_INDEX(i,j,k)) = 0.;
                         }
                         else {
-                            LOG_DEBUG("Doing %d %d %d = %d", i,j,k, HII_R_FFT_INDEX(i,j,k));
                             *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i,j,k)) = 0.;
                         }
 
@@ -125,15 +124,6 @@ int ComputePerturbField(
                 }
             }
         }
-
-        for (i=0; i<dimension*dimension*dimension; i++){
-            LOG_DEBUG("ABout to do %d", i);
-            LOG_DEBUG("%f", LOWRES_density_perturb[i]);
-        }
-        Throw(IOError);
-
-        LOG_DEBUG("A few values in LOWRES_density_perturb: %f %f %f %f", LOWRES_density_perturb[0],
-        LOWRES_density_perturb[user_params->HII_DIM], LOWRES_density_perturb[user_params->HII_DIM*user_params->HII_DIM], LOWRES_density_perturb[10*user_params->HII_DIM]);
 
         velocity_displacement_factor = (growth_factor-init_growth_factor) / user_params->BOX_LEN;
 

--- a/src/py21cmfast/src/PerturbHaloField.c
+++ b/src/py21cmfast/src/PerturbHaloField.c
@@ -27,12 +27,6 @@ LOG_DEBUG("redshift=%f", redshift);
         Broadcast_struct_global_UF(user_params,cosmo_params);
 
         omp_set_num_threads(user_params->N_THREADS);
-        fftwf_init_threads();
-        fftwf_plan_with_nthreads(user_params->N_THREADS);
-        fftwf_cleanup_threads();
-
-        char wisdom_filename[500];
-        fftwf_plan plan;
 
         float growth_factor, displacement_factor_2LPT, mass, xf, yf, zf, z, growth_factor_over_BOX_LEN,displacement_factor_2LPT_over_BOX_LEN;
         int i,j,k, i_halo,xi, yi, zi, DI, dimension;

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -530,25 +530,7 @@ LOG_SUPER_DEBUG("Looping through R");
 LOG_SUPER_DEBUG("Allocated unfiltered box");
 
             ////////////////// Transform unfiltered box to k-space to prepare for filtering /////////////////
-            if(user_params->USE_FFTW_WISDOM) {
-                // Check to see if the wisdom exists, create it if it doesn't
-                sprintf(wisdom_filename,"real_to_complex_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->HII_DIM,user_params->N_THREADS);
-                if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (float *)unfiltered_box, (fftwf_complex *)unfiltered_box, FFTW_WISDOM_ONLY);
-                    fftwf_execute(plan);
-                }
-                else {
-                    LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-                    Throw(FileError);
-                }
-            }
-            else {
-                plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                             (float *)unfiltered_box, (fftwf_complex *)unfiltered_box, FFTW_ESTIMATE);
-                fftwf_execute(plan);
-            }
-            fftwf_destroy_plan(plan);
+            dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, unfiltered_box);
 LOG_SUPER_DEBUG("Done FFT on unfiltered box");
 
             // remember to add the factor of VOLUME/TOT_NUM_PIXELS when converting from real space to k-space
@@ -579,25 +561,7 @@ LOG_SUPER_DEBUG("normalised unfiltered box");
                     filter_box(box, 1, global_params.HEAT_FILTER, R);
                 }
                 // now fft back to real space
-                if(user_params->USE_FFTW_WISDOM) {
-                    // Check to see if the wisdom exists, create it if it doesn't
-                    sprintf(wisdom_filename,"complex_to_real_DIM%d_NTHREADS%d.fftwf_wisdom",user_params->HII_DIM,user_params->N_THREADS);
-                    if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
-                        plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                     (fftwf_complex *)box, (float *)box, FFTW_WISDOM_ONLY);
-                        fftwf_execute(plan);
-                    }
-                    else {
-                        LOG_ERROR("Cannot locate FFTW Wisdom: %s file not found",wisdom_filename);
-                        Throw(FileError);
-                    }
-                }
-                else {
-                    plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (fftwf_complex *)box, (float *)box, FFTW_ESTIMATE);
-                    fftwf_execute(plan);
-                }
-                fftwf_destroy_plan(plan);
+                dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, box);
 LOG_ULTRA_DEBUG("Executed FFT for R=%f", R);
 
                 min_density = 0.0;
@@ -934,16 +898,7 @@ LOG_SUPER_DEBUG("got density gridpoints");
 
                 // NEED TO FILTER Mcrit_LW!!!
                 /*** Transform unfiltered box to k-space to prepare for filtering ***/
-                if(user_params->USE_FFTW_WISDOM) {
-                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (float *)log10_Mcrit_LW_unfiltered, (fftwf_complex *)log10_Mcrit_LW_unfiltered, FFTW_WISDOM_ONLY);
-                }
-                else {
-                    plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                 (float *)log10_Mcrit_LW_unfiltered, (fftwf_complex *)log10_Mcrit_LW_unfiltered, FFTW_ESTIMATE);
-                }
-                fftwf_execute(plan);
-                fftwf_destroy_plan(plan);
+                dft_r2c_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, log10_Mcrit_LW_unfiltered);
 
 #pragma omp parallel shared(log10_Mcrit_LW_unfiltered) private(ct) num_threads(user_params->N_THREADS)
                 {
@@ -1075,16 +1030,8 @@ LOG_SUPER_DEBUG("beginning loop over R_ct");
                     if (R_ct > 0){// don't filter on cell size
                         filter_box(log10_Mcrit_LW_filtered, 1, global_params.HEAT_FILTER, R_values[R_ct]);
                     }
-                    if(user_params->USE_FFTW_WISDOM) {
-                        plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                     (fftwf_complex *)log10_Mcrit_LW_filtered, (float *)log10_Mcrit_LW_filtered, FFTW_WISDOM_ONLY);
-                    }
-                    else {
-                        plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
-                                                     (fftwf_complex *)log10_Mcrit_LW_filtered, (float *)log10_Mcrit_LW_filtered, FFTW_ESTIMATE);
-                    }
-                    fftwf_execute(plan);
-                    fftwf_destroy_plan(plan);
+                    dft_c2r_cube(user_params->USE_FFTW_WISDOM, user_params->HII_DIM, user_params->N_THREADS, log10_Mcrit_LW_filtered);
+
                     log10_Mcrit_LW_ave = 0; //recalculate it at this filtering scale
 #pragma omp parallel shared(log10_Mcrit_LW,log10_Mcrit_LW_filtered,log10_Mcrit_mol) private(i,j,k) num_threads(user_params->N_THREADS)
                     {

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -57,14 +57,10 @@ if (LOG_LEVEL >= DEBUG_LEVEL){
 
     // This is an entire re-write of Ts.c from 21cmFAST. You can refer back to Ts.c in 21cmFAST if this become a little obtuse. The computation has remained the same //
     omp_set_num_threads(user_params->N_THREADS);
-    fftwf_init_threads();
-    fftwf_plan_with_nthreads(user_params->N_THREADS);
-    fftwf_cleanup_threads();
 
     /////////////////// Defining variables for the computation of Ts.c //////////////
-    char wisdom_filename[500];
+
     FILE *F, *OUT;
-    fftwf_plan plan;
 
     unsigned long long ct, FCOLL_SHORT_FACTOR, box_ct;
 

--- a/src/py21cmfast/src/UsefulFunctions.c
+++ b/src/py21cmfast/src/UsefulFunctions.c
@@ -1,66 +1,6 @@
-// ----------------------------------------------------------------------------------------- //
-
-// Taken from INIT_PARAMS.H
-
-// ----------------------------------------------------------------------------------------- //
-
-
-
-#define MIDDLE (user_params_ufunc->DIM/2)
-#define D (unsigned long long)user_params_ufunc->DIM // the unsigned long long dimension
-#define MID ((unsigned long long)MIDDLE)
-#define VOLUME (user_params_ufunc->BOX_LEN*user_params_ufunc->BOX_LEN*user_params_ufunc->BOX_LEN) // in Mpc^3
-#define DELTA_K (TWOPI/user_params_ufunc->BOX_LEN)
-#define TOT_NUM_PIXELS ((unsigned long long)(D*D*D)) // no padding
-#define TOT_FFT_NUM_PIXELS ((unsigned long long)(D*D*2llu*(MID+1llu)))
-#define KSPACE_NUM_PIXELS ((unsigned long long)(D*D*(MID+1llu)))
-
-// Define some useful macros
-
-// for 3D complex array
-#define C_INDEX(x,y,z)((unsigned long long)((z)+(MID+1llu)*((y)+D*(x))))
-
-// for 3D real array with the FFT padding
-#define R_FFT_INDEX(x,y,z)((unsigned long long)((z)+2llu*(MID+1llu)*((y)+D*(x))))
-
-// for 3D real array with no padding
-#define R_INDEX(x,y,z)((unsigned long long)((z)+D*((y)+D*(x))))
-
-
-// ----------------------------------------------------------------------------------------- //
-
-// Taken from ANAL_PARAMS.H
-
-// ----------------------------------------------------------------------------------------- //
-
-
-
-#define HII_D (unsigned long long) (user_params_ufunc->HII_DIM)
-#define HII_MIDDLE (user_params_ufunc->HII_DIM/2)
-#define HII_MID ((unsigned long long)HII_MIDDLE)
-
-#define HII_TOT_NUM_PIXELS (unsigned long long)(HII_D*HII_D*HII_D)
-#define HII_TOT_FFT_NUM_PIXELS ((unsigned long long)(HII_D*HII_D*2llu*(HII_MID+1llu)))
-#define HII_KSPACE_NUM_PIXELS ((unsigned long long)(HII_D*HII_D*(HII_MID+1llu)))
-
-// INDEXING MACROS //
-// for 3D complex array
-#define HII_C_INDEX(x,y,z)((unsigned long long)((z)+(HII_MID+1llu)*((y)+HII_D*(x))))
-// for 3D real array with the FFT padding
-#define HII_R_FFT_INDEX(x,y,z)((unsigned long long)((z)+2llu*(HII_MID+1llu)*((y)+HII_D*(x))))
-// for 3D real array with no padding
-#define HII_R_INDEX(x,y,z)((unsigned long long)((z)+HII_D*((y)+HII_D*(x))))
-
-
-
-// ----------------------------------------------------------------------------------------- //
-
+// -------------------------------------------------------------------------------------
 // Taken from COSMOLOGY.H
-
-// ----------------------------------------------------------------------------------------- //
-
-
-
+// -------------------------------------------------------------------------------------
 #define Ho  (double) (cosmo_params_ufunc->hlittle*3.2407e-18) // s^-1 at z=0
 #define RHOcrit (double) ( (3.0*Ho*Ho / (8.0*PI*G)) * (CMperMPC*CMperMPC*CMperMPC)/Msun) // Msun Mpc^-3 ---- at z=0
 #define RHOcrit_cgs (double) (3.0*Ho*Ho / (8.0*PI*G)) // g pcm^-3 ---- at z=0
@@ -74,7 +14,6 @@ struct CosmoParams *cosmo_params_ufunc;
 struct UserParams *user_params_ufunc;
 
 void Broadcast_struct_global_UF(struct UserParams *user_params, struct CosmoParams *cosmo_params){
-
     cosmo_params_ufunc = cosmo_params;
     user_params_ufunc = user_params;
 }

--- a/src/py21cmfast/src/dft.c
+++ b/src/py21cmfast/src/dft.c
@@ -44,7 +44,7 @@ int dft_r2c_cube(bool use_wisdom, int dim, int n_threads, fftwf_complex *box){
                 LOG_WARNING("Cannot locate FFTW Wisdom: %s file not found. Reverting to FFTW_ESTIMATE.", wisdom_filename);
             }
         }
-        plan = fftwf_plan_dft_c2r_3d(dim, dim, dim, (float *)box, (fftwf_complex *)box, flag);
+        plan = fftwf_plan_dft_r2c_3d(dim, dim, dim, (float *)box, (fftwf_complex *)box, flag);
         fftwf_execute(plan);
         fftwf_destroy_plan(plan);
     }

--- a/src/py21cmfast/src/dft.c
+++ b/src/py21cmfast/src/dft.c
@@ -1,0 +1,169 @@
+int dft_c2r_cube(bool use_wisdom, int dim, int n_threads, fftwf_complex *box){
+    char wisdom_filename[500];
+    unsigned flag = FFTW_ESTIMATE;
+    int status;
+    fftwf_plan plan;
+
+    Try{
+        if(use_wisdom) {
+            // Check to see if the wisdom exists
+            sprintf(wisdom_filename,"%s/c2r_DIM%d_NTHREADS%d.",global_params.wisdoms_path, dim, n_threads);
+
+            if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
+                unsigned flag = FFTW_WISDOM_ONLY;
+            }
+            else {
+                LOG_WARNING("Cannot locate FFTW Wisdom: %s file not found. Reverting to FFTW_ESTIMATE.", wisdom_filename);
+            }
+        }
+        plan = fftwf_plan_dft_c2r_3d(dim, dim, dim, (fftwf_complex *)box, (float *)box, flag);
+        fftwf_execute(plan);
+        fftwf_destroy_plan(plan);
+    }
+    Catch(status){
+        return(status);
+    }
+    return(0);
+}
+
+int dft_r2c_cube(bool use_wisdom, int dim, int n_threads, fftwf_complex *box){
+    char wisdom_filename[500];
+    unsigned flag = FFTW_ESTIMATE;
+    int status;
+    fftwf_plan plan;
+
+    Try{
+        if(use_wisdom) {
+            // Check to see if the wisdom exists
+            sprintf(wisdom_filename,"%s/r2c_DIM%d_NTHREADS%d", global_params.wisdoms_path, dim, n_threads);
+
+            if(fftwf_import_wisdom_from_filename(wisdom_filename)!=0) {
+                unsigned flag = FFTW_WISDOM_ONLY;
+            }
+            else {
+                LOG_WARNING("Cannot locate FFTW Wisdom: %s file not found. Reverting to FFTW_ESTIMATE.", wisdom_filename);
+            }
+        }
+        plan = fftwf_plan_dft_c2r_3d(dim, dim, dim, (float *)box, (fftwf_complex *)box, flag);
+        fftwf_execute(plan);
+        fftwf_destroy_plan(plan);
+    }
+    Catch(status){
+        return(status);
+    }
+    return(0);
+}
+
+int CreateFFTWWisdoms(struct UserParams *user_params, struct CosmoParams *cosmo_params) {
+
+    int status;
+    char *wisdom_string;
+
+    Try{ // This Try wraps the entire function so we don't indent.
+
+        Broadcast_struct_global_UF(user_params,cosmo_params);
+
+        fftwf_plan plan;
+
+        char wisdom_filename[500];
+
+        int i,j,k;
+
+        omp_set_num_threads(user_params->N_THREADS);
+        fftwf_init_threads();
+        fftwf_plan_with_nthreads(user_params->N_THREADS);
+        fftwf_cleanup_threads();
+
+        // allocate array for the k-space and real-space boxes
+        fftwf_complex *HIRES_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*KSPACE_NUM_PIXELS);
+        fftwf_complex *LOWRES_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
+//
+//#pragma omp parallel shared(HIRES_box) private(i,j,k) num_threads(user_params->N_THREADS)
+//        {
+//#pragma omp for
+//            for (i=0; i<user_params->DIM; i++){
+//                for (j=0; j<user_params->DIM; j++){
+//                    for (k=0; k<=MIDDLE; k++){
+//                        HIRES_box[C_INDEX(i, j, k)] = 0.0;
+//                    }
+//                }
+//            }
+//        }
+//
+//#pragma omp parallel shared(LOWRES_box) private(i,j,k) num_threads(user_params->N_THREADS)
+//        {
+//#pragma omp for
+//            for (i=0; i<user_params->HII_DIM; i++){
+//                for (j=0; j<user_params->HII_DIM; j++){
+//                    for (k=0; k<=HII_MIDDLE; k++){
+//                        LOWRES_box[HII_C_INDEX(i, j, k)] = 0.0;
+//                    }
+//                }
+//            }
+//        }
+
+
+
+        sprintf(wisdom_filename,"%s/r2c_DIM%d_NTHREADS%d",global_params.wisdoms_path, user_params->DIM,user_params->N_THREADS);
+        if(fftwf_import_wisdom_from_filename(wisdom_filename)==0) {
+            plan = fftwf_plan_dft_r2c_3d(user_params->DIM, user_params->DIM, user_params->DIM,
+                                         (float *)HIRES_box, (fftwf_complex *)HIRES_box, FFTW_PATIENT);
+            fftwf_export_wisdom_to_filename(wisdom_filename);
+            fftwf_destroy_plan(plan);
+        }
+
+        sprintf(wisdom_filename,"%s/c2r_DIM%d_NTHREADS%d",global_params.wisdoms_path, user_params->DIM,user_params->N_THREADS);
+        if(fftwf_import_wisdom_from_filename(wisdom_filename)==0) {
+            plan = fftwf_plan_dft_c2r_3d(user_params->DIM, user_params->DIM, user_params->DIM,
+                                         (fftwf_complex *)HIRES_box, (float *)HIRES_box,  FFTW_PATIENT);
+            fftwf_export_wisdom_to_filename(wisdom_filename);
+            fftwf_destroy_plan(plan);
+        }
+
+        sprintf(wisdom_filename,"r2c_DIM%d_NTHREADS%d",global_params.wisdoms_path, user_params->HII_DIM,user_params->N_THREADS);
+        if(fftwf_import_wisdom_from_filename(wisdom_filename)==0) {
+            plan = fftwf_plan_dft_r2c_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
+                                         (float *)LOWRES_box, (fftwf_complex *)LOWRES_box, FFTW_PATIENT);
+            fftwf_export_wisdom_to_filename(wisdom_filename);
+            fftwf_destroy_plan(plan);
+        }
+
+        sprintf(wisdom_filename,"c2r_DIM%d_NTHREADS%d",global_params.wisdoms_path, user_params->HII_DIM,user_params->N_THREADS);
+        if(fftwf_import_wisdom_from_filename(wisdom_filename)==0) {
+            plan = fftwf_plan_dft_c2r_3d(user_params->HII_DIM, user_params->HII_DIM, user_params->HII_DIM,
+                                         (fftwf_complex *)LOWRES_box, (float *)LOWRES_box,  FFTW_PATIENT);
+            fftwf_export_wisdom_to_filename(wisdom_filename);
+            fftwf_destroy_plan(plan);
+        }
+
+        fftwf_cleanup_threads();
+        fftwf_cleanup();
+        fftwf_forget_wisdom();
+
+        // deallocate
+        fftwf_free(HIRES_box);
+        fftwf_free(LOWRES_box);
+
+
+    } // End of Try{}
+
+    Catch(status){
+        return(status);
+    }
+    return(0);
+}
+
+//int CreateFFTWWisdoms(struct UserParams *user_params, struct CosmoParams *cosmo_params) {
+//    fftwf_plan plan;
+//    int dim = 75;
+//
+//    // allocate array for the k-space and real-space boxes
+////    fftwf_complex *HIRES_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*dim*dim*(dim/2+1));
+//    fftwf_complex *oned_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*dim);
+//
+//    // Going to need to construct an FFTW_Wisdom for this box
+////    plan = fftwf_plan_dft_r2c_3d(dim,dim,dim, (float *)HIRES_box, (fftwf_complex *)HIRES_box, FFTW_PATIENT);
+//    plan = fftwf_plan_dft_1d(dim, oned_box, oned_box, FFTW_FORWARD, FFTW_PATIENT);
+//    printf("Made a plan!\n");
+//    fftwf_print_plan(plan);
+//}

--- a/src/py21cmfast/src/dft.c
+++ b/src/py21cmfast/src/dft.c
@@ -77,32 +77,6 @@ int CreateFFTWWisdoms(struct UserParams *user_params, struct CosmoParams *cosmo_
         // allocate array for the k-space and real-space boxes
         fftwf_complex *HIRES_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*KSPACE_NUM_PIXELS);
         fftwf_complex *LOWRES_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
-//
-//#pragma omp parallel shared(HIRES_box) private(i,j,k) num_threads(user_params->N_THREADS)
-//        {
-//#pragma omp for
-//            for (i=0; i<user_params->DIM; i++){
-//                for (j=0; j<user_params->DIM; j++){
-//                    for (k=0; k<=MIDDLE; k++){
-//                        HIRES_box[C_INDEX(i, j, k)] = 0.0;
-//                    }
-//                }
-//            }
-//        }
-//
-//#pragma omp parallel shared(LOWRES_box) private(i,j,k) num_threads(user_params->N_THREADS)
-//        {
-//#pragma omp for
-//            for (i=0; i<user_params->HII_DIM; i++){
-//                for (j=0; j<user_params->HII_DIM; j++){
-//                    for (k=0; k<=HII_MIDDLE; k++){
-//                        LOWRES_box[HII_C_INDEX(i, j, k)] = 0.0;
-//                    }
-//                }
-//            }
-//        }
-
-
 
         sprintf(wisdom_filename,"%s/r2c_DIM%d_NTHREADS%d",global_params.wisdoms_path, user_params->DIM,user_params->N_THREADS);
         if(fftwf_import_wisdom_from_filename(wisdom_filename)==0) {
@@ -152,18 +126,3 @@ int CreateFFTWWisdoms(struct UserParams *user_params, struct CosmoParams *cosmo_
     }
     return(0);
 }
-
-//int CreateFFTWWisdoms(struct UserParams *user_params, struct CosmoParams *cosmo_params) {
-//    fftwf_plan plan;
-//    int dim = 75;
-//
-//    // allocate array for the k-space and real-space boxes
-////    fftwf_complex *HIRES_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*dim*dim*(dim/2+1));
-//    fftwf_complex *oned_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*dim);
-//
-//    // Going to need to construct an FFTW_Wisdom for this box
-////    plan = fftwf_plan_dft_r2c_3d(dim,dim,dim, (float *)HIRES_box, (fftwf_complex *)HIRES_box, FFTW_PATIENT);
-//    plan = fftwf_plan_dft_1d(dim, oned_box, oned_box, FFTW_FORWARD, FFTW_PATIENT);
-//    printf("Made a plan!\n");
-//    fftwf_print_plan(plan);
-//}

--- a/src/py21cmfast/src/indexing.c
+++ b/src/py21cmfast/src/indexing.c
@@ -1,0 +1,70 @@
+/*
+    indexing.c -- Macros for indexing the cubic arrays, and their Fourier Transforms.
+
+    How this works:
+
+        The box size and dimensionalities (eg. D and HII_D) expressed here rely on
+        ``user_params_ufunc`` being initialized. This is initialized by
+        ``Broadcast_struct_global_UF`` in ``UsefulFunctions.c``. Thus, that function
+        must be called any time the user/cosmo params change.
+
+    A note on the Fourier Transform number of pixels and indexing:
+
+        Details on what the "padding" is can be found here:
+        http://www.fftw.org/fftw3_doc/Real_002ddata-DFT-Array-Format.html#Real_002ddata-DFT-Array-Format
+
+        In a nutshell, for the in-place transforms we do, there are symmetries in the
+        real-complex FT that mean the last axis needs to have 2*(N/2 + 1) entries,
+        with the division rounded down. For an even N, this means 2 extra entries on
+        the last axis, and for odd N, it means 1 extra entry. While these are required
+        to do the FFT, the extra spaces don't actually get used, and the indexing
+        macros (eg. R_FFT_INDEX) skip these extra bits to index the truly used array.
+*/
+
+// -------------------------------------------------------------------------------------
+// Convenience Constants
+// -------------------------------------------------------------------------------------
+#define VOLUME (user_params_ufunc->BOX_LEN*user_params_ufunc->BOX_LEN*user_params_ufunc->BOX_LEN) // in Mpc^3
+#define DELTA_K (TWOPI/user_params_ufunc->BOX_LEN)
+
+
+// -------------------------------------------------------------------------------------
+// Convenience Macros for hi-resolution boxes
+// -------------------------------------------------------------------------------------
+#define D (unsigned long long)user_params_ufunc->DIM // the unsigned long long dimension
+#define MIDDLE (user_params_ufunc->DIM/2)
+#define MID ((unsigned long long)MIDDLE)
+#define TOT_NUM_PIXELS ((unsigned long long)(D*D*D)) // no padding
+
+// Fourier-Transform numbers
+#define TOT_FFT_NUM_PIXELS ((unsigned long long)(D*D*2llu*(MID+1llu)))
+#define KSPACE_NUM_PIXELS ((unsigned long long)(D*D*(MID+1llu)))
+
+// INDEXING MACROS
+// for 3D complex array
+#define C_INDEX(x,y,z)((unsigned long long)((z)+(MID+1llu)*((y)+D*(x))))
+// for 3D real array with the FFT padding
+#define R_FFT_INDEX(x,y,z)((unsigned long long)((z)+2llu*(MID+1llu)*((y)+D*(x))))
+// for 3D real array with no padding
+#define R_INDEX(x,y,z)((unsigned long long)((z)+D*((y)+D*(x))))
+
+
+// -------------------------------------------------------------------------------------
+// Convenience Macros for low-resolution boxes
+// -------------------------------------------------------------------------------------
+#define HII_D (unsigned long long) (user_params_ufunc->HII_DIM)
+#define HII_MIDDLE (user_params_ufunc->HII_DIM/2)
+#define HII_MID ((unsigned long long)HII_MIDDLE)
+#define HII_TOT_NUM_PIXELS (unsigned long long)(HII_D*HII_D*HII_D)
+
+// Fourier-Transform numbers
+#define HII_TOT_FFT_NUM_PIXELS ((unsigned long long)(HII_D*HII_D*2llu*(HII_MID+1llu)))
+#define HII_KSPACE_NUM_PIXELS ((unsigned long long)(HII_D*HII_D*(HII_MID+1llu)))
+
+// INDEXING MACROS
+// for 3D complex array
+#define HII_C_INDEX(x,y,z)((unsigned long long)((z)+(HII_MID+1llu)*((y)+HII_D*(x))))
+// for 3D real array with the FFT padding
+#define HII_R_FFT_INDEX(x,y,z)((unsigned long long)((z)+2llu*(HII_MID+1llu)*((y)+HII_D*(x))))
+// for 3D real array with no padding
+#define HII_R_INDEX(x,y,z)((unsigned long long)((z)+HII_D*((y)+HII_D*(x))))

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -314,7 +314,10 @@ def construct_fftw_wisdoms(*, user_params=None, cosmo_params=None):
     cosmo_params = CosmoParams(cosmo_params)
 
     # Run the C code
-    return lib.CreateFFTWWisdoms(user_params(), cosmo_params())
+    if user_params.USE_FFTW_WISDOM:
+        return lib.CreateFFTWWisdoms(user_params(), cosmo_params())
+    else:
+        return 0
 
 
 def compute_tau(*, redshifts, global_xHI, user_params=None, cosmo_params=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ def setup_and_teardown_package(tmpdirec):
 
 @pytest.fixture(scope="session")
 def default_user_params():
-    return UserParams(HII_DIM=35, DIM=70, BOX_LEN=50)
+    return UserParams(HII_DIM=32, DIM=64, BOX_LEN=50)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ def setup_and_teardown_package(tmpdirec):
 
 @pytest.fixture(scope="session")
 def default_user_params():
-    return UserParams(HII_DIM=32, DIM=64, BOX_LEN=50)
+    return UserParams(HII_DIM=35, DIM=70, BOX_LEN=50)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_high_level_io.py
+++ b/tests/test_high_level_io.py
@@ -2,7 +2,6 @@ import pytest
 
 import h5py
 import numpy as np
-from os import path
 
 from py21cmfast import (
     BrightnessTemp,

--- a/tests/test_integration_features.py
+++ b/tests/test_integration_features.py
@@ -58,7 +58,7 @@ def test_power_spectra_coeval(redshift, kwargs, module_direc):
             # Note that if zprime_step_factor is set in kwargs, it will over-ride this.
             k, p, bt = prd.produce_coeval_power_spectra(redshift, **kwargs)
 
-    assert np.allclose(power, p, atol=1e-3, rtol=1e-2)
+    assert np.allclose(power, p, atol=1e-2, rtol=1e-2)
 
 
 @pytest.mark.parametrize("redshift,kwargs", options)


### PR DESCRIPTION
This partly addresses #179 with a quick workaround where wisdoms are used if found, and otherwise don't produce an error, just a warning. 

More importantly, it removes a lot of boilerplate code from several C files, replacing it with a two simple functions in `dft.c`.