### PR TITLE
Fixed ACG flag when using FAST_FCOLL_TABLES

### DIFF
--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -29,7 +29,7 @@ struct UserParams{
     bool PERTURB_ON_HIGH_RES;
     bool NO_RNG;
     bool USE_INTERPOLATION_TABLES;
-    bool FAST_FCOLL_TABLES; //jbm:Whether to use the fast Fcoll table approximation in EPS
+    bool FAST_FCOLL_TABLES; //Whether to use the fast Fcoll table approximation in EPS
     bool USE_2LPT;
     bool MINIMIZE_MEMORY;
 };

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -2191,7 +2191,7 @@ double Nion_ConditionalM_MINI(double growthf, double M1, double M2, double sigma
 double Nion_ConditionalM(double growthf, double M1, double M2, double sigma2, double delta1, double delta2, double MassTurnover, double Alpha_star, double Alpha_esc, double Fstar10, double Fesc10, double Mlim_Fstar, double Mlim_Fesc, bool FAST_FCOLL_TABLES) {
 
 
-  if (FAST_FCOLL_TABLES) { //JBM: Fast tables. Assume sharp Mturn, not exponential cutoff.
+  if (FAST_FCOLL_TABLES && global_params.USE_FAST_ATOMIC) { //JBM: Fast tables. Assume sharp Mturn, not exponential cutoff.
 
     return GaussLegendreQuad_Nion(0, 0, (float) growthf, (float) M2, (float) sigma2, (float) delta1, (float) delta2, (float) MassTurnover, (float) Alpha_star, (float) Alpha_esc, (float) Fstar10, (float) Fesc10, (float) Mlim_Fstar, (float) Mlim_Fesc, FAST_FCOLL_TABLES);
 


### PR DESCRIPTION
It was only written for GaussLegendreQuad, but not for Nion_ConditionalM, and the latter was calling the former.