### PR TITLE
Lightcone distance unit fix

### DIFF
--- a/src/py21cmfast/outputs.py
+++ b/src/py21cmfast/outputs.py
@@ -1151,6 +1151,9 @@ class LightCone(_HighLevelOutput):
         self._current_redshift = current_redshift or redshift
         self.lightcone_distances = distances
 
+        if not hasattr(self.lightcone_distances, "unit"):
+            self.lightcone_distances = self.lightcone_distances * units.Mpc
+
         # A *copy* of the current global parameters.
         self.global_params = _globals or dict(global_params.items())
 

--- a/src/py21cmfast/outputs.py
+++ b/src/py21cmfast/outputs.py
@@ -1152,7 +1152,7 @@ class LightCone(_HighLevelOutput):
         self.lightcone_distances = distances
 
         if not hasattr(self.lightcone_distances, "unit"):
-            self.lightcone_distances = self.lightcone_distances * units.Mpc
+            self.lightcone_distances <<= units.Mpc
 
         # A *copy* of the current global parameters.
         self.global_params = _globals or dict(global_params.items())

--- a/tests/test_high_level_io.py
+++ b/tests/test_high_level_io.py
@@ -62,7 +62,7 @@ def test_lightcone_roundtrip(test_direc, lc):
 
     assert lc == lc2
     assert lc.get_unique_filename() == lc2.get_unique_filename()
-    assert lc.lightcone_redshifts == lc2.lightcone_redshifts
+    assert np.allclose(lc.lightcone_redshifts, lc2.lightcone_redshifts)
     assert np.all(np.isclose(lc.brightness_temp, lc2.brightness_temp))
 
 

--- a/tests/test_high_level_io.py
+++ b/tests/test_high_level_io.py
@@ -62,6 +62,7 @@ def test_lightcone_roundtrip(test_direc, lc):
 
     assert lc == lc2
     assert lc.get_unique_filename() == lc2.get_unique_filename()
+    assert lc.lightcone_redshifts == lc2.lightcone_redshifts
     assert np.all(np.isclose(lc.brightness_temp, lc2.brightness_temp))
 
 


### PR DESCRIPTION
Since the angular lightcone update, the `lightcone_distances` field has units. However these units are not saved and loaded from the HDF5 Files.

This is a quick fix which adds the units when required. It might be a better long-term idea to properly save the units of all quantities along with the values, however this will take more time, and currently you cannot call `lightcone_redshifts` on a lightcone loaded from file.

I have also added a `lightcone_redshift` check to `test_lightcone_roundtrip` to catch this in future.