### PR TITLE
Fixed relvel generation with hires PT

### DIFF
--- a/src/py21cmfast/src/GenerateICs.c
+++ b/src/py21cmfast/src/GenerateICs.c
@@ -370,7 +370,7 @@ int ComputeInitialConditions(
 
 
 
-      #pragma omp parallel shared(boxes,HIRES_box,f_pixel_factor,ii,dimension) private(i,j,k,vcb_i) num_threads(user_params->N_THREADS)
+      #pragma omp parallel shared(boxes,HIRES_box,f_pixel_factor,ii) private(i,j,k,vcb_i) num_threads(user_params->N_THREADS)
               {
       #pragma omp for
                   for (i=0; i<user_params->HII_DIM; i++){

--- a/src/py21cmfast/src/GenerateICs.c
+++ b/src/py21cmfast/src/GenerateICs.c
@@ -373,9 +373,9 @@ int ComputeInitialConditions(
       #pragma omp parallel shared(boxes,HIRES_box,f_pixel_factor,ii,dimension) private(i,j,k,vcb_i) num_threads(user_params->N_THREADS)
               {
       #pragma omp for
-                  for (i=0; i<dimension; i++){
-                      for (j=0; j<dimension; j++){
-                          for (k=0; k<dimension; k++){
+                  for (i=0; i<user_params->HII_DIM; i++){
+                      for (j=0; j<user_params->HII_DIM; j++){
+                          for (k=0; k<user_params->HII_DIM; k++){
                             vcb_i = *((float *)HIRES_box + R_FFT_INDEX((unsigned long long)(i*f_pixel_factor+0.5),
                                                              (unsigned long long)(j*f_pixel_factor+0.5),
                                                              (unsigned long long)(k*f_pixel_factor+0.5)));
@@ -390,9 +390,9 @@ int ComputeInitialConditions(
 
 
 //now we take the sqrt of that and normalize the FFT
-    for (i=0; i<dimension; i++){
-        for (j=0; j<dimension; j++){
-            for (k=0; k<dimension; k++){
+    for (i=0; i<user_params->HII_DIM; i++){
+        for (j=0; j<user_params->HII_DIM; j++){
+            for (k=0; k<user_params->HII_DIM; k++){
               boxes->lowres_vcb[HII_R_INDEX(i,j,k)] = sqrt(boxes->lowres_vcb[HII_R_INDEX(i,j,k)])/VOLUME;
             }
         }


### PR DESCRIPTION
Code was crashing with "`PERTURB_ON_HIGH_RES`": True, because the `boxes->lowres_vcb` loop indices were set to `dimension` rather than `HII_DIM`