### PR TITLE
ci: add codecov token due to rate limits

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -100,5 +100,6 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
 # CC=$HOME/miniconda/envs/$ENV_NAME/bin/gcc


### PR DESCRIPTION
Adds the CODECOV_TOKEN to avoid some of the upload errors from rate limits.