### PR TITLE
fix: issue with write=False not stopping I/O

### DIFF
--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -123,7 +123,7 @@ def _configure_inputs(
     defaults: list,
     *datasets,
     ignore: list = ["redshift"],
-    flag_none: [list, None] = None,
+    flag_none: list | None = None,
 ):
     """Configure a set of input parameter structs.
 
@@ -261,17 +261,19 @@ def _get_config_options(
 ) -> Tuple[str, bool, Dict[Callable, Dict[str, Any]]]:
 
     direc = str(os.path.expanduser(config["direc"] if direc is None else direc))
-    hooks = hooks or {}
 
-    if callable(write) and write not in hooks:
-        hooks[write] = {"direc": direc}
+    if hooks is None or len(hooks) > 0:
+        hooks = hooks or {}
 
-    if not hooks:
-        if write is None:
-            write = config["write"]
+        if callable(write) and write not in hooks:
+            hooks[write] = {"direc": direc}
 
-        if not callable(write) and write:
-            hooks["write"] = {"direc": direc}
+        if not hooks:
+            if write is None:
+                write = config["write"]
+
+            if not callable(write) and write:
+                hooks["write"] = {"direc": direc}
 
     return (
         direc,

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -123,7 +123,7 @@ def _configure_inputs(
     defaults: list,
     *datasets,
     ignore: list = ["redshift"],
-    flag_none: list | None = None,
+    flag_none: Union[list, None] = None,
 ):
     """Configure a set of input parameter structs.
 


### PR DESCRIPTION
Fixes #277 

This should fix the behaviour mentioned in the above issue where data was being written even with `write=False`. The problem was that in every sub-function (eg. `initial_conditions()`), the `hooks` keyword was passed through, but not the `write` keyword. While the hooks initially get built as a dict with the correct behaviour (i.e. no "write" entry), on the second time the hooks is constructed, with `write=None`, it was assuming that function was being called directly and automatically inserting the write hook in, then passing that on.