### PR TITLE
fix return value order in make_lightcone_slices

### DIFF
--- a/src/py21cmfast/lightcones.py
+++ b/src/py21cmfast/lightcones.py
@@ -162,11 +162,13 @@ class Lightconer(ABC):
 
         Returns
         -------
+        quantity
+            The field names of the quantities required by the lightcone.
+        lcidx
+            The indices of the lightcone to which these slices belong.
         scalar_field_slices
             The scalar fields evaluated on the "lightcone" slices that exist within
             the redshift range spanned by ``c1`` and ``c2``.
-        lcidx
-            The indices of the lightcone to which these slices belong.
         """
         if c1.user_params != c2.user_params:
             raise ValueError("c1 and c2 must have the same user parameters")
@@ -192,7 +194,7 @@ class Lightconer(ABC):
 
         # Return early if no lightcone indices are between the coeval distances.
         if len(lcidx) == 0:
-            yield None, None, lcidx
+            yield None, lcidx, None
 
         lc_distances = pixlcdist[lcidx]
 

--- a/tests/test_lightconer.py
+++ b/tests/test_lightconer.py
@@ -137,8 +137,8 @@ def test_coeval_redshifts_outside_box(equal_cdist):
 
     q, idx, out = next(equal_cdist.make_lightcone_slices(z6, z7))
     assert q is None
-    assert idx is None
-    assert len(out) == 0
+    assert len(idx) == 0
+    assert out is None
 
 
 def test_bad_coeval_sizes_for_redshift_interp(equal_cdist):


### PR DESCRIPTION
In some lightcone runs, I noticed a crash when the simulation was run at higher redshifts than the lightconer outputs. It seems that the case where we don't find any interpolation outputs in `make_lightcone_slices` yielded arguments in the wrong order, resulting in a KeyError when we index the lightcone. This has been fixed.

Before I merge, I would like to add to the tests to check for this, however we already run lightcones in the tests which have maximum redshifts below `Z_HEAT_MAX` and I'm having trouble figuring out why it doesn't crash there.