### PR TITLE
Large halo number fix

### DIFF
--- a/src/py21cmfast/src/FindHaloes.c
+++ b/src/py21cmfast/src/FindHaloes.c
@@ -9,7 +9,7 @@
 // the virialized halos
 
 int check_halo(char * in_halo, struct UserParams *user_params, float R, int x, int y, int z, int check_type);
-void init_halo_coords(struct HaloField *halos, int n_halos);
+void init_halo_coords(struct HaloField *halos, long long unsigned int n_halos);
 int pixel_in_halo(int grid_dim, int z_dim, int x, int x_index, int y, int y_index, int z, int z_index, float Rsq_curr_index );
 void free_halo_field(struct HaloField *halos);
 
@@ -52,7 +52,7 @@ LOG_DEBUG("redshift=%f", redshift);
         float growth_factor, R, delta_m, M, Delta_R, delta_crit;
         char *in_halo, *forbidden;
         int i,j,k,x,y,z;
-        int total_halo_num, r_halo_num;
+        long long unsigned int total_halo_num, r_halo_num;
         float R_temp, M_MIN;
 
         LOG_DEBUG("Begin Initialisation");
@@ -277,7 +277,7 @@ LOG_DEBUG("redshift=%f", redshift);
                 }
             }
             total_halo_num += r_halo_num;
-            LOG_SUPER_DEBUG("n_halo = %d, total = %d , D = %.3f, delcrit = %.3f", r_halo_num, total_halo_num, growth_factor, delta_crit);
+            LOG_SUPER_DEBUG("n_halo = %llu, total = %llu , D = %.3f, delcrit = %.3f", r_halo_num, total_halo_num, growth_factor, delta_crit);
 
             R /= global_params.DELTA_R_FACTOR;
         }
@@ -477,7 +477,7 @@ int check_halo(char * in_halo, struct UserParams *user_params, float R, int x, i
     }
 }
 
-void init_halo_coords(struct HaloField *halos, int n_halos){
+void init_halo_coords(struct HaloField *halos, long long unsigned int n_halos){
     // Minimise memory usage by only storing the halo mass and positions
     halos->n_halos = n_halos;
     halos->halo_masses = (float *)calloc(n_halos,sizeof(float));

--- a/src/py21cmfast/src/FindHaloes.c
+++ b/src/py21cmfast/src/FindHaloes.c
@@ -383,7 +383,7 @@ LOG_DEBUG("redshift=%f", redshift);
         fftwf_forget_wisdom();
 
 LOG_DEBUG("Finished halo cleanup.");
-LOG_DEBUG("Found %d Halos", halos->n_halos);
+LOG_DEBUG("Found %llu Halos", halos->n_halos);
 if (halos->n_halos > 3)
     LOG_DEBUG("Halo Masses: %e %e %e %e", halos->halo_masses[0], halos->halo_masses[1], halos->halo_masses[2], halos->halo_masses[3]);
 

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -367,7 +367,7 @@ int ComputeHaloBox(double redshift, struct UserParams *user_params, struct Cosmo
         Broadcast_struct_global_PS(user_params,cosmo_params);
         Broadcast_struct_global_STOC(user_params,cosmo_params,astro_params,flag_options);
 
-        int idx;
+        unsigned long long int idx;
 #pragma omp parallel for num_threads(user_params->N_THREADS) private(idx)
         for (idx=0; idx<HII_TOT_NUM_PIXELS; idx++) {
             grids->halo_mass[idx] = 0.0;
@@ -380,7 +380,7 @@ int ComputeHaloBox(double redshift, struct UserParams *user_params, struct Cosmo
             grids->count[idx] = 0;
         }
 
-        LOG_DEBUG("Gridding %d halos...",halos->n_halos);
+        LOG_DEBUG("Gridding %llu halos...",halos->n_halos);
 
         double alpha_esc = astro_params->ALPHA_ESC;
         double norm_esc = astro_params->F_ESC10;
@@ -419,16 +419,14 @@ int ComputeHaloBox(double redshift, struct UserParams *user_params, struct Cosmo
             M_turn_m_avg = averages_box[6];
             get_box_averages(redshift, norm_esc, alpha_esc, M_min, M_cell, M_turn_a_avg, M_turn_m_avg, averages_global);
             //This is the mean adjustment that happens in the rest of the code
-            int i;
-
             //NOTE: in the default mode, global averages are fixed separately for minihalo and regular parts
 #pragma omp parallel for num_threads(user_params->N_THREADS)
-            for(i=0;i<HII_TOT_NUM_PIXELS;i++){
-                grids->halo_mass[i] *= averages_global[0]/averages_box[0];
-                grids->halo_sfr[i] *= averages_global[1]/averages_box[1];
-                grids->halo_sfr_mini[i] *= averages_global[2]/averages_box[2];
-                grids->n_ion[i] *= averages_global[3]/averages_box[3];
-                grids->whalo_sfr[i] *= averages_global[4]/averages_box[4];
+            for(idx=0;idx<HII_TOT_NUM_PIXELS;idx++){
+                grids->halo_mass[idx] *= averages_global[0]/averages_box[0];
+                grids->halo_sfr[idx] *= averages_global[1]/averages_box[1];
+                grids->halo_sfr_mini[idx] *= averages_global[2]/averages_box[2];
+                grids->n_ion[idx] *= averages_global[3]/averages_box[3];
+                grids->whalo_sfr[idx] *= averages_global[4]/averages_box[4];
             }
 
             hm_avg = averages_global[0];
@@ -455,7 +453,8 @@ int ComputeHaloBox(double redshift, struct UserParams *user_params, struct Cosmo
             }
 #pragma omp parallel num_threads(user_params->N_THREADS) private(idx)
             {
-                int i_halo,x,y,z;
+                int x,y,z;
+                unsigned long long int i_halo;
                 double m,nion,sfr,wsfr,sfr_mini,stars_mini,stars;
                 double J21_val, Gamma12_val, zre_val;
 

--- a/src/py21cmfast/src/PerturbHaloField.c
+++ b/src/py21cmfast/src/PerturbHaloField.c
@@ -29,8 +29,8 @@ LOG_DEBUG("redshift=%f", redshift);
         omp_set_num_threads(user_params->N_THREADS);
 
         float growth_factor, displacement_factor_2LPT, mass, xf, yf, zf, z, growth_factor_over_BOX_LEN,displacement_factor_2LPT_over_BOX_LEN;
-        int i,j,k, i_halo,xi, yi, zi, DI, dimension;
-        unsigned long long ct;
+        int i, j, k, xi, yi, zi, DI, dimension;
+        unsigned long long ct, i_halo;
         float dz = 1e-10;
 
 LOG_DEBUG("Begin Initialisation");
@@ -240,7 +240,7 @@ LOG_DEBUG("Begin Initialisation");
         fftwf_cleanup_threads();
         fftwf_cleanup();
         fftwf_forget_wisdom();
-        LOG_DEBUG("Perturbed positions of %d Halos", halos_perturbed->n_halos);
+        LOG_DEBUG("Perturbed positions of %llu Halos", halos_perturbed->n_halos);
 
     } // End of Try()
     Catch(status){

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -491,7 +491,8 @@ void calculate_spectral_factors(double zp){
 
 //fill fftwf boxes, do the r2c transform and normalise
 void prepare_filter_boxes(double redshift, float *input_dens, float *input_vcb, float *input_j21, fftwf_complex *output_dens, fftwf_complex *output_LW){
-    int i,j,k,ct;
+    int i,j,k;
+    unsigned long long int ct;
     double curr_vcb,curr_j21,M_buf;
 
     //NOTE: Meraxes just applies a pointer cast box = (fftwf_complex *) input. Figure out why this works,
@@ -607,7 +608,8 @@ int UpdateXraySourceBox(struct UserParams *user_params, struct CosmoParams *cosm
         //the indexing needs these
         Broadcast_struct_global_UF(user_params,cosmo_params);
 
-        int i,j,k,ct;
+        int i,j,k;
+        unsigned long long int ct;
         fftwf_complex *filtered_box = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
         fftwf_complex *unfiltered_box = (fftwf_complex *)fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
         fftwf_complex *filtered_box_mini = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
@@ -793,7 +795,7 @@ void fill_freqint_tables(double zp, double x_e_ave, double filling_factor_of_HI_
 //construct a Ts table above Z_HEAT_MAX, this can happen if we are computing the first box or if we
 //request a redshift above Z_HEAT_MAX
 void init_first_Ts(struct TsBox * box, float *dens, float z, float zp, double *x_e_ave, double *Tk_ave){
-    int box_ct;
+    unsigned long long int box_ct;
     //zp is the requested redshift, z is the perturbed field redshift
     float growth_factor_zp;
     float inverse_growth_factor_z;
@@ -929,7 +931,7 @@ void calculate_sfrd_from_grid(int R_ct, float *dens_R_grid, float *Mcrit_R_grid,
 
     #pragma omp parallel num_threads(user_params_ts->N_THREADS)
     {
-        int box_ct;
+        unsigned long long int box_ct;
         double curr_dens,curr_mcrit;
         double fcoll, dfcoll;
         double fcoll_MINI=0;
@@ -1211,7 +1213,8 @@ void ts_main(float redshift, float prev_redshift, struct UserParams *user_params
                   struct AstroParams *astro_params, struct FlagOptions *flag_options, float perturbed_field_redshift, short cleanup,
                   struct PerturbedField *perturbed_field, struct XraySourceBox *source_box, struct TsBox *previous_spin_temp,
                   struct InitialConditions *ini_boxes, struct TsBox *this_spin_temp){
-    int box_ct, R_ct, i, j, k;
+    int R_ct, i, j, k;
+    unsigned long long int box_ct;
     double x_e_ave_p, Tk_ave_p;
     double growth_factor_z, growth_factor_zp;
     double inverse_growth_factor_z;


### PR DESCRIPTION
Fixes #384. Some indices for halo number were still `int` type, which caused issues for boxes with billions of halos. They have been changed to `long long unsigned`.