### PR TITLE
fix: update use_interpolation_tables default with warning.

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -97,8 +97,7 @@ jobs:
           export PATH="$HOME/miniconda/bin:$PATH"
           source activate $ENV_NAME
           python -m pytest -l --cov=py21cmfast --cov-config=.coveragerc -vv --cov-report xml:./coverage.xml --durations=25 ${{ env.extra_pytest_args }}
-      - uses: codecov/codecov-action@master
-        if: matrix.os == 'ubuntu-latest' && success()
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v1.5.2
         with:
-          token: ${{secrets.CODECOV_TOKEN}} #required
-          file: ./coverage.xml #optional
+          fail_ci_if_error: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 dev-version
 -----------
 
+Change
+~~~~~~
+
+* Updated ``USE_INTERPOLATION_TABLES`` to be default True. This makes much more sense as
+  a default value. Until v4, a warning will be raised if it is not set explicitly.
+
 v3.1.1 [13 Jun 2021]
 ----------------------
 

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -14,6 +14,7 @@ used throughout the computation which are very rarely varied.
 """
 import contextlib
 import logging
+import warnings
 from astropy.cosmology import Planck15
 from os import path
 from pathlib import Path
@@ -468,7 +469,7 @@ class UserParams(StructWithDefaults):
         "N_THREADS": 1,
         "PERTURB_ON_HIGH_RES": False,
         "NO_RNG": False,
-        "USE_INTERPOLATION_TABLES": False,
+        "USE_INTERPOLATION_TABLES": None,
         "FAST_FCOLL_TABLES": False,
         "USE_2LPT": True,
         "MINIMIZE_MEMORY": False,
@@ -476,6 +477,21 @@ class UserParams(StructWithDefaults):
 
     _hmf_models = ["PS", "ST", "WATSON", "WATSON-Z"]
     _power_models = ["EH", "BBKS", "EFSTATHIOU", "PEEBLES", "WHITE", "CLASS"]
+
+    @property
+    def USE_INTERPOLATION_TABLES(self):
+        """Whether to use interpolation tables for integrals, speeding things up."""
+        if self._USE_INTERPOLATION_TABLES is None:
+            warnings.warn(
+                "The USE_INTERPOLATION_TABLES setting has changed in v3.1.2 to be "
+                "default True. You can likely ignore this warning, but if you relied on"
+                "having USE_INTERPOLATION_TABLES=False by *default*, please set it "
+                "explicitly. To silence this warning, set it explicitly to True. This"
+                "warning will be removed in v4."
+            )
+            self._USE_INTERPOLATION_TABLES = True
+
+        return self._USE_INTERPOLATION_TABLES
 
     @property
     def DIM(self):

--- a/tests/test_input_structs.py
+++ b/tests/test_input_structs.py
@@ -7,7 +7,7 @@ import pytest
 import pickle
 
 from py21cmfast import AstroParams  # An example of a struct with defaults
-from py21cmfast import CosmoParams, FlagOptions, UserParams, global_params
+from py21cmfast import CosmoParams, FlagOptions, UserParams, __version__, global_params
 
 
 @pytest.fixture(scope="module")
@@ -163,3 +163,15 @@ def test_fcoll_on(caplog):
         "You cannot turn on FAST_FCOLL_TABLES without USE_INTERPOLATION_TABLES"
         in caplog.text
     )
+
+
+@pytest.mark.xfail(
+    __version__ >= "4.0.0", reason="the warning can be removed in v4", strict=True
+)
+def test_interpolation_table_warning():
+    with pytest.warns(UserWarning, match="setting has changed in v3.1.2"):
+        UserParams().USE_INTERPOLATION_TABLES
+
+    with pytest.warns(None) as record:
+        UserParams(USE_INTERPOLATION_TABLES=True).USE_INTERPOLATION_TABLES
+    assert not record


### PR DESCRIPTION
Closes #186

I went the route of issuing a warning whenever the user doesn't set this explicitly (because in principle this is API breaking, so we should at least warn users that it's happening). This warning can be removed in the next major version.