### PR TITLE
More informative errors

### DIFF
--- a/src/py21cmfast/_utils.py
+++ b/src/py21cmfast/_utils.py
@@ -39,7 +39,7 @@ class FatalCError(Exception):
 class ErrorIO(FatalCError):
     """An exception when an error occurs with file I/O."""
 
-    default_message = "Expected file could not be found! (check the LOG for more info"
+    default_message = "Expected file could not be found! (check the LOG for more info)"
 
 
 class GSLError(ParameterError):
@@ -123,7 +123,7 @@ def _process_exitcode(exitcode, fnc, args):
                     MASSDEPZETAERROR: MassDepZetaError,
                     MEMORYALLOCERROR: MemoryAllocError,
                 }[exitcode]
-            except KeyError:
+            except KeyError:  # pragma: no cover
                 raise FatalCError(
                     "Unknown error in C. Please report this error!"
                 )  # Unknown C code

--- a/src/py21cmfast/_utils.py
+++ b/src/py21cmfast/_utils.py
@@ -34,6 +34,94 @@ class FatalCError(Exception):
         super().__init__(msg or default_message)
 
 
+class ErrorIO(FatalCError):
+    """An exception when an error occurs with file I/O."""
+
+    def __init__(self):
+        error_message = (
+            "Expected file could not be found! (check the LOG for more info)"
+        )
+        super().__init__(error_message)
+
+
+class GSLError(FatalCError):
+    """An exception when a GSL routine encounters an error."""
+
+    def __init__(self):
+        error_message = "A GSL routine has errored! (check the LOG for more info)"
+        super().__init__(error_message)
+
+
+class ErrorValue(FatalCError):
+    """An exception when a function takes an unexpected input."""
+
+    def __init__(self):
+        error_message = "An incorrect argument has been defined or passed! (check the LOG for more info)"
+        super().__init__(error_message)
+
+
+class PhotonConsError(FatalCError):
+    """An exception when the photon non-conservation correction routine errors."""
+
+    def __init__(self):
+        error_message = "An error has occured with the Photon non-conservation correction! (check the LOG for more info)"
+        super().__init__(error_message)
+
+
+class TableGenerationError(FatalCError):
+    """An exception when an issue arises populating one of the interpolation tables."""
+
+    def __init__(self):
+        error_message = """An error has occured when generating an interpolation table!
+                This has likely occured due to the choice of input AstroParams (check the LOG for more info)"""
+        super().__init__(error_message)
+
+
+class TableEvaluationError(FatalCError):
+    """An exception when an issue arises populating one of the interpolation tables."""
+
+    def __init__(self):
+        error_message = """An error has occured when evaluating an interpolation table!
+                This can sometimes occur due to small boxes (either small DIM/HII_DIM or BOX_LEN) (check the LOG for more info)"""
+        super().__init__(error_message)
+
+
+class InfinityorNaNError(FatalCError):
+    """An exception when an infinity or NaN is encountered in a calculated quantity."""
+
+    def __init__(self):
+        error_message = """Something has returned an infinity or a NaN! This could be due to an issue with an
+                input parameter choice (check the LOG for more info)"""
+        super().__init__(error_message)
+
+
+class MassDepZetaError(FatalCError):
+    """An exception when determining the bisection for stellar mass/escape fraction."""
+
+    def __init__(self):
+        error_message = """There is an issue with the choice of parameters under MASS_DEPENDENT_ZETA. Could be an issue with
+                any of the chosen F_STAR10, ALPHA_STAR, F_ESC10 or ALPHA_ESC."""
+        super().__init__(error_message)
+
+
+class MemoryAllocError(FatalCError):
+    """An exception when unable to allocated memory."""
+
+    def __init__(self):
+        error_message = """An error has occured while attempting to allocate memory! (check the LOG for more info)"""
+        super().__init__(error_message)
+
+
+class FileError(FatalCError):
+    """Unknown what this refers to at this point, maintain for now."""
+
+    def __init__(self):
+        error_message = (
+            """I don't know what this one is, possibly redundant with IOERROR?"""
+        )
+        super().__init__(error_message)
+
+
 SUCCESS = 0
 IOERROR = 1
 GSLERROR = 2
@@ -60,49 +148,23 @@ def _process_exitcode(exitcode, fnc, args):
             raise FatalCError
         """
         if exitcode is IOERROR:
-            raise FatalCError(
-                "Expected file could not be found! (check the LOG for more info)"
-            )
+            raise ErrorIO
         elif exitcode is GSLERROR:
-            raise FatalCError(
-                "A GSL routine has errored! (check the LOG for more info)"
-            )
+            raise GSLError
         elif exitcode is VALUEERROR:
-            raise FatalCError(
-                "An incorrect argument has been defined or passed! (check the LOG for more info)"
-            )
+            raise ErrorValue
         elif exitcode is PHOTONCONSERROR:
-            raise FatalCError(
-                "An error has occured with the Photon non-conservation correction! (check the LOG for more info)"
-            )
+            raise PhotonConsError
         elif exitcode is TABLEGENERATIONERROR:
-            raise FatalCError(
-                """An error has occured when generating an interpolation table!
-                This has likely occured due to the choice of input AstroParams (check the LOG for more info)"""
-            )
+            raise TableGenerationError
         elif exitcode is TABLEEVALUATIONERROR:
-            raise FatalCError(
-                """An error has occured when evaluating an interpolation table!
-                This can sometimes occur due to small boxes (either small DIM/HII_DIM or BOX_LEN) (check the LOG for more info)"""
-            )
-        elif exitcode is INFINITYORNANERROR:
-            raise FatalCError(
-                """Something has returned an infinity or a NaN! This could be due to an issue with an
-                input parameter choice (check the LOG for more info)"""
-            )
+            raise TableEvaluationError
         elif exitcode is MASSDEPZETAERROR:
-            raise FatalCError(
-                """There is an issue with the choice of parameters under MASS_DEPENDENT_ZETA. Could be an issue with
-                any of the chosen F_STAR10, ALPHA_STAR, F_ESC10 or ALPHA_ESC."""
-            )
+            raise MassDepZetaError
         elif exitcode is MEMORYALLOCERROR:
-            raise FatalCError(
-                "An error has occured while attempting to allocate memory! (check the LOG for more info)"
-            )
+            raise MEMORYALLOCERROR
         elif exitcode is FILEERROR:
-            raise FatalCError(
-                "I don't know what this one is, possibly redundant with IOERROR?"
-            )
+            raise FileError
         else:  # Unknown C code
             raise FatalCError("Unknown error in C. Please report this error!")
 

--- a/src/py21cmfast/_utils.py
+++ b/src/py21cmfast/_utils.py
@@ -38,9 +38,14 @@ SUCCESS = 0
 IOERROR = 1
 GSLERROR = 2
 VALUEERROR = 3
-PARAMETERERROR = 4
-MEMORYALLOCERROR = 5
-FILEERROR = 6
+"""PARAMETERERROR = 4"""
+PHOTONCONSERROR = 4
+TABLEGENERATIONERROR = 5
+TABLEEVALUATIONERROR = 6
+INFINITYORNANERROR = 7
+MASSDEPZETAERROR = 8
+MEMORYALLOCERROR = 9
+FILEERROR = 10
 
 
 def _process_exitcode(exitcode, fnc, args):
@@ -48,10 +53,56 @@ def _process_exitcode(exitcode, fnc, args):
     if exitcode != SUCCESS:
         logger.error(f"In function: {fnc.__name__}.  Arguments: {args}")
 
+        """
         if exitcode in (GSLERROR, PARAMETERERROR):
             raise ParameterError
         elif exitcode in (IOERROR, VALUEERROR, MEMORYALLOCERROR, FILEERROR):
             raise FatalCError
+        """
+        if exitcode is IOERROR:
+            raise FatalCError(
+                "Expected file could not be found! (check the LOG for more info)"
+            )
+        elif exitcode is GSLERROR:
+            raise FatalCError(
+                "A GSL routine has errored! (check the LOG for more info)"
+            )
+        elif exitcode is VALUEERROR:
+            raise FatalCError(
+                "An incorrect argument has been defined or passed! (check the LOG for more info)"
+            )
+        elif exitcode is PHOTONCONSERROR:
+            raise FatalCError(
+                "An error has occured with the Photon non-conservation correction! (check the LOG for more info)"
+            )
+        elif exitcode is TABLEGENERATIONERROR:
+            raise FatalCError(
+                """An error has occured when generating an interpolation table!
+                This has likely occured due to the choice of input AstroParams (check the LOG for more info)"""
+            )
+        elif exitcode is TABLEEVALUATIONERROR:
+            raise FatalCError(
+                """An error has occured when evaluating an interpolation table!
+                This can sometimes occur due to small boxes (either small DIM/HII_DIM or BOX_LEN) (check the LOG for more info)"""
+            )
+        elif exitcode is INFINITYORNANERROR:
+            raise FatalCError(
+                """Something has returned an infinity or a NaN! This could be due to an issue with an
+                input parameter choice (check the LOG for more info)"""
+            )
+        elif exitcode is MASSDEPZETAERROR:
+            raise FatalCError(
+                """There is an issue with the choice of parameters under MASS_DEPENDENT_ZETA. Could be an issue with
+                any of the chosen F_STAR10, ALPHA_STAR, F_ESC10 or ALPHA_ESC."""
+            )
+        elif exitcode is MEMORYALLOCERROR:
+            raise FatalCError(
+                "An error has occured while attempting to allocate memory! (check the LOG for more info)"
+            )
+        elif exitcode is FILEERROR:
+            raise FatalCError(
+                "I don't know what this one is, possibly redundant with IOERROR?"
+            )
         else:  # Unknown C code
             raise FatalCError("Unknown error in C. Please report this error!")
 

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -875,3 +875,32 @@ class AstroParams(StructWithDefaults):
     def X_RAY_Tvir_MIN(self):
         """Minimum virial temperature of X-ray emitting sources (unlogged and set dynamically)."""
         return self._X_RAY_Tvir_MIN if self._X_RAY_Tvir_MIN else self.ION_Tvir_MIN
+
+    @property
+    def NU_X_THRESH(self):
+        """Check if the choice of NU_X_THRESH is sensible."""
+        if self._NU_X_THRESH < 100.0:
+            raise ValueError(
+                "Chosen NU_X_THRESH is < 100 eV. NU_X_THRESH must be above 100 eV as it describes X-ray photons"
+            )
+        elif self._NU_X_THRESH >= global_params.NU_X_BAND_MAX:
+            raise ValueError(
+                """
+                Chosen NU_X_THRESH > {}, which is the upper limit of the adopted X-ray band
+                (fiducially the soft band 0.5 - 2.0 keV). If you know what you are doing with this
+                choice, please modify the global parameter: NU_X_BAND_MAX""".format(
+                    global_params.NU_X_BAND_MAX
+                )
+            )
+        else:
+            if global_params.NU_X_BAND_MAX > global_params.NU_X_MAX:
+                raise ValueError(
+                    """
+                    Chosen NU_X_BAND_MAX > {}, which is the upper limit of X-ray integrals (fiducially 10 keV)
+                    If you know what you are doing, please modify the global parameter:
+                    NU_X_MAX""".format(
+                        global_params.NU_X_MAX
+                    )
+                )
+            else:
+                return self._NU_X_THRESH

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -904,3 +904,11 @@ class AstroParams(StructWithDefaults):
                 )
             else:
                 return self._NU_X_THRESH
+
+    @property
+    def t_STAR(self):
+        """Check if the choice of NU_X_THRESH is sensible."""
+        if self._t_STAR <= 0.0 or self._t_STAR > 1.0:
+            raise ValueError("t_STAR must be above zero and less than or equal to one")
+        else:
+            return self._t_STAR

--- a/src/py21cmfast/src/BrightnessTemperatureBox.c
+++ b/src/py21cmfast/src/BrightnessTemperatureBox.c
@@ -98,7 +98,8 @@ int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct
 
     if(isfinite(ave)==0) {
         LOG_ERROR("Average brightness temperature is infinite or NaN!");
-        Throw(ParameterError);
+//        Throw(ParameterError);
+        Throw(InfinityorNaNError);
     }
 
     ave /= (float)HII_TOT_NUM_PIXELS;
@@ -456,7 +457,8 @@ int ComputeBrightnessTemp(float redshift, struct UserParams *user_params, struct
 
     if(isfinite(ave)==0) {
         LOG_ERROR("Average brightness temperature (after including velocities) is infinite or NaN!");
-        Throw(ParameterError);
+//        Throw(ParameterError);
+        Throw(InfinityorNaNError);
     }
 
     LOG_DEBUG("z = %.2f, ave Tb = %e", redshift, ave);

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -169,7 +169,10 @@ LOG_DEBUG("PhotonCons data:");
 LOG_DEBUG("original redshift=%f, updated redshift=%f delta-z = %f", stored_redshift, redshift, absolute_delta_z);
         if(isfinite(redshift)==0 || isfinite(absolute_delta_z)==0) {
             LOG_ERROR("Updated photon non-conservation redshift is either infinite or NaN!");
-            Throw(ParameterError);
+            LOG_ERROR("This can sometimes occur when reionisation stalls (i.e. extremely low"\
+                      "F_ESC or F_STAR or not enough sources)");
+//            Throw(ParameterError);
+            Throw(PhotonConsError);
         }
     }
 
@@ -597,14 +600,16 @@ LOG_SUPER_DEBUG("sigma table has been initialised");
 
     if(isfinite(box->mean_f_coll)==0) {
         LOG_ERROR("Mean collapse fraction is either infinite or NaN!");
-        Throw(ParameterError);
+//        Throw(ParameterError);
+        Throw(InfinityorNaNError);
     }
 LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll: %e", box->mean_f_coll);
 
     if (flag_options->USE_MINI_HALOS){
         if(isfinite(box->mean_f_coll_MINI)==0) {
             LOG_ERROR("Mean collapse fraction of MINI is either infinite or NaN!");
-            Throw(ParameterError);
+//            Throw(ParameterError);
+            Throw(InfinityorNaNError);
         }
 LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll_MINI: %e", box->mean_f_coll_MINI);
     }
@@ -1158,7 +1163,8 @@ LOG_ULTRA_DEBUG("while loop for until RtoM(R)=%f reaches M_MIN=%f", RtoM(R), M_M
                                             x,y,z,curr_dens,prev_dens,previous_ionize_box->Fcoll[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)],\
                                             Splined_Fcoll, prev_Splined_Fcoll, curr_dens, prev_dens, \
                                             log10_Mturnover, *((float *)log10_Mturnover_filtered + HII_R_FFT_INDEX(x,y,z)));
-                                    Throw(ParameterError);
+//                                    Throw(ParameterError);
+                                    Throw(InfinityorNaNError);
                                 }
 
                                 if (Splined_Fcoll_MINI > 1.) Splined_Fcoll_MINI = 1.;
@@ -1191,7 +1197,8 @@ LOG_ULTRA_DEBUG("while loop for until RtoM(R)=%f reaches M_MIN=%f", RtoM(R), M_M
                                               log10_Nion_spline_MINI[overdense_int +1+ NSFR_low* log10_Mturnover_MINI_int   ], \
                                               log10_Nion_spline_MINI[overdense_int   + NSFR_low*(log10_Mturnover_MINI_int+1)],  \
                                               log10_Nion_spline_MINI[overdense_int +1+ NSFR_low*(log10_Mturnover_MINI_int+1)]);
-                                    Throw(ParameterError);
+//                                    Throw(ParameterError);
+                                    Throw(InfinityorNaNError);
                                 }
                             }
                             else{
@@ -1206,18 +1213,21 @@ LOG_ULTRA_DEBUG("while loop for until RtoM(R)=%f reaches M_MIN=%f", RtoM(R), M_M
             for (i = 0; i < user_params->N_THREADS; i++) {
                 if (overdense_int_boundexceeded_threaded[i] == 1) {
                     LOG_ERROR("I have overstepped my allocated memory for one of the interpolation tables for the nion_splines");
-                    Throw(ParameterError);
+//                    Throw(ParameterError);
+                    Throw(TableEvaluationError);
                 }
             }
             if(isfinite(f_coll)==0) {
                 LOG_ERROR("f_coll is either infinite or NaN!");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(InfinityorNaNError);
             }
             f_coll /= (double) HII_TOT_NUM_PIXELS;
 
             if(isfinite(f_coll_MINI)==0) {
                 LOG_ERROR("f_coll_MINI is either infinite or NaN!");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(InfinityorNaNError);
             }
 
             f_coll_MINI /= (double) HII_TOT_NUM_PIXELS;
@@ -1433,7 +1443,8 @@ LOG_ULTRA_DEBUG("while loop for until RtoM(R)=%f reaches M_MIN=%f", RtoM(R), M_M
                     if(isfinite(box->temp_kinetic_all_gas[HII_R_INDEX(x,y,z)])==0){
                         LOG_ERROR("Tk after fully ioinzation is either infinite or a Nan. Something has gone wrong "\
                                   "in the temperature calculation: z_re=%.4f, redshift=%.4f, curr_dens=%.4e", box->z_re_box[HII_R_INDEX(x,y,z)], redshift, curr_dens);
-                        Throw(ParameterError);
+//                        Throw(ParameterError);
+                        Throw(InfinityorNaNError);
                     }
                 }
             }
@@ -1456,7 +1467,8 @@ LOG_ULTRA_DEBUG("while loop for until RtoM(R)=%f reaches M_MIN=%f", RtoM(R), M_M
         if (isfinite(global_xH) == 0) {
             LOG_ERROR(
                     "Neutral fraction is either infinite or a Nan. Something has gone wrong in the ionisation calculation!");
-            Throw(ParameterError);
+//            Throw(ParameterError);
+            Throw(InfinityorNaNError);
         }
 
         // update the N_rec field
@@ -1498,7 +1510,8 @@ LOG_ULTRA_DEBUG("while loop for until RtoM(R)=%f reaches M_MIN=%f", RtoM(R), M_M
 
             if (something_finite_or_infinite) {
                 LOG_ERROR("Recombinations have returned either an infinite or NaN value.");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(InfinityorNaNError);
             }
         }
 

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -871,7 +871,8 @@ LOG_SUPER_DEBUG("got density gridpoints");
 
                 if(redshift_int_Nion_z < 0 || (redshift_int_Nion_z + 1) > (zpp_interp_points_SFR - 1)) {
                     LOG_ERROR("I have overstepped my allocated memory for the interpolation table Nion_z_val");
-                    Throw(ParameterError);
+//                    Throw(ParameterError);
+                    Throw(TableEvaluationError);
                 }
 
                 redshift_table_Nion_z = determine_zpp_min + zpp_bin_width*(float)redshift_int_Nion_z;
@@ -1043,7 +1044,8 @@ LOG_SUPER_DEBUG("beginning loop over R_ct");
 
                     if(redshift_int_SFRD < 0 || (redshift_int_SFRD + 1) > (zpp_interp_points_SFR - 1)) {
                         LOG_ERROR("I have overstepped my allocated memory for the interpolation table SFRD_val");
-                        Throw(ParameterError);
+//                        Throw(ParameterError);
+                        Throw(TableEvaluationError);
                     }
 
                     redshift_table_SFRD = determine_zpp_min + zpp_bin_width*(float)redshift_int_SFRD;
@@ -1121,7 +1123,8 @@ LOG_SUPER_DEBUG("beginning loop over R_ct");
 
                     if(zpp_gridpoint1_int < 0 || (zpp_gridpoint1_int + 1) > (zpp_interp_points_SFR - 1)) {
                         LOG_ERROR("I have overstepped my allocated memory for the interpolation table fcoll_R_grid");
-                        Throw(ParameterError);
+//                        Throw(ParameterError);
+                        Throw(TableEvaluationError);
                     }
 
                     zpp_gridpoint1 = determine_zpp_min + zpp_bin_width*(float)zpp_gridpoint1_int;
@@ -1185,7 +1188,8 @@ LOG_SUPER_DEBUG("beginning loop over R_ct");
 
                     if(isfinite(freq_int_heat_tbl[x_e_ct][R_ct])==0 || isfinite(freq_int_ion_tbl[x_e_ct][R_ct])==0 || isfinite(freq_int_lya_tbl[x_e_ct][R_ct])==0) {
                         LOG_ERROR("One of the frequency interpolation tables has an infinity or a NaN");
-                        Throw(ParameterError);
+//                        Throw(ParameterError);
+                        Throw(TableGenerationError);
                     }
                 }
             }
@@ -1273,7 +1277,8 @@ LOG_SUPER_DEBUG("beginning loop over R_ct");
                 for (x_e_ct = 0; x_e_ct < x_int_NXHII; x_e_ct++){
                     if(isfinite(freq_int_heat_tbl[x_e_ct][R_ct])==0 || isfinite(freq_int_ion_tbl[x_e_ct][R_ct])==0 || isfinite(freq_int_lya_tbl[x_e_ct][R_ct])==0) {
                         LOG_ERROR("One of the frequency interpolation tables has an infinity or a NaN");
-                        Throw(ParameterError);
+//                        Throw(ParameterError);
+                        Throw(TableGenerationError);
                     }
                 }
             }
@@ -1309,7 +1314,8 @@ LOG_SUPER_DEBUG("finished looping over R_ct filter steps");
                     }
                     if(table_int_boundexceeded==1) {
                         LOG_ERROR("I have overstepped my allocated memory for one of the interpolation tables of fcoll");
-                        Throw(ParameterError);
+//                        Throw(ParameterError);
+                        Throw(TableEvaluationError);
                     }
                 }
             }
@@ -1345,7 +1351,8 @@ LOG_SUPER_DEBUG("finished looping over R_ct filter steps");
                 for(i=0;i<user_params->N_THREADS;i++) {
                     if(table_int_boundexceeded_threaded[i]==1) {
                         LOG_ERROR("I have overstepped my allocated memory for one of the interpolation tables of fcoll");
-                        Throw(ParameterError);
+//                        Throw(ParameterError);
+                        Throw(TableEvaluationError);
                     }
                 }
             }
@@ -1685,7 +1692,8 @@ LOG_SUPER_DEBUG("looping over box...");
                 for(i=0;i<user_params->N_THREADS;i++) {
                     if(fcoll_int_boundexceeded_threaded[omp_get_thread_num()]==1) {
                         LOG_ERROR("I have overstepped my allocated memory for one of the interpolation tables for the fcoll/nion_splines");
-                        Throw(ParameterError);
+//                        Throw(ParameterError);
+                        Throw(TableEvaluationError);
                     }
                 }
 
@@ -2100,7 +2108,8 @@ LOG_SUPER_DEBUG("looping over box...");
             for(i=0;i<user_params->N_THREADS; i++) {
                 if(table_int_boundexceeded_threaded[i]==1) {
                     LOG_ERROR("I have overstepped my allocated memory for one of the interpolation tables of dfcoll_dz_val");
-                    Throw(ParameterError);
+//                    Throw(ParameterError);
+                    Throw(TableEvaluationError);
                 }
             }
         }
@@ -2108,7 +2117,8 @@ LOG_SUPER_DEBUG("looping over box...");
         for (box_ct=0; box_ct<HII_TOT_NUM_PIXELS; box_ct++){
             if(isfinite(this_spin_temp->Ts_box[box_ct])==0) {
                 LOG_ERROR("Estimated spin temperature is either infinite of NaN!");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(InfinityorNaNError);
             }
         }
 

--- a/src/py21cmfast/src/UsefulFunctions.c
+++ b/src/py21cmfast/src/UsefulFunctions.c
@@ -816,7 +816,8 @@ double reionization_feedback(float z, float Gamma_halo_HII, float z_IN){
     The following functions are simply for testing the exception framework
 */
 void FunctionThatThrows(){
-    Throw(ParameterError);
+//    Throw(ParameterError);
+    Throw(PhotonConsError);
 }
 
 int SomethingThatCatches(bool sub_func){
@@ -824,7 +825,8 @@ int SomethingThatCatches(bool sub_func){
     int status;
     Try{
         if(sub_func) FunctionThatThrows();
-        else Throw(ParameterError);
+        else Throw(PhotonConsError);
+//        else Throw(ParameterError);
     }
     Catch(status){
         return status;
@@ -837,7 +839,8 @@ int FunctionThatCatches(bool sub_func, bool pass, double *result){
     if(!pass){
         Try{
             if(sub_func) FunctionThatThrows();
-            else Throw(ParameterError);
+            else Throw(PhotonConsError);
+//            else Throw(ParameterError);
         }
         Catch(status){
             LOG_DEBUG("Caught the problem with status %d.", status);

--- a/src/py21cmfast/src/UsefulFunctions.c
+++ b/src/py21cmfast/src/UsefulFunctions.c
@@ -816,7 +816,6 @@ double reionization_feedback(float z, float Gamma_halo_HII, float z_IN){
     The following functions are simply for testing the exception framework
 */
 void FunctionThatThrows(){
-//    Throw(ParameterError);
     Throw(PhotonConsError);
 }
 
@@ -826,7 +825,6 @@ int SomethingThatCatches(bool sub_func){
     Try{
         if(sub_func) FunctionThatThrows();
         else Throw(PhotonConsError);
-//        else Throw(ParameterError);
     }
     Catch(status){
         return status;
@@ -840,7 +838,6 @@ int FunctionThatCatches(bool sub_func, bool pass, double *result){
         Try{
             if(sub_func) FunctionThatThrows();
             else Throw(PhotonConsError);
-//            else Throw(ParameterError);
         }
         Catch(status){
             LOG_DEBUG("Caught the problem with status %d.", status);

--- a/src/py21cmfast/src/exceptions.h
+++ b/src/py21cmfast/src/exceptions.h
@@ -9,8 +9,13 @@ struct exception_context the_exception_context[1];
 #define IOError 1
 #define GSLError 2
 #define ValueError 3
-#define ParameterError 4
-#define MemoryAllocError 5
-#define FileError 6
+#define PhotonConsError 4
+#define TableGenerationError 5
+#define TableEvaluationError 6
+#define InfinityorNaNError 7
+#define MassDepZetaError 8
+//#define ParameterError 4
+#define MemoryAllocError 9
+#define FileError 10
 
 #define GSL_ERROR(status) if(status>0) {LOG_ERROR("GSL Error Encountered (Code = %d): %s", status, gsl_strerror(status)); Throw(GSLError);}

--- a/src/py21cmfast/src/exceptions.h
+++ b/src/py21cmfast/src/exceptions.h
@@ -14,8 +14,6 @@ struct exception_context the_exception_context[1];
 #define TableEvaluationError 6
 #define InfinityorNaNError 7
 #define MassDepZetaError 8
-//#define ParameterError 4
 #define MemoryAllocError 9
-#define FileError 10
 
 #define GSL_ERROR(status) if(status>0) {LOG_ERROR("GSL Error Encountered (Code = %d): %s", status, gsl_strerror(status)); Throw(GSLError);}

--- a/src/py21cmfast/src/heating_helper_progs.c
+++ b/src/py21cmfast/src/heating_helper_progs.c
@@ -1168,8 +1168,9 @@ double nu_tau_one_MINI(double zp, double zpp, double x_e, double HI_filling_fact
 
     // check if too ionized
     if (x_e > 0.9999){
-        LOG_ERROR("x_e value is too close to 1 for convergence.");
-        Throw(ParameterError);
+//        LOG_ERROR("x_e value is too close to 1 for convergence.");
+//        Throw(ParameterError);
+        return global_params.NU_X_THRESH;
     }
 
     // select solver and allocate memory
@@ -1235,7 +1236,8 @@ double nu_tau_one(double zp, double zpp, double x_e, double HI_filling_factor_zp
 
     // check if too ionized
     if (x_e > 0.9999){
-        Throw(ParameterError);
+//        Throw(ParameterError);
+        return global_params.NU_X_THRESH;
     }
 
     // select solver and allocate memory

--- a/src/py21cmfast/src/heating_helper_progs.c
+++ b/src/py21cmfast/src/heating_helper_progs.c
@@ -1217,7 +1217,8 @@ double nu_tau_one_MINI(double zp, double zpp, double x_e, double HI_filling_fact
 
     if(!isfinite(r)){
         LOG_ERROR("Value for nu_tau_one_MINI is infinite or NAN");
-        Throw(ParameterError);
+//        Throw(ParameterError);
+        Throw(InfinityorNaNError);
     }
 
     return r;
@@ -1282,7 +1283,8 @@ double nu_tau_one(double zp, double zpp, double x_e, double HI_filling_factor_zp
 
     if(!isfinite(r)){
         LOG_ERROR("nu_tau_one is infinite or NAN");
-        Throw(ParameterError);
+//        Throw(ParameterError);
+        Throw(InfinityorNaNError);
     }
 
     return r;

--- a/src/py21cmfast/src/heating_helper_progs.c
+++ b/src/py21cmfast/src/heating_helper_progs.c
@@ -1169,7 +1169,6 @@ double nu_tau_one_MINI(double zp, double zpp, double x_e, double HI_filling_fact
     // check if too ionized
     if (x_e > 0.9999){
 //        LOG_ERROR("x_e value is too close to 1 for convergence.");
-//        Throw(ParameterError);
         return global_params.NU_X_THRESH;
     }
 
@@ -1236,7 +1235,7 @@ double nu_tau_one(double zp, double zpp, double x_e, double HI_filling_factor_zp
 
     // check if too ionized
     if (x_e > 0.9999){
-//        Throw(ParameterError);
+//        LOG_ERROR("x_e value is too close to 1 for convergence.");
         return global_params.NU_X_THRESH;
     }
 

--- a/src/py21cmfast/src/heating_helper_progs.c
+++ b/src/py21cmfast/src/heating_helper_progs.c
@@ -820,12 +820,15 @@ double integrate_over_nu(double zp, double local_x_e, double lower_int_limit, in
     int status;
     gsl_set_error_handler_off();
     status = gsl_integration_qag (&F, lower_int_limit, global_params.NU_X_MAX*NU_over_EV, 0, rel_tol, 1000, GSL_INTEG_GAUSS15, w, &result, &error);
-    gsl_integration_workspace_free (w);
 
     if(status!=0){
         LOG_ERROR("gsl error with code %d", status);
+        LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_int_limit,global_params.NU_X_MAX*NU_over_EV,rel_tol,result,error);
+        LOG_ERROR("data: zp=%e local_x_e=%e FLAG=%d",zp,local_x_e,FLAG);
         Throw GSLError;
     }
+
+    gsl_integration_workspace_free (w);
 
     // if it is the Lya integral, add prefactor
     if (FLAG == 2)
@@ -1028,10 +1031,22 @@ double tauX_MINI(double nu, double x_e, double x_e_ave, double zp, double zpp, d
     p.LOG10_MTURN_INT = LOG10_MTURN_INT;
 
     F.params = &p;
-    gsl_integration_qag (&F, zpp, zp, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
-    //    gsl_integration_qag (&F, zpp, zp, 0, rel_tol,1000, GSL_INTEG_GAUSS61, w, &result, &error);
-    gsl_integration_workspace_free (w);
 
+    int status;
+
+    gsl_set_error_handler_off();
+
+    status = gsl_integration_qag (&F, zpp, zp, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
+
+    if(status!=0){
+        LOG_ERROR("gsl error with code %d", status);
+        LOG_ERROR("(function argument): zp=%e zpp=%e rel_tol=%e result=%e error=%e",zp,zpp,rel_tol,result,error);
+        LOG_ERROR("data: nu=%e nu_0=%e x_e=%e x_e_ave=%e",nu,p.nu_0,p.x_e,p.x_e_ave);
+        LOG_ERROR("data: ion_eff=%e ion_eff_MINI=%e log10_Mturn_MINI=%e LOG10_MTURN_INT=%e",p.ion_eff,p.ion_eff_MINI,p.log10_Mturn_MINI,p.LOG10_MTURN_INT);
+        Throw GSLError;
+    }
+
+    gsl_integration_workspace_free (w);
 
     //     if (DEBUG_ON)
     //     printf("returning from tauX, return value=%e\n", result);
@@ -1099,16 +1114,25 @@ double tauX(double nu, double x_e, double x_e_ave, double zp, double zpp, double
         }
     }
 
+    F.params = &p;
+
+    int status;
+
     gsl_set_error_handler_off();
 
-    F.params = &p;
-    gsl_integration_qag (&F, zpp, zp, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
+    status = gsl_integration_qag (&F, zpp, zp, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
+
+    if(status!=0){
+        LOG_ERROR("gsl error with code %d", status);
+        LOG_ERROR("(function argument): zp=%e zpp=%e rel_tol=%e result=%e error=%e",zp,zpp,rel_tol,result,error);
+        LOG_ERROR("data: nu=%e nu_0=%e x_e=%e x_e_ave=%e ion_eff=%e",nu,nu/(1+zp),x_e,x_e_ave,p.ion_eff);
+        Throw GSLError;
+    }
+
     gsl_integration_workspace_free (w);
 
     return result;
 }
-
-
 
 // Returns the frequency threshold where \tau_X = 1, given parameter values of
 // electron fraction in the IGM outside of HII regions, x_e,

--- a/src/py21cmfast/src/heating_helper_progs.c
+++ b/src/py21cmfast/src/heating_helper_progs.c
@@ -1169,7 +1169,7 @@ double nu_tau_one_MINI(double zp, double zpp, double x_e, double HI_filling_fact
     // check if too ionized
     if (x_e > 0.9999){
 //        LOG_ERROR("x_e value is too close to 1 for convergence.");
-        return global_params.NU_X_THRESH;
+        return astro_params_hf->NU_X_THRESH;
     }
 
     // select solver and allocate memory
@@ -1236,7 +1236,7 @@ double nu_tau_one(double zp, double zpp, double x_e, double HI_filling_factor_zp
     // check if too ionized
     if (x_e > 0.9999){
 //        LOG_ERROR("x_e value is too close to 1 for convergence.");
-        return global_params.NU_X_THRESH;
+        return astro_params_hf->NU_X_THRESH;
     }
 
     // select solver and allocate memory

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -1268,7 +1268,7 @@ double Nion_General(double z, double M_Min, double MassTurnover, double Alpha_st
     }
     else {
         LOG_ERROR("Incorrect HMF selected: %i (should be between 0 and 3).", user_params_ps->HMF);
-        Throw ValueError;
+        Throw(ValueError);
     }
 }
 
@@ -1479,7 +1479,8 @@ void initialiseSigmaMInterpTable(float M_Min, float M_Max)
     for(i=0;i<NMass;i++) {
         if(isfinite(Mass_InterpTable[i]) == 0 || isfinite(Sigma_InterpTable[i]) == 0 || isfinite(dSigmadm_InterpTable[i])==0) {
             LOG_ERROR("Detected either an infinite or NaN value in initialiseSigmaMInterpTable");
-            Throw(ParameterError);
+//            Throw(ParameterError);
+            Throw(TableGenerationError);
         }
     }
 
@@ -1743,7 +1744,8 @@ float Mass_limit_bisection(float Mmin, float Mmax, float PL, float FRAC){
     // Got to max_iter without finding a solution.
     LOG_ERROR("Failed to find a mass limit to regulate stellar fraction/escape fraction is between 0 and 1.");
     LOG_ERROR(" The solution does not converge or iterations are not sufficient.");
-    Throw(ParameterError);
+//    Throw(ParameterError);
+    Throw(MassDepZetaError);
 
     return(0.0);
 }
@@ -2625,7 +2627,8 @@ void initialise_Nion_General_spline(float z, float min_density, float max_densit
     for (i=0; i<NSFR_low; i++){
         if(!isfinite(log10_Nion_spline[i])) {
             LOG_ERROR("Detected either an infinite or NaN value in log10_Nion_spline");
-            Throw(ParameterError);
+//            Throw(ParameterError);
+            Throw(TableGenerationError);
         }
     }
 
@@ -2645,7 +2648,8 @@ void initialise_Nion_General_spline(float z, float min_density, float max_densit
     for(i=0;i<NSFR_high;i++) {
         if(!isfinite(Nion_spline[i])) {
             LOG_ERROR("Detected either an infinite or NaN value in log10_Nion_spline");
-            Throw(ParameterError);
+//            Throw(ParameterError);
+            Throw(TableGenerationError);
         }
     }
 }
@@ -2731,12 +2735,14 @@ void initialise_Nion_General_spline_MINI(float z, float Mcrit_atom, float min_de
         for (j=0; j<NMTURN; j++){
             if(isfinite(log10_Nion_spline[i+j*NSFR_low])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in log10_Nion_spline");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
 
             if(isfinite(log10_Nion_spline_MINI[i+j*NSFR_low])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in log10_Nion_spline_MINI");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
         }
     }
@@ -2777,12 +2783,14 @@ void initialise_Nion_General_spline_MINI(float z, float Mcrit_atom, float min_de
         for (j=0; j<NMTURN; j++){
             if(isfinite(Nion_spline[i+j*NSFR_high])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in Nion_spline");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
 
             if(isfinite(Nion_spline_MINI[i+j*NSFR_high])==0) {
                LOG_ERROR("Detected either an infinite or NaN value in Nion_spline_MINI");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
         }
     }
@@ -2867,12 +2875,14 @@ void initialise_Nion_General_spline_MINI_prev(float z, float Mcrit_atom, float m
         for (j=0; j<NMTURN; j++){
             if(isfinite(prev_log10_Nion_spline[i+j*NSFR_low])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in prev_log10_Nion_spline");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
 
             if(isfinite(prev_log10_Nion_spline_MINI[i+j*NSFR_low])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in prev_log10_Nion_spline_MINI");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
         }
     }
@@ -2912,12 +2922,14 @@ void initialise_Nion_General_spline_MINI_prev(float z, float Mcrit_atom, float m
         for (j=0; j<NMTURN; j++){
             if(isfinite(prev_Nion_spline[i+j*NSFR_high])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in prev_Nion_spline");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
 
             if(isfinite(prev_Nion_spline_MINI[i+j*NSFR_high])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in prev_Nion_spline_MINI");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
         }
     }
@@ -2951,7 +2963,8 @@ void initialise_Nion_Ts_spline(
     for (i=0; i<Nbin; i++){
         if(isfinite(Nion_z_val[i])==0) {
             LOG_ERROR("Detected either an infinite or NaN value in Nion_z_val");
-            Throw(ParameterError);
+//            Throw(ParameterError);
+            Throw(TableGenerationError);
         }
     }
 }
@@ -2999,14 +3012,16 @@ void initialise_Nion_Ts_spline_MINI(
         if(isfinite(Nion_z_val[i])==0) {
             i = Nbin;
             LOG_ERROR("Detected either an infinite or NaN value in Nion_z_val");
-            Throw(ParameterError);
+//            Throw(ParameterError);
+            Throw(TableGenerationError);
         }
 
         for (j=0; j<NMTURN; j++){
             if(isfinite(Nion_z_val_MINI[i+j*Nbin])==0){
                 j = NMTURN;
                 LOG_ERROR("Detected either an infinite or NaN value in Nion_z_val_MINI");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
         }
     }
@@ -3037,7 +3052,8 @@ void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float MassTurn, fl
     for (i=0; i<Nbin; i++){
         if(isfinite(SFRD_val[i])==0) {
             LOG_ERROR("Detected either an infinite or NaN value in SFRD_val");
-            Throw(ParameterError);
+//            Throw(ParameterError);
+            Throw(TableGenerationError);
         }
     }
 }
@@ -3081,14 +3097,16 @@ void initialise_SFRD_spline_MINI(int Nbin, float zmin, float zmax, float Alpha_s
         if(isfinite(SFRD_val[i])==0) {
             i = Nbin;
             LOG_ERROR("Detected either an infinite or NaN value in SFRD_val");
-            Throw(ParameterError);
+//            Throw(ParameterError);
+            Throw(TableGenerationError);
         }
 
         for (j=0; j<NMTURN; j++){
             if(isfinite(SFRD_val_MINI[i+j*Nbin])==0) {
                 j = NMTURN;
                 LOG_ERROR("Detected either an infinite or NaN value in SFRD_val_MINI");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
         }
     }
@@ -3158,7 +3176,6 @@ void initialise_SFRD_Conditional_table(
             for (i=0; i<NSFR_low; i++){
 
                 log10_SFRD_z_low_table[j][i] = GaussLegendreQuad_Nion(1,NGL_SFR,growthf[j],Mmax,sigma2,Deltac,overdense_low_table[i]-1.,MassTurnover,Alpha_star,0.,Fstar10,1.,Mlim_Fstar,0., FAST_FCOLL_TABLES);
-//                printf("%d %d %e %e %e %e %e %e %e %e %e %e %e %e %e %e %e\n",j,i,R[j],RtoM(R[j]),growthf[j],Mmax,sigma2,Deltac,overdense_low_table[i]-1.,MassTurnover,Alpha_star,0.,Fstar10,1.,Mlim_Fstar,0.,log10_SFRD_z_low_table[j][i]);
                 if(fabs(log10_SFRD_z_low_table[j][i]) < 1e-38) {
                     log10_SFRD_z_low_table[j][i] = 1e-38;
                 }
@@ -3172,7 +3189,8 @@ void initialise_SFRD_Conditional_table(
         for (i=0; i<NSFR_low; i++){
             if(isfinite(log10_SFRD_z_low_table[j][i])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in log10_SFRD_z_low_table");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
         }
 
@@ -3190,7 +3208,8 @@ void initialise_SFRD_Conditional_table(
         for(i=0;i<NSFR_high;i++) {
             if(isfinite(SFRD_z_high_table[j][i])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in SFRD_z_high_table");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
         }
 
@@ -3290,13 +3309,15 @@ void initialise_SFRD_Conditional_table_MINI(
         for (i=0; i<NSFR_low; i++){
             if(isfinite(log10_SFRD_z_low_table[j][i])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in log10_SFRD_z_low_table");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
 
             for (k=0; k<NMTURN; k++){
                 if(isfinite(log10_SFRD_z_low_table_MINI[j][i+k*NSFR_low])==0) {
                     LOG_ERROR("Detected either an infinite or NaN value in log10_SFRD_z_low_table_MINI");
-                    Throw(ParameterError);
+//                    Throw(ParameterError);
+                    Throw(TableGenerationError);
                 }
             }
         }
@@ -3331,13 +3352,15 @@ void initialise_SFRD_Conditional_table_MINI(
         for(i=0;i<NSFR_high;i++) {
             if(isfinite(SFRD_z_high_table[j][i])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in SFRD_z_high_table");
-                Throw(ParameterError);
+//                Throw(ParameterError);
+                Throw(TableGenerationError);
             }
 
             for (k=0; k<NMTURN; k++){
                 if(isfinite(SFRD_z_high_table_MINI[j][i+k*NSFR_high])==0) {
                     LOG_ERROR("Detected either an infinite or NaN value in SFRD_z_high_table_MINI");
-                    Throw(ParameterError);
+//                    Throw(ParameterError);
+                    Throw(TableGenerationError);
                 }
             }
         }
@@ -3530,7 +3553,8 @@ int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cos
             num_fails += 1;
             if(num_fails>10) {
                 LOG_ERROR("Failed too many times.");
-                Throw ParameterError;
+//                Throw ParameterError;
+                Throw(PhotonConsError);
             }
         }
 
@@ -3936,7 +3960,8 @@ float adjust_redshifts_for_photoncons(
             "(global_params.PhotonConsEndCalibz = %f). If this behaviour is desired then set global_params.PhotonConsEndCalibz "\
             "to a value lower than z = %f.",*redshift,global_params.PhotonConsEndCalibz,*redshift
                   );
-        Throw(ParameterError);
+//        Throw(ParameterError);
+        Throw(PhotonConsError);
     }
 
     // Determine the neutral fraction (filling factor) of the analytic calibration expression given the current sampled redshift
@@ -4090,11 +4115,16 @@ void z_at_Q(double Q, double *splined_value){
 
     if (Q < Qmin) {
         LOG_ERROR("The minimum value of Q is %.4e",Qmin);
-        Throw(ParameterError);
+//        Throw(ParameterError);
+        Throw(PhotonConsError);
     }
     else if (Q > Qmax) {
         LOG_ERROR("The maximum value of Q is %.4e. Reionization ends at ~%.4f.",Qmax,Zmin);
-        Throw(ParameterError);
+        LOG_ERROR("This error can occur if global_params.PhotonConsEndCalibz is close to "\
+                  "the final sampled redshift. One can consider a lower value for "\
+                  "global_params.PhotonConsEndCalibz to mitigate this");
+//        Throw(ParameterError);
+        Throw(PhotonConsError);
     }
     else {
         returned_value = gsl_spline_eval(z_at_Q_spline, Q, z_at_Q_spline_acc);

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -433,9 +433,20 @@ double sigma_z0(double M){
 
     F.function = &dsigma_dk;
     F.params = &Radius;
-    //gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS61, w, &result, &error);
-    //    gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS41, w, &result, &error);
-    gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
+
+    int status;
+
+    gsl_set_error_handler_off();
+
+    status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
+
+    if(status!=0) {
+        LOG_ERROR("gsl integration error occured!");
+        LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+        LOG_ERROR("data: M=%e",M);
+        Throw GSLError;
+    }
+
     gsl_integration_workspace_free (w);
 
     return sigma_norm * sqrt(result);
@@ -621,8 +632,20 @@ double init_ps(){
 
     F.function = &dsigma_dk;
     F.params = &Radius_8;
-    gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
+
+    int status;
+
+    gsl_set_error_handler_off();
+
+    status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
                          1000, GSL_INTEG_GAUSS61, w, &result, &error);
+
+    if(status!=0) {
+        LOG_ERROR("gsl integration error occured!");
+        LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+        Throw GSLError;
+    }
+
     gsl_integration_workspace_free (w);
 
     LOG_DEBUG("Initialized Power Spectrum.");
@@ -766,8 +789,20 @@ double dsigmasqdm_z0(double M){
 
     F.function = &dsigmasq_dm;
     F.params = &Radius;
-    gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS61, w, &result, &error);
-    //  gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
+
+    int status;
+
+    gsl_set_error_handler_off();
+
+    status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS61, w, &result, &error);
+
+    if(status!=0) {
+        LOG_ERROR("gsl integration error occured!");
+        LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+        LOG_ERROR("data: M=%e",M);
+        Throw GSLError;
+    }
+
     gsl_integration_workspace_free (w);
 
 //    return sigma_norm * sigma_norm * result /d2fact;
@@ -1000,8 +1035,20 @@ double FgtrM_Watson_z(double z, double growthf, double M){
     lower_limit = log(M);
     upper_limit = log(fmax(global_params.M_MAX_INTEGRAL, M*100));
 
-    gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
+    int status;
+
+    gsl_set_error_handler_off();
+
+    status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
                          1000, GSL_INTEG_GAUSS61, w, &result, &error);
+
+    if(status!=0) {
+        LOG_ERROR("gsl integration error occured!");
+        LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+        LOG_ERROR("data: z=%e growthf=%e M=%e",z,growthf,M);
+        Throw GSLError;
+    }
+
     gsl_integration_workspace_free (w);
 
     return result / (cosmo_params_ps->OMm*RHOcrit);
@@ -1030,8 +1077,20 @@ double FgtrM_Watson(double growthf, double M){
     lower_limit = log(M);
     upper_limit = log(fmax(global_params.M_MAX_INTEGRAL, M*100));
 
-    gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
+    int status;
+
+    gsl_set_error_handler_off();
+
+    status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
                          1000, GSL_INTEG_GAUSS61, w, &result, &error);
+
+    if(status!=0) {
+        LOG_ERROR("gsl integration error occured!");
+        LOG_ERROR("lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+        LOG_ERROR("data: growthf=%e M=%e",growthf,M);
+        Throw(GSLError);
+    }
+
     gsl_integration_workspace_free (w);
 
     return result / (cosmo_params_ps->OMm*RHOcrit);
@@ -1195,9 +1254,12 @@ double Nion_General(double z, double M_Min, double MassTurnover, double Alpha_st
         gsl_set_error_handler_off();
 
         status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol, 1000, GSL_INTEG_GAUSS61, w, &result, &error);
+
         if(status!=0) {
-            LOG_ERROR("(function argument): %e %e %e %e %e\n",lower_limit,upper_limit,rel_tol,result,error);
-            LOG_ERROR("data: %e %e %e %e %e %e %e %e %e\n",z,growthf,MassTurnover,Alpha_star,Alpha_esc,Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc);
+            LOG_ERROR("gsl integration error occured!");
+            LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+            LOG_ERROR("data: z=%e growthf=%e MassTurnover=%e Alpha_star=%e Alpha_esc=%e",z,growthf,MassTurnover,Alpha_star,Alpha_esc);
+            LOG_ERROR("data: Fstar10=%e Fesc10=%e Mlim_Fstar=%e Mlim_Fesc=%e",Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc);
             Throw GSLError;
         }
         gsl_integration_workspace_free (w);
@@ -1260,6 +1322,7 @@ double dNion_General_MINI(double lnM, void *params){
 double Nion_General_MINI(double z, double M_Min, double MassTurnover, double MassTurnover_upper, double Alpha_star, double Alpha_esc, double Fstar7_MINI, double Fesc7_MINI, double Mlim_Fstar, double Mlim_Fesc){
 
     double growthf;
+    int status;
 
     growthf = dicke(z);
 
@@ -1291,7 +1354,18 @@ double Nion_General_MINI(double z, double M_Min, double MassTurnover, double Mas
         lower_limit = log(M_Min);
         upper_limit = log(fmax(global_params.M_MAX_INTEGRAL, M_Min*100));
 
-        gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol, 1000, GSL_INTEG_GAUSS61, w, &result, &error);
+        gsl_set_error_handler_off();
+
+        status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol, 1000, GSL_INTEG_GAUSS61, w, &result, &error);
+
+        if(status!=0) {
+            LOG_ERROR("gsl integration error occurred!");
+            LOG_ERROR("lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+            LOG_ERROR("data: z=%e growthf=%e MassTurnover=%e MassTurnover_upper=%e",z,growthf,MassTurnover,MassTurnover_upper);
+            LOG_ERROR("data: Alpha_star=%e Alpha_esc=%e Fstar7_MINI=%e Fesc7_MINI=%e Mlim_Fstar=%e Mlim_Fesc=%e",Alpha_star,Alpha_esc,Fstar7_MINI,Fesc7_MINI,Mlim_Fstar,Mlim_Fesc);
+            Throw(GSLError);
+        }
+
         gsl_integration_workspace_free (w);
 
         return result / ((cosmo_params_ps->OMm)*RHOcrit);
@@ -2075,14 +2149,26 @@ double Nion_ConditionalM_MINI(double growthf, double M1, double M2, double sigma
         .LimitMass_Fstar = Mlim_Fstar,
         .LimitMass_Fesc = Mlim_Fesc
     };
+    int status;
 
     F.function = &dNion_ConditionallnM_MINI;
     F.params = &parameters_gsl_SFR_con;
     lower_limit = M1;
     upper_limit = M2;
 
-    gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
+    gsl_set_error_handler_off();
+
+    status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
                          1000, GSL_INTEG_GAUSS61, w, &result, &error);
+
+    if(status!=0) {
+        LOG_ERROR("gsl integration error occured!");
+        LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+        LOG_ERROR("data: growthf=%e M2=%e sigma2=%e delta1=%e delta2=%e MassTurnover=%e",growthf,M2,sigma2,delta1,delta2,MassTurnover);
+        LOG_ERROR("data: MassTurnover_upper=%e Alpha_star=%e Alpha_esc=%e Fstar10=%e Fesc10=%e Mlim_Fstar=%e Mlim_Fesc=%e",MassTurnover_upper,Alpha_star,Alpha_esc,Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc);
+        Throw GSLError;
+    }
+
     gsl_integration_workspace_free (w);
 
     if(delta2 > delta1) {
@@ -2143,8 +2229,10 @@ double Nion_ConditionalM(double growthf, double M1, double M2, double sigma2, do
                          1000, GSL_INTEG_GAUSS61, w, &result, &error);
 
     if(status!=0) {
-        LOG_ERROR("(function argument): %e %e %e %e %e\n",lower_limit,upper_limit,rel_tol,result,error);
-        LOG_ERROR("data: %e %e %e %e %e %e %e %e %e %e %e %e %e\n",growthf,M1,M2,sigma2,delta1,delta2,MassTurnover,Alpha_star,Alpha_esc,Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc);
+        LOG_ERROR("gsl integration error occured!");
+        LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+        LOG_ERROR("data: growthf=%e M1=%e M2=%e sigma2=%e delta1=%e delta2=%e",growthf,M1,M2,sigma2,delta1,delta2);
+        LOG_ERROR("data: MassTurnover=%e Alpha_star=%e Alpha_esc=%e Fstar10=%e Fesc10=%e Mlim_Fstar=%e Mlim_Fesc=%e",MassTurnover,Alpha_star,Alpha_esc,Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc);
         Throw GSLError;
     }
 

--- a/src/py21cmfast/src/recombinations.c
+++ b/src/py21cmfast/src/recombinations.c
@@ -164,8 +164,21 @@ double recombination_rate(double z, double gamma12_bg, double T4, int usecaseB){
   lower_limit = log(0.01);
   upper_limit = log(200);
 
-  gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
+  int status;
+
+  gsl_set_error_handler_off();
+
+  status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
 		       1000, GSL_INTEG_GAUSS61, w, &result, &error);
+
+  if(status!=0) {
+      LOG_ERROR("gsl integration error occured!");
+      LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+      LOG_ERROR("data: z=%e gamma12_bg=%e T4=%e A_MHR(z)=%e",z,gamma12_bg,T4,A_MHR(z));
+      LOG_ERROR("data: C_MHR(z)=%e beta_MHR(z)=%e nH=%e usecaseB=%d\n",C_MHR(z),beta_MHR(z),No*pow( 1+z, 3),usecaseB);
+      Throw GSLError;
+  }
+
   gsl_integration_workspace_free (w);
 
   return result;
@@ -191,8 +204,20 @@ double A_aux_integral(double z){
   lower_limit = 1e-25;
   upper_limit = 1e25;
 
-  gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
+  int status;
+
+  gsl_set_error_handler_off();
+
+  status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,
 		       1000, GSL_INTEG_GAUSS61, w, &result, &error);
+
+  if(status!=0) {
+      LOG_ERROR("gsl integration error occured!");
+      LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
+      LOG_ERROR("data: z=%e",z);
+      Throw GSLError;
+  }
+
   gsl_integration_workspace_free (w);
 
   return result;

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,5 @@
 import pytest
 
-"""from py21cmfast._utils import PARAMETERERROR, ParameterError"""
 from py21cmfast._utils import PHOTONCONSERROR, ParameterError
 from py21cmfast.c_21cmfast import lib
 from py21cmfast.wrapper import _call_c_simple
@@ -9,7 +8,6 @@ from py21cmfast.wrapper import _call_c_simple
 @pytest.mark.parametrize("subfunc", [True, False])
 def test_basic(subfunc):
     status = lib.SomethingThatCatches(subfunc)
-    """assert status == PARAMETERERROR"""
     assert status == PHOTONCONSERROR
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,7 @@
 import pytest
 
-from py21cmfast._utils import PARAMETERERROR, ParameterError
+"""from py21cmfast._utils import PARAMETERERROR, ParameterError"""
+from py21cmfast._utils import PHOTONCONSERROR, PhotonConsError
 from py21cmfast.c_21cmfast import lib
 from py21cmfast.wrapper import _call_c_simple
 
@@ -8,12 +9,14 @@ from py21cmfast.wrapper import _call_c_simple
 @pytest.mark.parametrize("subfunc", [True, False])
 def test_basic(subfunc):
     status = lib.SomethingThatCatches(subfunc)
-    assert status == PARAMETERERROR
+    """assert status == PARAMETERERROR"""
+    assert status == PHOTONCONSERROR
 
 
 @pytest.mark.parametrize("subfunc", [True, False])
 def test_simple(subfunc):
-    with pytest.raises(ParameterError):
+    """with pytest.raises(ParameterError):"""
+    with pytest.raises(PhotonConsError):
         _call_c_simple(lib.FunctionThatCatches, subfunc, False)
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,7 @@
 import pytest
 
 """from py21cmfast._utils import PARAMETERERROR, ParameterError"""
-from py21cmfast._utils import PHOTONCONSERROR, PhotonConsError
+from py21cmfast._utils import PHOTONCONSERROR, ParameterError
 from py21cmfast.c_21cmfast import lib
 from py21cmfast.wrapper import _call_c_simple
 
@@ -15,8 +15,7 @@ def test_basic(subfunc):
 
 @pytest.mark.parametrize("subfunc", [True, False])
 def test_simple(subfunc):
-    """with pytest.raises(ParameterError):"""
-    with pytest.raises(PhotonConsError):
+    with pytest.raises(ParameterError):
         _call_c_simple(lib.FunctionThatCatches, subfunc, False)
 
 


### PR DESCRIPTION
Hey @steven-murray, I have taken a first stab at updating the granularity of the error coding and modifying the error messaging to try and make them a bit more informative. As I mentioned I did away with the `ParameterError` thing entirely, turning everything into a `FatalCError`.

Obviously the long `elif` code is ugly, but just temporary for now. Let me know what you think.

In some places I added to the output error through LOG, in particular including information known from some recent failings with the PhotonCons option (under certain parameter combinations).

Also, I have added some error checks for some AstroParams, causing it to exit with an informative error as to why.

I'm contemplating adding a warning for the other parameters when they are outside the usual parameter ranges we have used in publications. The idea would be that if outside that range, we haven't tested if they'll pass/fail. So warn the user that this might be the case (that their parameter choice is outside of the ranges it has been tested on, but could still be fine).