### PR TITLE
maint: fallback versions for downloading tarballs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,5 +90,9 @@ setup(
     setup_requires=["cffi>=1.0", "setuptools_scm"],
     entry_points={"console_scripts": ["21cmfast = py21cmfast.cli:main"]},
     cffi_modules=[f"{pkgdir}/build_cffi.py:ffi"],
-    use_scm_version={"write_to": "src/py21cmfast/_version.py"},
+    use_scm_version={
+        "write_to": "src/py21cmfast/_version.py",
+        "parentdir_prefix_version": "21cmFAST-",
+        "fallback_version": "0.0.0",
+    },
 )


### PR DESCRIPTION
This adds fallback versions when downloading releases from Github.

Firstly, if you download an actual release, eg. `21cmFAST-3.1.5.tar.gz`, then it will get the version actually correct. If you just download the tarball from the master branch, eg. `21cmFAST.tar.gz`, then it will fallback to v0.0.0 without error.