### PR TITLE
Added ubuntu installation instructions

### DIFF
--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -41,8 +41,8 @@ Most linux distros come with packages for the requirements, and also ``gcc`` by 
 which supports ``-fopenmp``. As long as these packages install into the standard location,
 a standard installation of ``21cmFAST`` will be automatically possible (see below).
 If they are installed to a place not on the ``LD_LIBRARY``/``INCLUDE`` paths, then you
-must use the compilation options (see below) to specify where they are. 
-For example, you can check if the header file for ``fftw3`` is 
+must use the compilation options (see below) to specify where they are.
+For example, you can check if the header file for ``fftw3`` is
 in its default location ``/usr/include/`` by running::
 
     cd /usr/include/
@@ -58,13 +58,13 @@ or::
 
 Ubuntu
 ^^^^^^
-If you are installing 21cmFAST just as a user, the very simplest method is ``conda`` 
--- with this method you simply need ``conda install -c conda-forge 21cmFAST``, and all 
+If you are installing 21cmFAST just as a user, the very simplest method is ``conda``
+-- with this method you simply need ``conda install -c conda-forge 21cmFAST``, and all
 dependencies will be automatically installed. However, if you are going to use
 ``pip`` to install the package directly from the repository, there is
 a [bug in pip](https://stackoverflow.com/questions/71340058/conda-does-not-look-for-libpthread-and-libpthread-nonshared-at-the-right-place-w)
-that means it cannot find conda-installed shared libraries properly. In that case, it is much 
-easier to install the basic dependencies (``gcc``, ``gsl`` and ``fftw3``) with your 
+that means it cannot find conda-installed shared libraries properly. In that case, it is much
+easier to install the basic dependencies (``gcc``, ``gsl`` and ``fftw3``) with your
 system's package manager. ``gcc`` is by default available in Ubuntu.
 To check if ``gcc`` is installed, run ``gcc --version`` in your terminal.
 Install ``fftw3`` and ``gsl`` on your system with  ``sudo apt-get install libfftw3-dev libgsl-dev``.
@@ -79,9 +79,9 @@ If there is an issue during installation, add ``DEBUG=all`` or ``--DEBUG`` which
 information.
 
 .. note:: If there is an error during compilation that the ``fftw3`` library cannot be found,
-          check where the ``fftw3`` library is actually located using ``locate libfftw3.so``. 
+          check where the ``fftw3`` library is actually located using ``locate libfftw3.so``.
           For example, it may be located in ``/usr/lib/x86_64-linux-gnu/``. Then, provide this path
-          to the installation command with the ``LIB`` flag. For more details see the note in the 
+          to the installation command with the ``LIB`` flag. For more details see the note in the
           MacOSX section below.
 
 .. note:: You may choose to install ``gsl`` as an anaconda package as well, however, in that case,

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -76,6 +76,10 @@ In your ``21cmfast`` environment, now install the ``21cmFAST`` package using::
 If there is an issue during installation, add ``DEBUG=all`` or ``--DEBUG`` which may provide additional
 information.
 
+.. note:: You may choose to install ``gsl`` as an anaconda package as well, however, in that case, 
+          you need to add the path to the gsl header in the environment e.g. 
+          ``INC=/usr/include /path/to/conda/env/include/``
+
 MacOSX
 ~~~~~~
 On MacOSX, obtaining ``gsl`` and ``fftw`` is typically more difficult, and in addition,

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -47,6 +47,27 @@ must use the compilation options (see below) to specify where they are.
           This is discussed below in the context of MacOSX, where it is often the
           easiest way to get the dependencies, but it is equally applicable to linux.
 
+Ubuntu
+^^^^^^
+It is best to use a system-wide installation of ``gcc, gsl,`` and ``fftw3`` rather than installing 
+them in a conda environment. ``gcc`` is by default available in Ubuntu. 
+To check if ``gcc`` is installed, run ``gcc --version`` in your terminal.
+Install ``fftw3`` and ``gsl`` on your system with  ``sudo apt-get install libfftw3-dev libgsl-dev``.
+
+Once these are successfully installed, check where the ``fftw3`` library is actually located 
+using ``locate libfftw3.so``. For example, it may be located in ``/usr/lib/x86_64-linux-gnu/``.
+
+Make sure you can locate the header files as well, usually in 
+``/usr/include/``. Check this by running ``cd /usr/include/`` and ``find fftw3.h`` or ``locate fftw3.h``.
+
+Lastly, locate your ``gcc`` installation using ``which gcc``.
+
+In your ``21cmfast`` environment, now install the ``21cmFAST`` package using ``cd /path/to/21cmFAST/``,
+followed by ``CC=/path/to/gcc LIB=/path/to/lib/ INC=/path/to/headers/include/ pip install .``.
+If there is an issue during installation, add ``DEBUG=all`` or ``--DEBUG`` which may provide additional
+information.
+
+
 MacOSX
 ~~~~~~
 On MacOSX, obtaining ``gsl`` and ``fftw`` is typically more difficult, and in addition,

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -49,15 +49,15 @@ must use the compilation options (see below) to specify where they are.
 
 Ubuntu
 ^^^^^^
-It is best to use a system-wide installation of ``gcc, gsl,`` and ``fftw3`` rather than installing 
-them in a conda environment. ``gcc`` is by default available in Ubuntu. 
+It is best to use a system-wide installation of ``gcc, gsl,`` and ``fftw3`` rather than installing
+them in a conda environment. ``gcc`` is by default available in Ubuntu.
 To check if ``gcc`` is installed, run ``gcc --version`` in your terminal.
 Install ``fftw3`` and ``gsl`` on your system with  ``sudo apt-get install libfftw3-dev libgsl-dev``.
 
-Once these are successfully installed, check where the ``fftw3`` library is actually located 
+Once these are successfully installed, check where the ``fftw3`` library is actually located
 using ``locate libfftw3.so``. For example, it may be located in ``/usr/lib/x86_64-linux-gnu/``.
 
-Make sure you can locate the header files as well, usually in 
+Make sure you can locate the header files as well, usually in
 ``/usr/include/``. Check this by running ``cd /usr/include/`` and ``find fftw3.h`` or ``locate fftw3.h``.
 
 Lastly, locate your ``gcc`` installation using ``which gcc``.

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -41,24 +41,10 @@ Most linux distros come with packages for the requirements, and also ``gcc`` by 
 which supports ``-fopenmp``. As long as these packages install into the standard location,
 a standard installation of ``21cmFAST`` will be automatically possible (see below).
 If they are installed to a place not on the ``LD_LIBRARY``/``INCLUDE`` paths, then you
-must use the compilation options (see below) to specify where they are.
+must use the compilation options (see below) to specify where they are. 
+For example, you can check if the header file for ``fftw3`` is 
+in its default location ``/usr/include/`` by running::
 
-.. note:: there exists the option of installing ``gsl``, ``fftw`` and ``gcc`` using ``conda``.
-          This is discussed below in the context of MacOSX, where it is often the
-          easiest way to get the dependencies, but it is equally applicable to linux.
-
-Ubuntu
-^^^^^^
-It is best to use a system-wide installation of ``gcc, gsl,`` and ``fftw3`` rather than installing
-them in a conda environment. ``gcc`` is by default available in Ubuntu.
-To check if ``gcc`` is installed, run ``gcc --version`` in your terminal.
-Install ``fftw3`` and ``gsl`` on your system with  ``sudo apt-get install libfftw3-dev libgsl-dev``.
-
-Once these are successfully installed, check where the ``fftw3`` library is actually located
-using ``locate libfftw3.so``. For example, it may be located in ``/usr/lib/x86_64-linux-gnu/``.
-
-Make sure you can locate the header files as well, usually in
-``/usr/include/``. Check this by running::
     cd /usr/include/
     find fftw3.h
 
@@ -66,19 +52,41 @@ or::
 
     locate fftw3.h
 
-Lastly, locate your ``gcc`` installation using ``which gcc``.
+.. note:: there exists the option of installing ``gsl``, ``fftw`` and ``gcc`` using ``conda``.
+          This is discussed below in the context of MacOSX, where it is often the
+          easiest way to get the dependencies, but it is equally applicable to linux.
+
+Ubuntu
+^^^^^^
+If you are installing 21cmFAST just as a user, the very simplest method is ``conda`` 
+-- with this method you simply need ``conda install -c conda-forge 21cmFAST``, and all 
+dependencies will be automatically installed. However, if you are going to use
+``pip`` to install the package directly from the repository, there is
+a [bug in pip](https://stackoverflow.com/questions/71340058/conda-does-not-look-for-libpthread-and-libpthread-nonshared-at-the-right-place-w)
+that means it cannot find conda-installed shared libraries properly. In that case, it is much 
+easier to install the basic dependencies (``gcc``, ``gsl`` and ``fftw3``) with your 
+system's package manager. ``gcc`` is by default available in Ubuntu.
+To check if ``gcc`` is installed, run ``gcc --version`` in your terminal.
+Install ``fftw3`` and ``gsl`` on your system with  ``sudo apt-get install libfftw3-dev libgsl-dev``.
+
 
 In your ``21cmfast`` environment, now install the ``21cmFAST`` package using::
 
     cd /path/to/21cmFAST/
-    CC=/path/to/gcc LIB=/path/to/lib/ INC=/path/to/headers/include/ pip install
+    pip install .
 
 If there is an issue during installation, add ``DEBUG=all`` or ``--DEBUG`` which may provide additional
 information.
 
+.. note:: If there is an error during compilation that the ``fftw3`` library cannot be found,
+          check where the ``fftw3`` library is actually located using ``locate libfftw3.so``. 
+          For example, it may be located in ``/usr/lib/x86_64-linux-gnu/``. Then, provide this path
+          to the installation command with the ``LIB`` flag. For more details see the note in the 
+          MacOSX section below.
+
 .. note:: You may choose to install ``gsl`` as an anaconda package as well, however, in that case,
-          you need to add the path to the gsl header in the environment e.g.
-          ``INC=/usr/include /path/to/conda/env/include/``
+          you need to add both ``INC`` paths in the installation command e.g.:
+          ``GSL_INC=/path/to/conda/env/include FFTW_INC=/usr/include``
 
 MacOSX
 ~~~~~~

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -61,7 +61,7 @@ Make sure you can locate the header files as well, usually in
 ``/usr/include/``. Check this by running::
     cd /usr/include/
     find fftw3.h
-    
+
 or::
 
     locate fftw3.h
@@ -69,7 +69,7 @@ or::
 Lastly, locate your ``gcc`` installation using ``which gcc``.
 
 In your ``21cmfast`` environment, now install the ``21cmFAST`` package using::
-   
+
     cd /path/to/21cmFAST/
     CC=/path/to/gcc LIB=/path/to/lib/ INC=/path/to/headers/include/ pip install
 

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -76,8 +76,8 @@ In your ``21cmfast`` environment, now install the ``21cmFAST`` package using::
 If there is an issue during installation, add ``DEBUG=all`` or ``--DEBUG`` which may provide additional
 information.
 
-.. note:: You may choose to install ``gsl`` as an anaconda package as well, however, in that case, 
-          you need to add the path to the gsl header in the environment e.g. 
+.. note:: You may choose to install ``gsl`` as an anaconda package as well, however, in that case,
+          you need to add the path to the gsl header in the environment e.g.
           ``INC=/usr/include /path/to/conda/env/include/``
 
 MacOSX

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -58,15 +58,23 @@ Once these are successfully installed, check where the ``fftw3`` library is actu
 using ``locate libfftw3.so``. For example, it may be located in ``/usr/lib/x86_64-linux-gnu/``.
 
 Make sure you can locate the header files as well, usually in
-``/usr/include/``. Check this by running ``cd /usr/include/`` and ``find fftw3.h`` or ``locate fftw3.h``.
+``/usr/include/``. Check this by running::
+    cd /usr/include/
+    find fftw3.h
+    
+or::
+
+    locate fftw3.h
 
 Lastly, locate your ``gcc`` installation using ``which gcc``.
 
-In your ``21cmfast`` environment, now install the ``21cmFAST`` package using ``cd /path/to/21cmFAST/``,
-followed by ``CC=/path/to/gcc LIB=/path/to/lib/ INC=/path/to/headers/include/ pip install .``.
+In your ``21cmfast`` environment, now install the ``21cmFAST`` package using::
+   
+    cd /path/to/21cmFAST/
+    CC=/path/to/gcc LIB=/path/to/lib/ INC=/path/to/headers/include/ pip install
+
 If there is an issue during installation, add ``DEBUG=all`` or ``--DEBUG`` which may provide additional
 information.
-
 
 MacOSX
 ~~~~~~

--- a/build_cffi.py
+++ b/build_cffi.py
@@ -11,9 +11,9 @@ include_dirs = [CLOC]
 # Set compilation arguments dependent on environment... a bit buggy
 # =================================================================
 if "DEBUG" in os.environ:
-    extra_compile_args = ["-fopenmp", "-w", "-g", "-O0"]
+    extra_compile_args = ["-fopenmp", "-w", "-g", "-O0", "--verbose"]
 else:
-    extra_compile_args = ["-fopenmp", "-Ofast", "-w"]
+    extra_compile_args = ["-fopenmp", "-Ofast", "-w", "--verbose"]
 
 # Set the C-code logging level.
 # If DEBUG is set, we default to the highest level, but if not,

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -2,7 +2,7 @@ name: 21cmfast
 channels:
   - defaults
 dependencies:
-  - python=3.7
+  - python=3.9
   - sphinxcontrib-htmlhelp
   - zlib
   - pip
@@ -10,7 +10,6 @@ dependencies:
   - libffi
   - zipp
   - click
-  - libgcc-ng
   - scipy
   - expat
   - pytest


### PR DESCRIPTION
Added installation instructions for ubuntu reflecting my recent struggles (thank you @steven-murray )
Updated the 21cmfast environment YAML file to install python 3.9 and removed the gcc library package inside (since we found it was better to use a system installation of gcc)
Added --verbose flags in build_cffi,py