### PR TITLE
Fix for the specific case in #311

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,8 @@ Added
   across all neighbouring cells instead of the previous nearest cell approach
 * Changed PhotonConsEndCalibz from z = 5 -> z = 3.5 to handle later reionisation
   scenarios in line with current observations (#305)
+* Add in an initialisation check for the photon conservation to address some issues
+  arising for early EOR histories (#311)
 
 v3.2.1 [13 Sep 2022]
 ----------------------

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -95,7 +95,7 @@ dependencies:
   - wheel
   - astropy
   - dbus
-  - jinja2
+  - jinja2=3.0.3
   - sphinxcontrib-applehelp
   - libxcb
   - pcre

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -3984,6 +3984,14 @@ float adjust_redshifts_for_photoncons(
             adjusted_redshift = *redshift;
         }
         else {
+            // Initialise the photon non-conservation correction curve
+            // It is possible that for certain parameter choices that we can get here without initialisation happening.
+            // Thus check and initialise if not already done so
+            if(!photon_cons_allocated) {
+                determine_deltaz_for_photoncons();
+                photon_cons_allocated = true;
+            }
+
             // We have crossed the NF threshold for the photon conservation correction so now set to the delta z at the threshold
             if(required_NF < global_params.PhotonConsAsymptoteTo) {
 


### PR DESCRIPTION
Photon conservation correction could miss the initialisation step under an extreme scenario of a very early EoR and with low `Z_HEAT_MAX`. This PR adds in a check for this occurrence and initialises the requisite function if it has not already been initialised.

A fix for the specific example in #311. But not necessarily the broader issue of dealing with the brittle photon conservation correction