### PR TITLE
maint: include tests in source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst CHANGELOG.rst build_cffi.py LICENSE
 recursive-include src *
 recursive-include user_data *
+recursive-include tests *


### PR DESCRIPTION
This simply includes the `tests/` directory in the source tarball that ends up on PyPI. This is useful for the `conda` build, which can then run some of the tests before deployment.