### PR TITLE
Minor fixes to resolve gsl error in integration for sigma_z0

### DIFF
--- a/src/py21cmfast/src/UsefulFunctions.c
+++ b/src/py21cmfast/src/UsefulFunctions.c
@@ -482,7 +482,7 @@ double tau_e(float zstart, float zend, float *zarry, float *xHarry, int len){
                 LOG_ERROR("gsl integration error occured!");
                 LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",global_params.Zreion_HeII,zstart,rel_tol,prehelium,error);
                 LOG_ERROR("data: zstart=%e zend=%e",zstart,zend);
-                Throw GSLError;
+                GSL_ERROR(status);
             }
 
             status = gsl_integration_qag (&F, zend, global_params.Zreion_HeII, 0, rel_tol,
@@ -492,7 +492,7 @@ double tau_e(float zstart, float zend, float *zarry, float *xHarry, int len){
                 LOG_ERROR("gsl integration error occured!");
                 LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",zend,global_params.Zreion_HeII,rel_tol,posthelium,error);
                 LOG_ERROR("data: zstart=%e zend=%e",zstart,zend);
-                Throw GSLError;
+                GSL_ERROR(status);
             }
         }
         else{
@@ -503,7 +503,7 @@ double tau_e(float zstart, float zend, float *zarry, float *xHarry, int len){
             if(status!=0) {
                 LOG_ERROR("gsl integration error occured!");
                 LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",zend,zstart,rel_tol,posthelium,error);
-                Throw GSLError;
+                GSL_ERROR(status);
             }
         }
     }
@@ -515,7 +515,7 @@ double tau_e(float zstart, float zend, float *zarry, float *xHarry, int len){
         if(status!=0) {
             LOG_ERROR("gsl integration error occured!");
             LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",zend,zstart,rel_tol,prehelium,error);
-            Throw GSLError;
+            GSL_ERROR(status);
         }
     }
     gsl_integration_workspace_free (w);

--- a/src/py21cmfast/src/heating_helper_progs.c
+++ b/src/py21cmfast/src/heating_helper_progs.c
@@ -822,10 +822,9 @@ double integrate_over_nu(double zp, double local_x_e, double lower_int_limit, in
     status = gsl_integration_qag (&F, lower_int_limit, global_params.NU_X_MAX*NU_over_EV, 0, rel_tol, 1000, GSL_INTEG_GAUSS15, w, &result, &error);
 
     if(status!=0){
-        LOG_ERROR("gsl error with code %d", status);
         LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_int_limit,global_params.NU_X_MAX*NU_over_EV,rel_tol,result,error);
         LOG_ERROR("data: zp=%e local_x_e=%e FLAG=%d",zp,local_x_e,FLAG);
-        Throw GSLError;
+        GSL_ERROR(status);
     }
 
     gsl_integration_workspace_free (w);
@@ -1039,11 +1038,10 @@ double tauX_MINI(double nu, double x_e, double x_e_ave, double zp, double zpp, d
     status = gsl_integration_qag (&F, zpp, zp, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
 
     if(status!=0){
-        LOG_ERROR("gsl error with code %d", status);
         LOG_ERROR("(function argument): zp=%e zpp=%e rel_tol=%e result=%e error=%e",zp,zpp,rel_tol,result,error);
         LOG_ERROR("data: nu=%e nu_0=%e x_e=%e x_e_ave=%e",nu,p.nu_0,p.x_e,p.x_e_ave);
         LOG_ERROR("data: ion_eff=%e ion_eff_MINI=%e log10_Mturn_MINI=%e LOG10_MTURN_INT=%e",p.ion_eff,p.ion_eff_MINI,p.log10_Mturn_MINI,p.LOG10_MTURN_INT);
-        Throw GSLError;
+        GSL_ERROR(status);
     }
 
     gsl_integration_workspace_free (w);
@@ -1123,10 +1121,9 @@ double tauX(double nu, double x_e, double x_e_ave, double zp, double zpp, double
     status = gsl_integration_qag (&F, zpp, zp, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
 
     if(status!=0){
-        LOG_ERROR("gsl error with code %d", status);
         LOG_ERROR("(function argument): zp=%e zpp=%e rel_tol=%e result=%e error=%e",zp,zpp,rel_tol,result,error);
         LOG_ERROR("data: nu=%e nu_0=%e x_e=%e x_e_ave=%e ion_eff=%e",nu,nu/(1+zp),x_e,x_e_ave,p.ion_eff);
-        Throw GSLError;
+        GSL_ERROR(status);
     }
 
     gsl_integration_workspace_free (w);

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -443,6 +443,7 @@ double sigma_z0(double M){
 
     if(status!=0) {
         LOG_ERROR("gsl integration error occured!");
+        LOG_ERROR("error: %s\n", gsl_strerror (status));
         LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
         LOG_ERROR("data: M=%e",M);
         Throw GSLError;

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -438,12 +438,11 @@ double sigma_z0(double M){
 
     gsl_set_error_handler_off();
 
-//    status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
     status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS61, w, &result, &error);
 
     if(status!=0) {
         LOG_ERROR("gsl integration error occured!");
-        LOG_ERROR("error: %s\n", gsl_strerror (status));
+        LOG_ERROR("gsl inbuilt error message: %s\n", gsl_strerror (status));
         LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
         LOG_ERROR("data: M=%e",M);
         Throw GSLError;

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -442,10 +442,9 @@ double sigma_z0(double M){
 
     if(status!=0) {
         LOG_ERROR("gsl integration error occured!");
-        LOG_ERROR("gsl inbuilt error message: %s\n", gsl_strerror (status));
         LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
         LOG_ERROR("data: M=%e",M);
-        Throw GSLError;
+        GSL_ERROR(status);
     }
 
     gsl_integration_workspace_free (w);
@@ -644,7 +643,7 @@ double init_ps(){
     if(status!=0) {
         LOG_ERROR("gsl integration error occured!");
         LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
-        Throw GSLError;
+        GSL_ERROR(status);
     }
 
     gsl_integration_workspace_free (w);
@@ -801,7 +800,7 @@ double dsigmasqdm_z0(double M){
         LOG_ERROR("gsl integration error occured!");
         LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
         LOG_ERROR("data: M=%e",M);
-        Throw GSLError;
+        GSL_ERROR(status);
     }
 
     gsl_integration_workspace_free (w);
@@ -1047,7 +1046,7 @@ double FgtrM_Watson_z(double z, double growthf, double M){
         LOG_ERROR("gsl integration error occured!");
         LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
         LOG_ERROR("data: z=%e growthf=%e M=%e",z,growthf,M);
-        Throw GSLError;
+        GSL_ERROR(status);
     }
 
     gsl_integration_workspace_free (w);
@@ -1089,7 +1088,7 @@ double FgtrM_Watson(double growthf, double M){
         LOG_ERROR("gsl integration error occured!");
         LOG_ERROR("lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
         LOG_ERROR("data: growthf=%e M=%e",growthf,M);
-        Throw(GSLError);
+        GSL_ERROR(status);
     }
 
     gsl_integration_workspace_free (w);
@@ -1159,7 +1158,7 @@ double FgtrM_General(double z, double M){
             LOG_ERROR("gsl integration error occured!");
             LOG_ERROR("lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
             LOG_ERROR("data: z=%e growthf=%e M=%e",z,growthf,M);
-            Throw(GSLError);
+            GSL_ERROR(status);
         }
 
         gsl_integration_workspace_free (w);
@@ -1261,7 +1260,7 @@ double Nion_General(double z, double M_Min, double MassTurnover, double Alpha_st
             LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
             LOG_ERROR("data: z=%e growthf=%e MassTurnover=%e Alpha_star=%e Alpha_esc=%e",z,growthf,MassTurnover,Alpha_star,Alpha_esc);
             LOG_ERROR("data: Fstar10=%e Fesc10=%e Mlim_Fstar=%e Mlim_Fesc=%e",Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc);
-            Throw GSLError;
+            GSL_ERROR(status);
         }
         gsl_integration_workspace_free (w);
 
@@ -1364,7 +1363,7 @@ double Nion_General_MINI(double z, double M_Min, double MassTurnover, double Mas
             LOG_ERROR("lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
             LOG_ERROR("data: z=%e growthf=%e MassTurnover=%e MassTurnover_upper=%e",z,growthf,MassTurnover,MassTurnover_upper);
             LOG_ERROR("data: Alpha_star=%e Alpha_esc=%e Fstar7_MINI=%e Fesc7_MINI=%e Mlim_Fstar=%e Mlim_Fesc=%e",Alpha_star,Alpha_esc,Fstar7_MINI,Fesc7_MINI,Mlim_Fstar,Mlim_Fesc);
-            Throw(GSLError);
+            GSL_ERROR(status);
         }
 
         gsl_integration_workspace_free (w);
@@ -2169,7 +2168,7 @@ double Nion_ConditionalM_MINI(double growthf, double M1, double M2, double sigma
         LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
         LOG_ERROR("data: growthf=%e M2=%e sigma2=%e delta1=%e delta2=%e MassTurnover=%e",growthf,M2,sigma2,delta1,delta2,MassTurnover);
         LOG_ERROR("data: MassTurnover_upper=%e Alpha_star=%e Alpha_esc=%e Fstar10=%e Fesc10=%e Mlim_Fstar=%e Mlim_Fesc=%e",MassTurnover_upper,Alpha_star,Alpha_esc,Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc);
-        Throw GSLError;
+        GSL_ERROR(status);
     }
 
     gsl_integration_workspace_free (w);
@@ -2236,7 +2235,7 @@ double Nion_ConditionalM(double growthf, double M1, double M2, double sigma2, do
         LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
         LOG_ERROR("data: growthf=%e M1=%e M2=%e sigma2=%e delta1=%e delta2=%e",growthf,M1,M2,sigma2,delta1,delta2);
         LOG_ERROR("data: MassTurnover=%e Alpha_star=%e Alpha_esc=%e Fstar10=%e Fesc10=%e Mlim_Fstar=%e Mlim_Fesc=%e",MassTurnover,Alpha_star,Alpha_esc,Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc);
-        Throw GSLError;
+        GSL_ERROR(status);
     }
 
     gsl_integration_workspace_free (w);

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -438,7 +438,8 @@ double sigma_z0(double M){
 
     gsl_set_error_handler_off();
 
-    status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
+//    status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS15, w, &result, &error);
+    status = gsl_integration_qag (&F, lower_limit, upper_limit, 0, rel_tol,1000, GSL_INTEG_GAUSS61, w, &result, &error);
 
     if(status!=0) {
         LOG_ERROR("gsl integration error occured!");

--- a/src/py21cmfast/src/recombinations.c
+++ b/src/py21cmfast/src/recombinations.c
@@ -176,7 +176,7 @@ double recombination_rate(double z, double gamma12_bg, double T4, int usecaseB){
       LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
       LOG_ERROR("data: z=%e gamma12_bg=%e T4=%e A_MHR(z)=%e",z,gamma12_bg,T4,A_MHR(z));
       LOG_ERROR("data: C_MHR(z)=%e beta_MHR(z)=%e nH=%e usecaseB=%d\n",C_MHR(z),beta_MHR(z),No*pow( 1+z, 3),usecaseB);
-      Throw GSLError;
+      GSL_ERROR(status);
   }
 
   gsl_integration_workspace_free (w);
@@ -215,7 +215,7 @@ double A_aux_integral(double z){
       LOG_ERROR("gsl integration error occured!");
       LOG_ERROR("(function argument): lower_limit=%e upper_limit=%e rel_tol=%e result=%e error=%e",lower_limit,upper_limit,rel_tol,result,error);
       LOG_ERROR("data: z=%e",z);
-      Throw GSLError;
+      GSL_ERROR(status);
   }
 
   gsl_integration_workspace_free (w);


### PR DESCRIPTION
Increase the accuracy of the GSL integration routine to resolve #225. May make the code ever so slightly slower, but should be negligible.

Additionally, update the error reporting for GSL errors to report the inbuilt GSL status code. This uses the already defined function that clearly I missed...