### PR TITLE
feat: floats in hashes now written to given sig figs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,11 +9,13 @@ Changed
 
 * Floats are now represented to a specific number of significant digits in the hash of
   an output object. This fixes problems with very close redshifts not being read from
-  cache (#80). Note that this means that ver close astro/cosmo params will now be read
+  cache (#80). Note that this means that very close astro/cosmo params will now be read
   from cache. This could cause issues when creating large databases with many random
   parameters. The behaviour can modified in the configuration by setting the
-  ``cache_significant_figures`` parameter. **NOTE**: updating to this version will cause
-  your previous cached files to become unusable. Remove them before updating.
+  ``cache_param_sigfigs`` and ``cache_redshift_sigfigs`` parameters (these are 6 and
+  4 by default, respectively).
+  **NOTE**: updating to this version will cause your previous cached files to become
+  unusable. Remove them before updating.
 
 v3.1.5 [27 Apr 2022]
 ----------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ Changelog
 dev-version
 -----------
 
+Changed
+-------
+
+* Floats are now represented to a specific number of significant digits in the hash of
+  an output object. This fixes problems with very close redshifts not being read from
+  cache (#80). Note that this means that ver close astro/cosmo params will now be read
+  from cache. This could cause issues when creating large databases with many random
+  parameters. The behaviour can modified in the configuration by setting the
+  ``cache_significant_figures`` parameter. **NOTE**: updating to this version will cause
+  your previous cached files to become unusable. Remove them before updating.
+
 v3.1.5 [27 Apr 2022]
 ----------------------
 

--- a/src/py21cmfast/_cfg.py
+++ b/src/py21cmfast/_cfg.py
@@ -1,4 +1,6 @@
 """Open and read the configuration file."""
+from __future__ import annotations
+
 import contextlib
 import copy
 import warnings

--- a/src/py21cmfast/_cfg.py
+++ b/src/py21cmfast/_cfg.py
@@ -22,7 +22,8 @@ class Config(dict):
         "direc": "~/21cmFAST-cache",
         "regenerate": False,
         "write": True,
-        "cache_significant_figures": 4,
+        "cache_param_sigfigs": 6,
+        "cache_redshift_sigfigs": 4,
     }
 
     _aliases = {"direc": ("boxdir",)}

--- a/src/py21cmfast/_cfg.py
+++ b/src/py21cmfast/_cfg.py
@@ -16,7 +16,12 @@ class ConfigurationError(Exception):
 class Config(dict):
     """Simple over-ride of dict that adds a context manager."""
 
-    _defaults = {"direc": "~/21cmFAST-cache", "regenerate": False, "write": True}
+    _defaults = {
+        "direc": "~/21cmFAST-cache",
+        "regenerate": False,
+        "write": True,
+        "cache_significant_figures": 4,
+    }
 
     _aliases = {"direc": ("boxdir",)}
 
@@ -73,7 +78,7 @@ class Config(dict):
         for k in kwargs:
             self[k] = backup[k]
 
-    def write(self, fname: [str, Path, None] = None):
+    def write(self, fname: str | Path | None = None):
         """Write current configuration to file to make it permanent."""
         fname = Path(fname or self.file_name)
         if fname:
@@ -88,7 +93,7 @@ class Config(dict):
         return {k: str(Path) if isinstance(v, Path) else v for k, v in self.items()}
 
     @classmethod
-    def load(cls, file_name: [str, Path]):
+    def load(cls, file_name: str | Path):
         """Create a Config object from a config file."""
         file_name = Path(file_name).expanduser().absolute()
 

--- a/src/py21cmfast/_utils.py
+++ b/src/py21cmfast/_utils.py
@@ -516,7 +516,18 @@ class StructWithDefaults(StructWrapper):
         return (
             self.__class__.__name__
             + "("
-            + ", ".join(sorted(k + ":" + str(v) for k, v in self.defining_dict.items()))
+            + ", ".join(
+                sorted(
+                    k
+                    + ":"
+                    + (
+                        float_to_string_precision(v)
+                        if isinstance(v, (float, np.float32))
+                        else str(v)
+                    )
+                    for k, v in self.defining_dict.items()
+                )
+            )
             + ")"
         )
 
@@ -554,6 +565,14 @@ def camel_to_snake(word: str, depublicize: bool = False):
         word = word.lstrip("_")
 
     return word
+
+
+def float_to_string_precision(x, n=config["cache_significant_figures"]):
+    """Prints out a standard float number at a given number of significant digits.
+
+    Code here: https://stackoverflow.com/a/48812729
+    """
+    return f'{float(f"{x:.{int(n)}g}"):g}'
 
 
 def get_all_subclasses(cls):
@@ -1213,7 +1232,13 @@ class OutputStruct(StructWrapper, metaclass=ABCMeta):
                     else (
                         v.filtered_repr(self._filter_params)
                         if isinstance(v, StructInstanceWrapper)
-                        else k.lstrip("_") + ":" + repr(v)
+                        else k.lstrip("_")
+                        + ":"
+                        + (
+                            float_to_string_precision(v, 4)
+                            if isinstance(v, (float, np.float32))
+                            else repr(v)
+                        )
                     )
                     for k, v in [
                         (k, getattr(self, k))

--- a/src/py21cmfast/_utils.py
+++ b/src/py21cmfast/_utils.py
@@ -521,7 +521,7 @@ class StructWithDefaults(StructWrapper):
                     k
                     + ":"
                     + (
-                        float_to_string_precision(v)
+                        float_to_string_precision(v, config["cache_redshift_sigfigs"])
                         if isinstance(v, (float, np.float32))
                         else str(v)
                     )
@@ -567,7 +567,7 @@ def camel_to_snake(word: str, depublicize: bool = False):
     return word
 
 
-def float_to_string_precision(x, n=config["cache_significant_figures"]):
+def float_to_string_precision(x, n):
     """Prints out a standard float number at a given number of significant digits.
 
     Code here: https://stackoverflow.com/a/48812729
@@ -1235,7 +1235,7 @@ class OutputStruct(StructWrapper, metaclass=ABCMeta):
                         else k.lstrip("_")
                         + ":"
                         + (
-                            float_to_string_precision(v, 4)
+                            float_to_string_precision(v, config["cache_param_sigfigs"])
                             if isinstance(v, (float, np.float32))
                             else repr(v)
                         )


### PR DESCRIPTION
Fixes #80

This changes the string representation of `OutputStructs` and `StructWithDefaults` objects so that floats appear with a certain number of significant digits (configurable in global configuration). Primarily deals with the caching of redshifts (by default, it uses 4 significant digits, so the redshifts 6.001 and 6.000 would be considered different, but not 6.0001). 

A couple of things to think about:

1. I've applied the float rendering also to input structs, so eg. `HII_EFF_FACTOR=30.0` and `HII_EFF_FACTOR=30.001` would be considered the same. This could play a little havoc on MCMC routines (or other uses where a large database of randomly sampled parameters is chosen), so that the parameters change but the outputs don't, creating a "step-like" likelihood. To offset this, the user can set the significant digits much higher on a particular run. Also, they probably shouldn't be caching on such a run. But if we think that's not a good idea, I can turn off the significant figure truncation on the input params (but not redshift).
2. Unfortunately, this change could render a user's existing cache unusable. I've warned about this in the CHANGELOG, but they might not read that.
3. it strikes me that different parameters might need different precision. Redshifts probably don't need 4 digits, while astro/cosmo params might. I don't have a great way of enforcing this. I could hack it out though, if we think it's important.