### PR TITLE
Updated generation of relvels to not require extra memory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Added
   class, or the Lightcone.
 * Ability to gather all evolutionary antecedents from a Coeval/Lightcone into the one
   file.
+* Fast and low-memory generation of relative-velocity (vcb) initial conditions. Eliminated hi-res vcb boxes, as they are never needed.
 
 Fixed
 ~~~~~

--- a/src/py21cmfast/outputs.py
+++ b/src/py21cmfast/outputs.py
@@ -123,7 +123,6 @@ class InitialConditions(_OutputStruct):
             self.user_params.tot_fft_num_pixels, dtype=np.float32
         )
 
-        self.hires_vcb = np.zeros(self.user_params.tot_fft_num_pixels, dtype=np.float32)
         self.lowres_vcb = np.zeros(
             self.user_params.HII_tot_num_pixels, dtype=np.float32
         )
@@ -152,7 +151,6 @@ class InitialConditions(_OutputStruct):
         self.hires_vz_2LPT.shape = hires_shape
 
         self.lowres_vcb.shape = shape
-        self.hires_vcb.shape = hires_shape
 
 
 class PerturbedField(_OutputStructZ):

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -77,7 +77,7 @@ struct FlagOptions{
 struct InitialConditions{
     float *lowres_density, *lowres_vx, *lowres_vy, *lowres_vz, *lowres_vx_2LPT, *lowres_vy_2LPT, *lowres_vz_2LPT;
     float *hires_density, *hires_vx, *hires_vy, *hires_vz, *hires_vx_2LPT, *hires_vy_2LPT, *hires_vz_2LPT; //cw addition
-    float *lowres_vcb, *hires_vcb;
+    float *lowres_vcb;
 };
 
 struct PerturbedField{

--- a/tests/test_initial_conditions.py
+++ b/tests/test_initial_conditions.py
@@ -28,7 +28,6 @@ def test_box_shape(ic):
     assert ic.hires_vx_2LPT.shape == hires_shape
     assert ic.hires_vy_2LPT.shape == hires_shape
     assert ic.hires_vz_2LPT.shape == hires_shape
-    assert ic.hires_vcb.shape == hires_shape
 
     assert ic.cosmo_params == wrapper.CosmoParams()
 
@@ -75,20 +74,12 @@ def test_relvels():
         ),
     )
 
-    vcbrms = np.sqrt(np.mean(ic.hires_vcb ** 2))
-    vcbavg = np.mean(ic.hires_vcb)
-
     vcbrms_lowres = np.sqrt(np.mean(ic.lowres_vcb ** 2))
     vcbavg_lowres = np.mean(ic.lowres_vcb)
 
-    assert vcbrms > 25.0
-    assert vcbrms < 35.0  # it should be about 30 km/s, so we check it is around it
-
+    # we test the lowres box
+    # rms should be about 30 km/s for LCDM, so we check it is finite and not far off
     # the average should be 0.92*vrms, since it follows a maxwell boltzmann
-    assert vcbavg < 0.95 * vcbrms
-    assert vcbavg > 0.90 * vcbrms
-
-    # we also test the lowres box. Increase its error margin because its low res.
     assert vcbrms_lowres > 20.0
     assert vcbrms_lowres < 40.0
     assert vcbavg_lowres < 0.97 * vcbrms_lowres


### PR DESCRIPTION
I re-used the HIRES_box variable to loop over the 3 v_cb directions and add them in quadrature directly to boxes->lowres_vcb. The high-res vcb box is never used, so there isn't much point in generating it.

This is fast and does not add any memory overload over a no-vcb run. The modification follows what was already in generateICs.c for the perturbation velocities, though with different k weightings (to track the power in vcb).

Plots attached are the old vcb both in lowres and hires (which look very similar as vcb has not power at small scales), and the new vcb. Which is identical to the old lowres.

![Screen Shot 2021-02-08 at 9 11 12 PM](https://user-images.githubusercontent.com/22434409/107403309-f4f05680-6ad2-11eb-83bc-047a732d4ba7.png)

![Screen Shot 2021-02-09 at 12 15 03 PM](https://user-images.githubusercontent.com/22434409/107403314-f588ed00-6ad2-11eb-8f6c-5e174b70092d.png)
