### PR TITLE
ci: update to use codecov

### DIFF
--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -21,6 +21,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       OS: ${{ matrix.os }}
       CC: gcc
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     name: Testing
     runs-on: ${{ matrix.os }}
     strategy:
@@ -101,11 +102,10 @@ jobs:
           path: |
             testplots/*.pdf
 
-      - uses: codecov/codecov-action@v3
+      - name: Upload Coverage
         if: matrix.os == 'ubuntu-latest' && success() && !contains(github.event.pull_request.labels.*.name, 'auto-pr')
-        with:
-          fail_ci_if_error: true
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-# CC=$HOME/miniconda/envs/$ENV_NAME/bin/gcc
+        run: |
+          pip install codecov-cli
+          codecovcli create-commit
+          codecovcli create-report
+          codecovcli do-upload


### PR DESCRIPTION
Use the codecov-cli instead of the github action uploader, in preparation for using new codecov ATS