### PR TITLE
fix interpolation of LFs between ACHs and minihalos

### DIFF
--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -560,19 +560,19 @@ def compute_luminosity_function(
             )
             lfunc_all[iz] = np.log10(
                 10
-                ** (interp1d(Muvfunc, lfunc, fill_value="extrapolate")(Muvfunc_all[iz]))
+                ** (interp1d(Muvfunc[iz], lfunc[iz], fill_value="extrapolate")(Muvfunc_all[iz]))
                 + 10
                 ** (
-                    interp1d(Muvfunc_MINI, lfunc_MINI, fill_value="extrapolate")(
+                    interp1d(Muvfunc_MINI[iz], lfunc_MINI[iz], fill_value="extrapolate")(
                         Muvfunc_all[iz]
                     )
                 )
             )
             Mhfunc_all[iz] = np.array(
-                interp1d(Muvfunc, Mhfunc, fill_value="extrapolate")(Muvfunc_all[iz]),
-                interp1d(Muvfunc_MINI, Mhfunc_MINI, fill_value="extrapolate")(
+                [interp1d(Muvfunc[iz], Mhfunc[iz], fill_value="extrapolate")(Muvfunc_all[iz]),
+                interp1d(Muvfunc_MINI[iz], Mhfunc_MINI[iz], fill_value="extrapolate")(
                     Muvfunc_all[iz]
-                ),
+                )],
             ).T
         lfunc_all[lfunc_all <= -30] = np.nan
         return Muvfunc_all, Mhfunc_all, lfunc_all

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -560,19 +560,27 @@ def compute_luminosity_function(
             )
             lfunc_all[iz] = np.log10(
                 10
-                ** (interp1d(Muvfunc[iz], lfunc[iz], fill_value="extrapolate")(Muvfunc_all[iz]))
-                + 10
                 ** (
-                    interp1d(Muvfunc_MINI[iz], lfunc_MINI[iz], fill_value="extrapolate")(
+                    interp1d(Muvfunc[iz], lfunc[iz], fill_value="extrapolate")(
                         Muvfunc_all[iz]
                     )
                 )
+                + 10
+                ** (
+                    interp1d(
+                        Muvfunc_MINI[iz], lfunc_MINI[iz], fill_value="extrapolate"
+                    )(Muvfunc_all[iz])
+                )
             )
             Mhfunc_all[iz] = np.array(
-                [interp1d(Muvfunc[iz], Mhfunc[iz], fill_value="extrapolate")(Muvfunc_all[iz]),
-                interp1d(Muvfunc_MINI[iz], Mhfunc_MINI[iz], fill_value="extrapolate")(
-                    Muvfunc_all[iz]
-                )],
+                [
+                    interp1d(Muvfunc[iz], Mhfunc[iz], fill_value="extrapolate")(
+                        Muvfunc_all[iz]
+                    ),
+                    interp1d(
+                        Muvfunc_MINI[iz], Mhfunc_MINI[iz], fill_value="extrapolate"
+                    )(Muvfunc_all[iz]),
+                ],
             ).T
         lfunc_all[lfunc_all <= -30] = np.nan
         return Muvfunc_all, Mhfunc_all, lfunc_all

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -293,6 +293,12 @@ def test_run_lf():
     assert lf2.shape == (3, 100)
     assert np.allclose(lf2[~np.isnan(lf2)], lf[~np.isnan(lf)])
 
+    muv_minih, mhalo_minih, lf_minih = wrapper.compute_luminosity_function(redshifts=[7, 8, 9], nbins=100,
+                                                        component=0, flag_options={'USE_MINI_HALOS':True},
+                                                        mturnovers=[7.,7.,7.], mturnovers_mini=[5.,5.,5.]))
+    assert np.all(lf_minih[~np.isnan(lf_minih)] > -30)
+    assert lf_minih.shape == (3, 100)
+
 
 def test_coeval_st(ic, perturb_field):
     coeval = wrapper.run_coeval(

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -293,9 +293,14 @@ def test_run_lf():
     assert lf2.shape == (3, 100)
     assert np.allclose(lf2[~np.isnan(lf2)], lf[~np.isnan(lf)])
 
-    muv_minih, mhalo_minih, lf_minih = wrapper.compute_luminosity_function(redshifts=[7, 8, 9], nbins=100,
-                                                        component=0, flag_options={'USE_MINI_HALOS':True},
-                                                        mturnovers=[7.,7.,7.], mturnovers_mini=[5.,5.,5.]))
+    muv_minih, mhalo_minih, lf_minih = wrapper.compute_luminosity_function(
+        redshifts=[7, 8, 9],
+        nbins=100,
+        component=0,
+        flag_options={"USE_MINI_HALOS": True},
+        mturnovers=[7.0, 7.0, 7.0],
+        mturnovers_mini=[5.0, 5.0, 5.0],
+    )
     assert np.all(lf_minih[~np.isnan(lf_minih)] > -30)
     assert lf_minih.shape == (3, 100)
 


### PR DESCRIPTION
Fix for bug #226 in making LFs with both ACHs + minihalos (`component=0`).

Added index for each redshift, and fixed array creation for Mhfunc_all to create the expected LFs. Added one test for LFs with minihalos.