### PR TITLE
Update rmax

### DIFF
--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -627,6 +627,8 @@ class FlagOptions(StructWithDefaults):
         Determines whether to use a fixed vcb=VAVG (*regardless* of USE_RELATIVE_VELOCITIES). It includes the average effect of velocities but not its fluctuations.
     USE_VELS_AUX: bool, optional
         Auxiliary variable (not input) to check if minihaloes are being used without relative velocities and complain
+    EVOLVING_R_BUBBLE_MAX: bool, optional
+        Whether to use the redshift-dependent R_BUBBLE_MAX (37*0.7/hlittle*((1+z)/5)**-5.7; cap at z>6). This will overide R_BUBBLE_MAX set in AstroParams.
     """
 
     _ffi = ffi
@@ -641,6 +643,7 @@ class FlagOptions(StructWithDefaults):
         "M_MIN_in_Mass": False,
         "PHOTON_CONS": False,
         "FIX_VCB_AVG": False,
+        "EVOLVING_R_BUBBLE_MAX": False,
     }
 
     # This checks if relative velocities are off to complain if minihaloes are on

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -624,11 +624,14 @@ class FlagOptions(StructWithDefaults):
         Whether to perform a small correction to account for the inherent
         photon non-conservation.
     FIX_VCB_AVG: bool, optional
-        Determines whether to use a fixed vcb=VAVG (*regardless* of USE_RELATIVE_VELOCITIES). It includes the average effect of velocities but not its fluctuations.
+        Determines whether to use a fixed vcb=VAVG (*regardless* of USE_RELATIVE_VELOCITIES).
+        It includes the average effect of velocities but not its fluctuations.
     USE_VELS_AUX: bool, optional
-        Auxiliary variable (not input) to check if minihaloes are being used without relative velocities and complain
+        Auxiliary variable (not input) to check if minihaloes are being used without relative velocities and complain.
     EVOLVING_R_BUBBLE_MAX: bool, optional
-        Whether to use the redshift-dependent R_BUBBLE_MAX (37*0.7/hlittle*((1+z)/5)**-5.7; cap at z>6). This will overide R_BUBBLE_MAX set in AstroParams.
+        Whether to use the redshift-dependent R_BUBBLE_MAX (37pMpc*0.7/hlittle*((1+z)/5)**-4.7
+        from Worseck+14 adjusted index for Becker+21; cap at z>6, i.e. ~40cMpc).
+        This will overide R_BUBBLE_MAX set in AstroParams.
     """
 
     _ffi = ffi

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -78,7 +78,7 @@ struct FlagOptions{
     bool M_MIN_in_Mass;
     bool PHOTON_CONS;
     bool FIX_VCB_AVG;
-    bool USE_VELS_AUEVOLVING_R_BUBBLE_MAX;
+    bool EVOLVING_R_BUBBLE_MAX;
 };
 
 

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -78,6 +78,7 @@ struct FlagOptions{
     bool M_MIN_in_Mass;
     bool PHOTON_CONS;
     bool FIX_VCB_AVG;
+    bool USE_VELS_AUEVOLVING_R_BUBBLE_MAX;
 };
 
 

--- a/src/py21cmfast/src/Globals.h
+++ b/src/py21cmfast/src/Globals.h
@@ -89,7 +89,7 @@ struct GlobalParams{
 
 extern struct GlobalParams global_params = {
 
-    .ALPHA_UVB = 5.0,
+    .ALPHA_UVB = 2.0, // see https://arxiv.org/pdf/1807.09282.pdf
     .EVOLVE_DENSITY_LINEARLY = 0,
     .SMOOTH_EVOLVED_DENSITY_FIELD = 0,
     .R_smooth_density = 0.2,
@@ -152,7 +152,7 @@ extern struct GlobalParams global_params = {
     .M_MIN_INTEGRAL = 1e5,
     .M_MAX_INTEGRAL = 1e16,
 
-    .T_RE = 2e4,
+    .T_RE = 1e4,
 
     .VAVG=25.86,
 

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -356,9 +356,9 @@ LOG_DEBUG("first redshift, do some initialization");
     }
     if (astro_params->R_BUBBLE_MAX && flag_options->EVOLVING_R_BUBBLE_MAX){
         if (redshift > 6)
-            R_BUBBLE_MAX = 3.8051340473779267 / cosmo_params->hlittle
+            R_BUBBLE_MAX = 26.635938331645487 / cosmo_params->hlittle
         else
-            R_BUBBLE_MAX = 37 * 0.7 / cosmo_params->hlittle * pow( (1.+redshift) / 5 , -5.7);
+            R_BUBBLE_MAX = 129.5 / cosmo_params->hlittle * pow( (1.+redshift) / 5. , -4.7);
     }
     else
         R_BUBBLE_MAX = astro_params->R_BUBBLE_MAX

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -356,12 +356,12 @@ LOG_DEBUG("first redshift, do some initialization");
     }
     if (astro_params->R_BUBBLE_MAX && flag_options->EVOLVING_R_BUBBLE_MAX){
         if (redshift > 6)
-            R_BUBBLE_MAX = 26.635938331645487 / cosmo_params->hlittle
+            R_BUBBLE_MAX = 26.635938331645487 / cosmo_params->hlittle;
         else
             R_BUBBLE_MAX = 129.5 / cosmo_params->hlittle * pow( (1.+redshift) / 5. , -4.7);
     }
     else
-        R_BUBBLE_MAX = astro_params->R_BUBBLE_MAX
+        R_BUBBLE_MAX = astro_params->R_BUBBLE_MAX;
     //set the minimum source mass
     if (flag_options->USE_MASS_DEPENDENT_ZETA) {
         if (flag_options->USE_MINI_HALOS){

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -98,6 +98,7 @@ int ComputeIonizedBox(float redshift, float prev_redshift, struct UserParams *us
     float prev_min_density, prev_max_density;
 
     float stored_redshift, adjustment_factor;
+    float R_BUBBLE_MAX;
 
     gsl_rng * r[user_params->N_THREADS];
 
@@ -132,7 +133,7 @@ LOG_SUPER_DEBUG("defined parameters");
         }
 
      if (prev_redshift < 1) //deal with first redshift
-		 ZSTEP = (1. + redshift) * (global_params.ZPRIME_STEP_FACTOR - 1.);
+        ZSTEP = (1. + redshift) * (global_params.ZPRIME_STEP_FACTOR - 1.);
      else
         ZSTEP = prev_redshift - redshift;
 
@@ -353,6 +354,14 @@ LOG_DEBUG("first redshift, do some initialization");
         if (flag_options->INHOMO_RECO)
             previous_ionize_box->dNrec_box   = (float *) calloc(HII_TOT_NUM_PIXELS, sizeof(float));
     }
+    if (astro_params->R_BUBBLE_MAX && flag_options->EVOLVING_R_BUBBLE_MAX){
+        if (redshift > 6)
+            R_BUBBLE_MAX = 3.8051340473779267 / cosmo_params->hlittle
+        else
+            R_BUBBLE_MAX = 37 * 0.7 / cosmo_params->hlittle * pow( (1.+redshift) / 5 , -5.7);
+    }
+    else
+        R_BUBBLE_MAX = astro_params->R_BUBBLE_MAX
     //set the minimum source mass
     if (flag_options->USE_MASS_DEPENDENT_ZETA) {
         if (flag_options->USE_MINI_HALOS){
@@ -365,8 +374,8 @@ LOG_DEBUG("first redshift, do some initialization");
                 // really painful to get the length...
                 counter = 1;
                 R=fmax(global_params.R_BUBBLE_MIN, (cell_length_factor*user_params->BOX_LEN/(float)user_params->HII_DIM));
-                while ((R - fmin(astro_params->R_BUBBLE_MAX, L_FACTOR*user_params->BOX_LEN)) <= FRACT_FLOAT_ERR ){
-                    if(R >= fmin(astro_params->R_BUBBLE_MAX, L_FACTOR*user_params->BOX_LEN)) {
+                while ((R - fmin(R_BUBBLE_MAX, L_FACTOR*user_params->BOX_LEN)) <= FRACT_FLOAT_ERR ){
+                    if(R >= fmin(R_BUBBLE_MAX, L_FACTOR*user_params->BOX_LEN)) {
                         stored_R = R/(global_params.DELTA_R_HII_FACTOR);
                     }
                     R*= global_params.DELTA_R_HII_FACTOR;
@@ -742,22 +751,22 @@ LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll_MINI: %e", box->mean_f
 
         R=fmax(global_params.R_BUBBLE_MIN, (cell_length_factor*user_params->BOX_LEN/(float)user_params->HII_DIM));
 
-        while ((R - fmin(astro_params->R_BUBBLE_MAX, L_FACTOR * user_params->BOX_LEN)) <= FRACT_FLOAT_ERR) {
+        while ((R - fmin(R_BUBBLE_MAX, L_FACTOR * user_params->BOX_LEN)) <= FRACT_FLOAT_ERR) {
             R *= global_params.DELTA_R_HII_FACTOR;
-            if (R >= fmin(astro_params->R_BUBBLE_MAX, L_FACTOR * user_params->BOX_LEN)) {
+            if (R >= fmin(R_BUBBLE_MAX, L_FACTOR * user_params->BOX_LEN)) {
                 stored_R = R / (global_params.DELTA_R_HII_FACTOR);
             }
         }
 
         LOG_DEBUG("set max radius: %f", R);
 
-        R=fmin(astro_params->R_BUBBLE_MAX, L_FACTOR*user_params->BOX_LEN);
+        R=fmin(R_BUBBLE_MAX, L_FACTOR*user_params->BOX_LEN);
 
         LAST_FILTER_STEP = 0;
 
         first_step_R = 1;
 
-        double R_temp = (double) (astro_params->R_BUBBLE_MAX);
+        double R_temp = (double) (R_BUBBLE_MAX);
 
         counter = 0;
 


### PR DESCRIPTION
add the EVOLVING_R_BUBBLE_MAX flag to use the redshift-dependent R_BUBBLE_MAX (37pMpc*0.7/hlittle*((1+z)/5)**-4.7 from Worseck+14 with adjusted index for Becker+21; cap at z>6, i.e. ~40cMpc).