### PR TITLE
Lx scatter and Nikolic+2024 scaling relations

### DIFF
--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -978,15 +978,16 @@ class AstroParams(StructWithDefaults):
         Power-law index of fraction of galactic gas in stars as a function of halo mass, for MCGs.
         See Sec 2 of Muñoz+21 (2110.13919).
     SIGMA_STAR : float, optional
-        Lognormal scatter of the halo mass to stellar mass relation.
+        Lognormal scatter (dex) of the halo mass to stellar mass relation.
         Uniform across all masses and redshifts.
     CORR_STAR : float, optional
         Self-correlation length used for updating halo properties. Properties are interpolated between
         a random sample at the current halo mass and one matching the point in the PDF of the
         previous sample, the interpolation point in [0,1] is given by exp(-dz/CORR_STAR)
-    SIGMA_SFR : float, optional
-        Lognormal scatter of the stellar mass to SFR relation.
-        Uniform across all masses and redshifts.
+    SIGMA_SFR_LIM : float, optional
+        Lognormal scatter (dex) of the stellar mass to SFR relation above a stellar mass of 1e10 solar.
+    SIGMA_SFR_INDEX : float, optional
+        index of the power-law between SFMS scatter and stellar mass below 1e10 solar.
     CORR_SFR : float, optional
         Self-correlation length used for updating halo properties. Properties are interpolated between
         a random sample at the current halo mass and one matching the point in the PDF of the
@@ -1054,6 +1055,13 @@ class AstroParams(StructWithDefaults):
     UPPER_STELLAR_TURNOVER_INDEX:
         The power-law index associated with the optional upper mass power-law of the stellar-halo mass relation
         (see FlagOptions.USE_UPPER_STELLAR_TURNOVER)
+    SIGMA_LX: float, optional
+        Lognormal scatter (dex) of the Xray luminosity relation.
+        Uniform across all masses and redshifts.
+    CORR_LX : float, optional
+        Self-correlation length used for updating halo properties. Properties are interpolated between
+        a random sample at the current halo mass and one matching the point in the PDF of the
+        previous sample, the interpolation point in [0,1] is given by exp(-dz/CORR_STAR)
     """
 
     _ffi = ffi
@@ -1064,9 +1072,10 @@ class AstroParams(StructWithDefaults):
         "F_STAR7_MINI": -2.0,
         "ALPHA_STAR": 0.5,
         "ALPHA_STAR_MINI": 0.5,
-        "SIGMA_STAR": 0.5,
+        "SIGMA_STAR": 0.25,
         "CORR_STAR": 0.5,
-        "SIGMA_SFR": 0.6,
+        "SIGMA_SFR_LIM": 0.19,
+        "SIGMA_SFR_INDEX": -0.12,
         "CORR_SFR": 0.2,
         "F_ESC10": -1.0,
         "F_ESC7_MINI": -2.0,
@@ -1087,7 +1096,9 @@ class AstroParams(StructWithDefaults):
         "A_VCB": 1.0,
         "BETA_VCB": 1.8,
         "UPPER_STELLAR_TURNOVER_MASS": 11.447,  # 2.8e11
-        "UPPER_STELLAR_TURNOVER_INDEX": -0.61,
+        "UPPER_STELLAR_TURNOVER_INDEX": -0.6,
+        "SIGMA_LX": 0.5,
+        "CORR_LX": 0.2,  # NOTE (Jdavies): It's difficult to know what this should be, ASTRID doesn't have the xrays and I don't know which hydros do
     }
 
     def __init__(
@@ -1112,7 +1123,9 @@ class AstroParams(StructWithDefaults):
             "X_RAY_Tvir_MIN",
             "UPPER_STELLAR_TURNOVER_MASS",
         ]:
-            return 10**val
+            return 10**val  # log10 to linear conversion
+        if key in ["SIMGA_STAR" "SIGMA_SFR_LIM" "SIGMA_LX"]:
+            return 2.3025851 * val  # dex to base e conversion
         else:
             return val
 

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -1037,12 +1037,12 @@ class AstroParams(StructWithDefaults):
         Given in log10 units.
     L_X : float, optional
         The specific X-ray luminosity per unit star formation escaping host galaxies.
-        Cf. Eq. 6 of Greig+2018. Given in log10 units. For models which use metallicity this gives
-        the value at solar metallicity.
+        Cf. Eq. 6 of Greig+2018. Given in log10 units. For the double power-law used in the Halo Model
+        This gives the low-z limite.
     L_X_MINI: float, optional
         The specific X-ray luminosity per unit star formation escaping host galaxies for
-        minihalos. Cf. Eq. 23 of Qin+2020. Given in log10 units. For models which use metallicity this gives
-        the value at solar metallicity.
+        minihalos. Cf. Eq. 23 of Qin+2020. Given in log10 units. For the double power-law used in the Halo Model
+        This gives the low-z limite.
     NU_X_THRESH : float, optional
         X-ray energy threshold for self-absorption by host galaxies (in eV). Also called
         E_0 (cf. Sec 4.1 of Greig+2018). Typical range is (100, 1500).
@@ -1094,8 +1094,8 @@ class AstroParams(StructWithDefaults):
         "M_TURN": None,
         "R_BUBBLE_MAX": None,
         "ION_Tvir_MIN": 4.69897,
-        "L_X": 39.46,  # Kaur+22 and Brorby+16
-        "L_X_MINI": 39.46,
+        "L_X": 40.5,  # Kaur+22
+        "L_X_MINI": 40.5,
         "NU_X_THRESH": 500.0,
         "X_RAY_SPEC_INDEX": 1.0,
         "X_RAY_Tvir_MIN": None,

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -1025,10 +1025,12 @@ class AstroParams(StructWithDefaults):
         Given in log10 units.
     L_X : float, optional
         The specific X-ray luminosity per unit star formation escaping host galaxies.
-        Cf. Eq. 6 of Greig+2018. Given in log10 units.
+        Cf. Eq. 6 of Greig+2018. Given in log10 units. For models which use metallicity this gives
+        the value at solar metallicity.
     L_X_MINI: float, optional
         The specific X-ray luminosity per unit star formation escaping host galaxies for
-        minihalos. Cf. Eq. 23 of Qin+2020. Given in log10 units.
+        minihalos. Cf. Eq. 23 of Qin+2020. Given in log10 units. For models which use metallicity this gives
+        the value at solar metallicity.
     NU_X_THRESH : float, optional
         X-ray energy threshold for self-absorption by host galaxies (in eV). Also called
         E_0 (cf. Sec 4.1 of Greig+2018). Typical range is (100, 1500).
@@ -1080,8 +1082,8 @@ class AstroParams(StructWithDefaults):
         "M_TURN": 8.7,
         "R_BUBBLE_MAX": None,
         "ION_Tvir_MIN": 4.69897,
-        "L_X": 38.44,  # Nikolic et al. 2024 L_X at 10^10 solar
-        "L_X_MINI": 38.44,  # Nikolic et al. 2024
+        "L_X": 39.46,  # Kaur+22 and Brorby+16
+        "L_X_MINI": 39.46,
         "NU_X_THRESH": 500.0,
         "X_RAY_SPEC_INDEX": 1.0,
         "X_RAY_Tvir_MIN": None,

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -931,11 +931,23 @@ class FlagOptions(StructWithDefaults):
         return self._HALO_STOCHASTICITY
 
     @property
+    def USE_EXP_FILTER(self):
+        """Automatically setting USE_EXP_FILTER to False if not HII_FILTER==0."""
+        if self._USE_EXP_FILTER and global_params.HII_FILTER != 0:
+            warnings.warn(
+                "USE_EXP_FILTER can only be used with a real-space tophat HII_FILTER==0"
+                "Setting USE_EXP_FILTER to False"
+            )
+            return False
+        return self._USE_EXP_FILTER
+
+    @property
     def CELL_RECOMB(self):
         """Automatically setting CELL_RECOMB if USE_EXP_FILTER is active."""
         if self.USE_EXP_FILTER and not self._CELL_RECOMB:
             warnings.warn(
                 "CELL_RECOMB is automatically set to True if USE_EXP_FILTER is True."
+                "setting CELL_RECOMB to True"
             )
             return True
         return self._CELL_RECOMB
@@ -1350,9 +1362,3 @@ def validate_all_inputs(
 
         if flag_options.USE_EXP_FILTER and not flag_options.USE_HALO_FIELD:
             warnings.warn("USE_EXP_FILTER has no effect unless USE_HALO_FIELD is true")
-
-        if flag_options.USE_EXP_FILTER and global_params.HII_FILTER != 0:
-            warnings.warn(
-                "USE_EXP_FILTER can only be used with a tophat HII_FILTER, setting HII_FILTER = 0"
-            )
-            global_params.HII_FILTER = 0

--- a/src/py21cmfast/outputs.py
+++ b/src/py21cmfast/outputs.py
@@ -337,6 +337,7 @@ class HaloField(_AllParamsBox):
             "halo_masses": (self.buffer_size,),
             "star_rng": (self.buffer_size,),
             "sfr_rng": (self.buffer_size,),
+            "xray_rng": (self.buffer_size,),
             "halo_coords": (self.buffer_size, 3),
         }
 
@@ -400,6 +401,7 @@ class PerturbHaloField(_AllParamsBox):
             "halo_masses": (self.buffer_size,),
             "star_rng": (self.buffer_size,),
             "sfr_rng": (self.buffer_size,),
+            "xray_rng": (self.buffer_size,),
             "halo_coords": (self.buffer_size, 3),
         }
 
@@ -461,6 +463,7 @@ class HaloBox(_AllParamsBox):
             "count": shape,
             "halo_sfr": shape,
             "halo_sfr_mini": shape,
+            "halo_xray": shape,
             "n_ion": shape,
             "whalo_sfr": shape,
         }
@@ -534,6 +537,7 @@ class XraySourceBox(_AllParamsBox):
         out = {
             "filtered_sfr": shape,
             "filtered_sfr_mini": shape,
+            "filtered_xray": shape,
             "mean_sfr": (global_params.NUM_FILTER_STEPS_FOR_Ts,),
             "mean_sfr_mini": (global_params.NUM_FILTER_STEPS_FOR_Ts,),
             "mean_log10_Mcrit_LW": (global_params.NUM_FILTER_STEPS_FOR_Ts,),
@@ -545,7 +549,9 @@ class XraySourceBox(_AllParamsBox):
         """Return all input arrays required to compute this object."""
         required = []
         if isinstance(input_box, HaloBox):
-            required += ["halo_sfr", "halo_sfr_mini"]
+            required += ["halo_sfr", "halo_xray"]
+            if self.flag_options.USE_MINI_HALOS:
+                required += ["halo_sfr_mini"]
         else:
             raise ValueError(f"{type(input_box)} is not an input required for HaloBox!")
 
@@ -650,7 +656,7 @@ class TsBox(_AllParamsBox):
                 required += ["J_21_LW_box"]
         elif isinstance(input_box, XraySourceBox):
             if self.flag_options.USE_HALO_FIELD:
-                required += ["filtered_sfr"]
+                required += ["filtered_sfr", "filtered_xray"]
                 if self.flag_options.USE_MINI_HALOS:
                     required += ["filtered_sfr_mini"]
         else:

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -64,8 +64,8 @@ struct AstroParams{
     //SFMS
     float t_STAR;
     float CORR_SFR;
-    double SFR_SIGMA_INDEX;
-    double SFR_SIGMA_LIM;
+    double SIGMA_SFR_INDEX;
+    double SIGMA_SFR_LIM;
 
     //L_X/SFR
     double L_X;
@@ -278,6 +278,10 @@ void free(void *ptr);
 int single_test_sample(struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params, struct FlagOptions *flag_options,
                         int seed, int n_condition, float *conditions, int *cond_crd, double z_out, double z_in, int *out_n_tot, int *out_n_cell, double *out_n_exp,
                         double *out_m_cell, double *out_m_exp, float *out_halo_masses, int *out_halo_coords);
+//test function for getting halo properties from the wrapper, can use a lot of memory for large catalogs
+int halo_props_exposed(double redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params,
+                    struct FlagOptions * flag_options, struct InitialConditions *ini_boxes, struct PerturbedField * perturbed_field, struct PerturbHaloField *halos,
+                    struct TsBox *previous_spin_temp, struct IonizedBox *previous_ionize_box, float *halo_props);
 
 //This function, designed to be used in the wrapper to estimate Halo catalogue size, takes the parameters and returns average number of halos within the box
 double expected_nhalo(double redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params, struct FlagOptions * flag_options);

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -279,7 +279,7 @@ int single_test_sample(struct UserParams *user_params, struct CosmoParams *cosmo
                         int seed, int n_condition, float *conditions, int *cond_crd, double z_out, double z_in, int *out_n_tot, int *out_n_cell, double *out_n_exp,
                         double *out_m_cell, double *out_m_exp, float *out_halo_masses, int *out_halo_coords);
 //test function for getting halo properties from the wrapper, can use a lot of memory for large catalogs
-int halo_props_exposed(double redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params,
+int test_halo_props(double redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params,
                     struct FlagOptions * flag_options, struct InitialConditions *ini_boxes, struct PerturbedField * perturbed_field, struct PerturbHaloField *halos,
                     struct TsBox *previous_spin_temp, struct IonizedBox *previous_ionize_box, float *halo_props);
 
@@ -360,7 +360,7 @@ double Nion_General(double z, double lnM_Min, double lnM_Max, double MassTurnove
                      double Fesc10, double Mlim_Fstar, double Mlim_Fesc);
 double Nion_General_MINI(double z, double lnM_Min, double lnM_Max, double MassTurnover, double MassTurnover_upper, double Alpha_star,
                          double Alpha_esc, double Fstar7_MINI, double Fesc7_MINI, double Mlim_Fstar, double Mlim_Fesc);
-double FgtrM_General(double z, double M);
+double Fcoll_General(double z, double lnM_min, double lnM_max);
 double unconditional_mf(double growthf, double lnM, double z, int HMF);
 double conditional_mf(double growthf, double lnM, double delta_cond, double sigma_cond, int HMF);
 double atomic_cooling_threshold(float z);

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -48,27 +48,40 @@ struct UserParams{
 };
 
 struct AstroParams{
-
     // Parameters taken from INIT_PARAMS.H
     float HII_EFF_FACTOR;
 
+    //SHMR
     float F_STAR10;
     float ALPHA_STAR;
     float ALPHA_STAR_MINI;
     float SIGMA_STAR;
-    float SIGMA_SFR;
     float CORR_STAR;
+    double UPPER_STELLAR_TURNOVER_MASS;
+    double UPPER_STELLAR_TURNOVER_INDEX;
+    float F_STAR7_MINI;
+
+    //SFMS
+    float t_STAR;
     float CORR_SFR;
+    double SFR_SIGMA_INDEX;
+    double SFR_SIGMA_LIM;
+
+    //L_X/SFR
+    double L_X;
+    double L_X_MINI;
+    double SIGMA_LX;
+    double CORR_LX;
+
+    //Escape Fraction
     float F_ESC10;
     float ALPHA_ESC;
-    float M_TURN;
-    float F_STAR7_MINI;
     float F_ESC7_MINI;
+
+    float M_TURN;
     float R_BUBBLE_MAX;
     float ION_Tvir_MIN;
     double F_H2_SHIELD;
-    double L_X;
-    double L_X_MINI;
     float NU_X_THRESH;
     float X_RAY_SPEC_INDEX;
     float X_RAY_Tvir_MIN;
@@ -78,12 +91,7 @@ struct AstroParams{
     double A_VCB;
     double BETA_VCB;
 
-    float t_STAR;
-
     int N_RSD_STEPS;
-
-    double UPPER_STELLAR_TURNOVER_MASS;
-    double UPPER_STELLAR_TURNOVER_INDEX;
 };
 
 struct FlagOptions{
@@ -128,6 +136,7 @@ struct HaloField{
     //Halo properties for stochastic model
     float *star_rng;
     float *sfr_rng;
+    float *xray_rng;
 };
 
 //gridded halo properties
@@ -141,6 +150,7 @@ struct HaloBox{
     //For IonisationBox.c and SpinTemperatureBox.c
     float *n_ion; //weighted by F_ESC*PopN_ion
     float *halo_sfr; //for x-rays and Ts stuff
+    float *halo_xray;
     float *halo_sfr_mini; //for x-rays and Ts stuff
     float *whalo_sfr; //SFR weighted by PopN_ion and F_ESC, used for Gamma12
 
@@ -156,6 +166,7 @@ struct PerturbHaloField{
     //Halo properties for stochastic model
     float *star_rng;
     float *sfr_rng;
+    float *xray_rng;
 };
 
 struct TsBox{
@@ -167,6 +178,7 @@ struct TsBox{
 
 struct XraySourceBox{
     float *filtered_sfr;
+    float *filtered_xray;
     float *filtered_sfr_mini;
 
     double *mean_log10_Mcrit_LW;

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -280,8 +280,8 @@ int single_test_sample(struct UserParams *user_params, struct CosmoParams *cosmo
                         double *out_m_cell, double *out_m_exp, float *out_halo_masses, int *out_halo_coords);
 //test function for getting halo properties from the wrapper, can use a lot of memory for large catalogs
 int test_halo_props(double redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params,
-                    struct FlagOptions * flag_options, struct InitialConditions *ini_boxes, struct PerturbedField * perturbed_field, struct PerturbHaloField *halos,
-                    struct TsBox *previous_spin_temp, struct IonizedBox *previous_ionize_box, float *halo_props);
+                    struct FlagOptions * flag_options, float * vcb_grid, float *J21_LW_grid, float *z_re_grid, float *Gamma12_ion_grid,
+                    struct PerturbHaloField *halos, float *halo_props_out);
 
 //This function, designed to be used in the wrapper to estimate Halo catalogue size, takes the parameters and returns average number of halos within the box
 double expected_nhalo(double redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params, struct FlagOptions * flag_options);

--- a/src/py21cmfast/src/21cmFAST.h
+++ b/src/py21cmfast/src/21cmFAST.h
@@ -154,7 +154,9 @@ struct HaloBox{
     float *halo_sfr_mini; //for x-rays and Ts stuff
     float *whalo_sfr; //SFR weighted by PopN_ion and F_ESC, used for Gamma12
 
-    double log10_Mcrit_LW_ave;
+    //Average volume-weighted log10 Turnover masses are kept in order to compare with the expected MF integrals
+    double log10_Mcrit_ACG_ave;
+    double log10_Mcrit_MCG_ave;
 };
 
 struct PerturbHaloField{

--- a/src/py21cmfast/src/FindHaloes.c
+++ b/src/py21cmfast/src/FindHaloes.c
@@ -70,7 +70,7 @@ LOG_DEBUG("redshift=%f", redshift);
         //set minimum source mass
         M_MIN = minimum_source_mass(redshift, false, astro_params, flag_options);
         //if we use the sampler we want to stop at the HII cell mass
-        if(flag_options->HALO_STOCHASTICITY || flag_options->FIXED_HALO_GRIDS)
+        if(flag_options->HALO_STOCHASTICITY)
             M_MIN = fmax(M_MIN,RtoM(L_FACTOR*user_params->BOX_LEN/user_params->HII_DIM));
         //otherwise we stop at the cell mass
         else
@@ -481,6 +481,7 @@ void init_halo_coords(struct HaloField *halos, long long unsigned int n_halos){
 
     halos->star_rng = (float *) calloc(n_halos,sizeof(float));
     halos->sfr_rng = (float *) calloc(n_halos,sizeof(float));
+    halos->xray_rng = (float *) calloc(n_halos,sizeof(float));
 }
 
 void free_halo_field(struct HaloField *halos){
@@ -489,6 +490,7 @@ void free_halo_field(struct HaloField *halos){
     free(halos->halo_coords);
     free(halos->star_rng);
     free(halos->sfr_rng);
+    free(halos->xray_rng);
     halos->n_halos = 0;
 }
 

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -53,9 +53,9 @@ struct HaloProperties{
     double fescweighted_sfr;
     double n_ion;
     double halo_xray;
-    double m_turn_a;
-    double m_turn_m;
-    double m_turn_r;
+    double m_turn_acg;
+    double m_turn_mcg;
+    double m_turn_reion;
 };
 
 void set_hbox_constants(double redshift, struct AstroParams *astro_params, struct FlagOptions *flag_options, struct HaloBoxConstants *consts){
@@ -72,10 +72,10 @@ void set_hbox_constants(double redshift, struct AstroParams *astro_params, struc
     consts->fstar_7 = astro_params->F_STAR7_MINI;
     consts->alpha_star_mini = astro_params->ALPHA_STAR_MINI;
 
-    consts->t_h = 1/Hubble(redshift);
+    consts->t_h = t_hubble(redshift);
     consts->t_star = astro_params->t_STAR;
-    consts->sigma_sfr_lim = astro_params->SFR_SIGMA_LIM;
-    consts->sigma_sfr_idx = astro_params->SFR_SIGMA_INDEX;
+    consts->sigma_sfr_lim = astro_params->SIGMA_SFR_LIM;
+    consts->sigma_sfr_idx = astro_params->SIGMA_SFR_INDEX;
 
     consts->l_x = astro_params->L_X;
     consts->l_x_mini = astro_params->L_X_MINI;
@@ -85,8 +85,9 @@ void set_hbox_constants(double redshift, struct AstroParams *astro_params, struc
     consts->fesc_10= astro_params->F_ESC10;
     consts->fesc_7 = astro_params->F_ESC7_MINI;
 
-    consts->mturn_a_nofb= flag_options->USE_MINI_HALOS ? atomic_cooling_threshold(redshift) : astro_params->M_TURN;
+    consts->mturn_a_nofb = flag_options->USE_MINI_HALOS ? atomic_cooling_threshold(redshift) : astro_params->M_TURN;
 
+    consts->mturn_m_nofb = 0.;
     if(flag_options->USE_MINI_HALOS){
         consts->mturn_m_nofb = lyman_werner_threshold(redshift, 0., consts->vcb_norel, astro_params);
         consts->vcb_norel = flag_options->FIX_VCB_AVG ? global_params.VAVG : 0;
@@ -132,10 +133,6 @@ void get_halo_stellarmass(double halo_mass, double mturn_acg, double mturn_mcg, 
 
     double baryon_ratio = cosmo_params_stoc->OMb / cosmo_params_stoc->OMm;
 
-    /* Simply adding lognormal scatter to a delta increases the mean (2* is as likely as 0.5*)
-    * We multiply by exp(-sigma^2/2) so that X = exp(mu + N(0,1)*sigma) has the desired mean */
-    star_rng = -sigma_star*sigma_star/2 + star_rng*sigma_star;
-
     //We don't want an upturn even with a negative ALPHA_STAR
     if(flag_options_stoc->USE_UPPER_STELLAR_TURNOVER && (f_a > fu_a)){
         fstar_mean = consts->upper_pivot_ratio / (pow(halo_mass/fu_p,-f_a)+pow(halo_mass/fu_p,-fu_a));
@@ -143,7 +140,7 @@ void get_halo_stellarmass(double halo_mass, double mturn_acg, double mturn_mcg, 
     else{
         fstar_mean = pow(halo_mass/1e10,f_a); //PL term
     }
-    f_sample *= f_10 * exp(-mturn_acg/halo_mass + star_rng); //1e10 normalisation of stellar mass
+    f_sample = f_10 * exp(-mturn_acg/halo_mass + star_rng*sigma_star); //1e10 normalisation of stellar mass
     if(f_sample > 1.) f_sample = 1.;
 
     sm_sample = f_sample * halo_mass * baryon_ratio;
@@ -169,7 +166,6 @@ void get_halo_sfr(double stellar_mass, double stellar_mass_mini, double sfr_rng,
     double sigma_sfr_lim = consts->sigma_sfr_lim;
     double sigma_sfr_idx = consts->sigma_sfr_idx;
     double sigma_sfr, sigma_sfr_mini;
-    double sfr_gauss, sfr_gauss_mini;
 
     //set the scatter based on the total Stellar mass
     //We use the total stellar mass (MCG + ACG) NOTE: it might be better to separate later
@@ -178,9 +174,7 @@ void get_halo_sfr(double stellar_mass, double stellar_mass_mini, double sfr_rng,
 
     sfr_mean = stellar_mass / (consts->t_star * consts->t_h);
 
-    //Since there's no clipping on t_STAR, we can apply the lognormal to SFR directly instead of t_STAR
-    sfr_gauss = exp(-sigma_sfr*sigma_sfr/2 + sfr_gauss*sigma_sfr);
-    sfr_sample = sfr_mean * sfr_gauss;
+    sfr_sample = sfr_mean * exp(sfr_rng*sigma_sfr);
     *sfr = sfr_sample;
 
     if(!flag_options_stoc->USE_MINI_HALOS){
@@ -189,7 +183,7 @@ void get_halo_sfr(double stellar_mass, double stellar_mass_mini, double sfr_rng,
     }
 
     sfr_mean_mini = stellar_mass_mini / (consts->t_star * consts->t_h);
-    sfr_sample_mini = sfr_mean_mini * sfr_gauss;
+    sfr_sample_mini = sfr_mean_mini * sfr_rng;
     *sfr_mini = sfr_sample_mini;
 }
 
@@ -205,15 +199,16 @@ void get_halo_metallicity(double sfr, double stellar, double redshift, double *m
 void get_halo_xray(double sfr, double sfr_mini, double metallicity, double xray_rng, struct HaloBoxConstants *consts, double *xray_lum){
     //Hardcoded for now (except the lx normalisation and the scatter): 3 extra fit parameters in the equation
     double xray_mean, xray_mean_mini;
-    double sigma = consts->sigma_xray;
+    xray_mean = (-0.11*log(metallicity) + 1.30)*log(sfr*SperYR) + -0.31*log(metallicity);
+    xray_mean = exp(xray_mean + xray_rng*consts->sigma_xray);
 
-    xray_rng = -sigma*sigma/2 + xray_rng*sigma;
-    xray_mean = (-0.11*log(metallicity) + 1.30)*log(sfr_mini*SperYR) + -0.31*log(metallicity) + consts->l_x;
-    xray_mean = exp(xray_mean + xray_rng);
-    xray_mean_mini = (-0.11*log(metallicity) + 1.30)*log(sfr_mini*SperYR) + -0.31*log(metallicity) + consts->l_x_mini;
-    xray_mean_mini = exp(xray_mean_mini + xray_rng);
+    xray_mean_mini = 0.;
+    if(flag_options_stoc->USE_MINI_HALOS){
+        xray_mean_mini = (-0.11*log(metallicity) + 1.30)*log(sfr_mini*SperYR) + -0.31*log(metallicity);
+        xray_mean_mini = exp(xray_mean_mini + xray_rng*consts->sigma_xray);
+    }
 
-    *xray_lum = xray_mean + xray_mean_mini;
+    *xray_lum = xray_mean*consts->l_x + xray_mean_mini*consts->l_x_mini;
 }
 
 //calculates halo properties from astro parameters plus the correlated rng
@@ -228,9 +223,16 @@ void get_halo_xray(double sfr, double sfr_mini, double metallicity, double xray_
 //in order to remain consistent with the minihalo treatment in default (Nion_a * exp(-M/M_a) + Nion_m * exp(-M/M_m - M_a/M))
 //  we treat the minihalos as a shift in the mean, where each halo will have both components, representing a smooth
 //  transition in halo mass from one set of SFR/emmissivity parameters to the other.
-void set_halo_properties(double halo_mass, double M_turn_a, float M_turn_m, struct HaloBoxConstants *consts, double *input_rng, struct HaloProperties *output){
+void set_halo_properties(double halo_mass, double M_turn_a, double M_turn_m, double M_turn_r,
+                         struct HaloBoxConstants *consts, double *input_rng, struct HaloProperties *output){
     double n_ion_sample, wsfr_sample;
     double fesc,fesc_mini;
+
+    //do reionization feedback
+    if(flag_options_stoc->USE_MINI_HALOS){
+        if(M_turn_a < M_turn_r)M_turn_a = M_turn_r;
+        if(M_turn_m < M_turn_r)M_turn_m = M_turn_r;
+    }
 
     double stellar_mass, stellar_mass_mini;
     get_halo_stellarmass(halo_mass,M_turn_a,M_turn_m,input_rng[0],consts,&stellar_mass,&stellar_mass_mini);
@@ -251,8 +253,6 @@ void set_halo_properties(double halo_mass, double M_turn_a, float M_turn_m, stru
     wsfr_sample = sfr*global_params.Pop2_ion*fesc + sfr_mini*global_params.Pop3_ion*fesc_mini;
 
     output->halo_mass = halo_mass;
-    output->m_turn_a = M_turn_a;
-    output->m_turn_m = M_turn_m;
     output->stellar_mass = stellar_mass;
     output->stellar_mini = stellar_mass_mini;
     output->halo_sfr = sfr;
@@ -260,6 +260,10 @@ void set_halo_properties(double halo_mass, double M_turn_a, float M_turn_m, stru
     output->fescweighted_sfr = wsfr_sample;
     output->n_ion = n_ion_sample;
     output->halo_xray = xray_lum;
+
+    output->m_turn_acg = M_turn_a;
+    output->m_turn_mcg = M_turn_m;
+    output->m_turn_reion = M_turn_r;
 }
 
 //Fixed halo grids, where each property is set as the integral of the CMF on the EULERIAN cell scale
@@ -369,13 +373,17 @@ int set_fixed_grids(double M_min, double M_max, struct InitialConditions *ini_bo
                 if(!flag_options_stoc->FIX_VCB_AVG && user_params_stoc->USE_RELATIVE_VELOCITIES){
                     curr_vcb = ini_boxes->lowres_vcb[i];
                 }
-                J21_val = consts->redshift < global_params.Z_HEAT_MAX ? previous_spin_temp->J_21_LW_box[i] : 0.;
-                Gamma12_val = consts->redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->Gamma12_box[i] : 0.;
-                zre_val = consts->redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->z_re_box[i] : 0.;
+                J21_val=Gamma12_val=zre_val=0.;
+                if(consts->redshift < global_params.Z_HEAT_MAX){
+                    J21_val = previous_spin_temp->J_21_LW_box[i];
+                    Gamma12_val = previous_ionize_box->Gamma12_box[i];
+                    zre_val = previous_ionize_box->z_re_box[i];
+                }
+                M_turn_a = M_turn_a_nofb;
                 M_turn_m = lyman_werner_threshold(consts->redshift, J21_val, curr_vcb, astro_params_stoc);
                 M_turn_r = reionization_feedback(consts->redshift, Gamma12_val, zre_val);
-                M_turn_a = M_turn_r > M_turn_a_nofb ? M_turn_r : M_turn_a_nofb; //since ACG turnover not reassigned
-                M_turn_m = M_turn_r > M_turn_m ? M_turn_r : M_turn_m;
+                if(M_turn_a < M_turn_r)M_turn_a = M_turn_r;
+                if(M_turn_m < M_turn_r)M_turn_m = M_turn_r;
             }
 
             h_count = EvaluateNhalo(dens, growth_z, lnMmin, lnMmax, M_cell, sigma_cell, dens);
@@ -435,9 +443,9 @@ int set_fixed_grids(double M_min, double M_max, struct InitialConditions *ini_bo
     averages->sfr_mini = sfr_avg_mini;
     averages->n_ion = nion_avg;
     averages->fescweighted_sfr = wsfr_avg;
-    averages->m_turn_a = Mlim_a_avg;
-    averages->m_turn_m = Mlim_m_avg;
-    averages->m_turn_r = Mlim_r_avg;
+    averages->m_turn_acg = Mlim_a_avg;
+    averages->m_turn_mcg = Mlim_m_avg;
+    averages->m_turn_reion = Mlim_r_avg;
 
     return 0;
 }
@@ -446,7 +454,7 @@ int set_fixed_grids(double M_min, double M_max, struct InitialConditions *ini_bo
 //WARNING: THESE AVERAGE BOXES ARE WRONG, CHECK THEM
 int get_box_averages(double M_min, double M_max, double M_turn_a, double M_turn_m, struct HaloBoxConstants *consts, struct HaloProperties *averages){
     LOG_SUPER_DEBUG("Getting Box averages z=%.2f M [%.2e %.2e] Mt [%.2e %.2e]",consts->redshift,M_min,M_max,M_turn_a,M_turn_m);
-    double t_h = t_hubble(consts->redshift);
+    double t_h = consts->t_h;
     double lnMmax = log(M_max);
     double lnMmin = log(M_min);
     double growth_z = dicke(consts->redshift);
@@ -500,8 +508,8 @@ int get_box_averages(double M_min, double M_max, double M_turn_a, double M_turn_
     averages->n_ion = intgrl_fesc_weighted*prefactor_nion + intgrl_fesc_weighted_mini*prefactor_nion_mini;
     averages->fescweighted_sfr = intgrl_fesc_weighted*prefactor_wsfr + intgrl_fesc_weighted_mini*prefactor_wsfr_mini;
     averages->halo_xray = intgrl_stars_only*prefactor_xray + intgrl_stars_only*prefactor_xray_mini;
-    averages->m_turn_a = M_turn_a;
-    averages->m_turn_m = M_turn_m;
+    averages->m_turn_acg = M_turn_a;
+    averages->m_turn_mcg = M_turn_m;
 
     return 0;
 }
@@ -510,13 +518,13 @@ void halobox_debug_print_avg(struct HaloProperties *averages_box, struct HaloPro
     if(LOG_LEVEL < DEBUG_LEVEL)
         return;
     struct HaloProperties averages_sub_expected, averages_global;
-    if(!flag_options_stoc->FIXED_HALO_GRIDS){
-        get_box_averages(M_min, M_cell, averages_box->m_turn_a, averages_box->m_turn_m, consts, &averages_global);
+    if(flag_options_stoc->FIXED_HALO_GRIDS){
+        get_box_averages(M_min, M_cell, averages_box->m_turn_acg, averages_box->m_turn_mcg, consts, &averages_global);
     }
     else{
-        get_box_averages(user_params_stoc->SAMPLER_MIN_MASS, M_cell, averages_box->m_turn_a, averages_box->m_turn_m, consts, &averages_global);
+        get_box_averages(user_params_stoc->SAMPLER_MIN_MASS, M_cell, averages_box->m_turn_acg, averages_box->m_turn_mcg, consts, &averages_global);
         if(user_params_stoc->AVG_BELOW_SAMPLER){
-            get_box_averages(M_min, user_params_stoc->SAMPLER_MIN_MASS, averages_box->m_turn_a, averages_box->m_turn_m, consts, &averages_subsampler);
+            get_box_averages(M_min, user_params_stoc->SAMPLER_MIN_MASS, averages_box->m_turn_acg, averages_box->m_turn_mcg, consts, &averages_sub_expected);
         }
     }
 
@@ -532,9 +540,9 @@ void halobox_debug_print_avg(struct HaloProperties *averages_box, struct HaloPro
         LOG_DEBUG("Box  averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e)",averages_subsampler->halo_mass,averages_subsampler->n_ion,
                                                                                                 averages_subsampler->halo_sfr,averages_subsampler->sfr_mini);
     }
-    LOG_DEBUG("Turnovers: ACG %11.3e global %11.3e",averages_box->m_turn_a,consts->mturn_a_nofb);
-    LOG_DEBUG("MCG  %11.3e nofb %11.3e",averages_box->m_turn_a,consts->mturn_m_nofb);
-    LOG_DEBUG("Reion %11.3e",averages_box->m_turn_r);
+    LOG_DEBUG("Turnovers: ACG %11.3e global %11.3e",averages_box->m_turn_acg,consts->mturn_a_nofb);
+    LOG_DEBUG("MCG  %11.3e nofb %11.3e",averages_box->m_turn_acg,consts->mturn_m_nofb);
+    LOG_DEBUG("Reion %11.3e",averages_box->m_turn_reion);
 }
 
 void sum_halos_onto_grid(struct InitialConditions *ini_boxes, struct TsBox *previous_spin_temp, struct IonizedBox * previous_ionize_box,
@@ -559,12 +567,12 @@ void sum_halos_onto_grid(struct InitialConditions *ini_boxes, struct TsBox *prev
         double curr_vcb = consts->vcb_norel;
         double M_turn_m = consts->mturn_m_nofb;
         double M_turn_a = consts->mturn_a_nofb;
-        double M_turn_r;
+        double M_turn_r = 0.;
 
-        float in_props[3];
-        float out_props[7];
+        double in_props[3];
+        struct HaloProperties out_props;
 
-    #pragma omp for reduction(+:hm_avg,sm_avg,sm_avg_mini,sfr_avg,sfr_avg_mini,M_turn_a_avg,M_turn_m_avg,M_turn_r_avg,n_halos_cut)
+    #pragma omp for reduction(+:hm_avg,sm_avg,sm_avg_mini,sfr_avg,sfr_avg_mini,n_ion_avg,xray_avg,wsfr_avg,M_turn_a_avg,M_turn_m_avg,M_turn_r_avg,n_halos_cut)
         for(i_halo=0; i_halo<halos->n_halos; i_halo++){
             m = halos->halo_masses[i_halo];
             //It is sometimes useful to make cuts to the halo catalogues before gridding.
@@ -573,23 +581,26 @@ void sum_halos_onto_grid(struct InitialConditions *ini_boxes, struct TsBox *prev
                 n_halos_cut++;
                 continue;
             }
-            x = halos->halo_coords[0+3*i_halo]; //NOTE:PerturbHaloField is on HII_DIM, HaloField is on DIM
+            //NOTE:Unlike HaloField, PerturbHaloField is on HII_DIM so we don't need to correct here
+            x = halos->halo_coords[0+3*i_halo];
             y = halos->halo_coords[1+3*i_halo];
             z = halos->halo_coords[2+3*i_halo];
+            i_cell = HII_R_INDEX(x,y,z);
 
             //set values before reionisation feedback
             //NOTE: I could easily apply reionization feedback without minihalos but this was not done previously
             if(flag_options_stoc->USE_MINI_HALOS){
                 if(!flag_options_stoc->FIX_VCB_AVG && user_params_stoc->USE_RELATIVE_VELOCITIES)
-                    curr_vcb = ini_boxes->lowres_vcb[HII_R_INDEX(x,y,z)];
+                    curr_vcb = ini_boxes->lowres_vcb[i_cell];
 
-                J21_val = redshift < global_params.Z_HEAT_MAX ? previous_spin_temp->J_21_LW_box[HII_R_INDEX(x,y,z)] : 0.;
-                Gamma12_val = redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->Gamma12_box[HII_R_INDEX(x, y, z)] : 0.;
-                zre_val = redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->z_re_box[HII_R_INDEX(x, y, z)] : 0.;
+                J21_val=Gamma12_val=zre_val=0.;
+                if(consts->redshift < global_params.Z_HEAT_MAX){
+                    J21_val = previous_spin_temp->J_21_LW_box[i_cell];
+                    Gamma12_val = previous_ionize_box->Gamma12_box[i_cell];
+                    zre_val = previous_ionize_box->z_re_box[i_cell];
+                }
                 M_turn_m = lyman_werner_threshold(redshift, J21_val, curr_vcb, astro_params_stoc);
                 M_turn_r = reionization_feedback(redshift, Gamma12_val, zre_val);
-                M_turn_a = consts->mturn_a_nofb < M_turn_r ? M_turn_r : consts->mturn_a_nofb; //since ACG turnover not reassigned
-                if(M_turn_m < M_turn_r)M_turn_m = M_turn_r;
             }
 
             //these are the halo property RNG sequences
@@ -597,40 +608,42 @@ void sum_halos_onto_grid(struct InitialConditions *ini_boxes, struct TsBox *prev
             in_props[1] = halos->sfr_rng[i_halo];
             in_props[2] = halos->xray_rng[i_halo];
 
-            set_halo_properties(m,M_turn_a,M_turn_m,consts,in_props,out_props);
+            set_halo_properties(halos->halo_masses[i_halo],M_turn_a,M_turn_m,M_turn_r,consts,in_props,&out_props);
 
-            sfr = out_props[0];
-            sfr_mini = out_props[1];
-            nion = out_props[2];
-            wsfr = out_props[3];
-            stars = out_props[4];
-            stars_mini = out_props[5];
-            xray = out_props[6];
+            sfr = out_props.halo_sfr;
+            sfr_mini = out_props.sfr_mini;
+            nion = out_props.n_ion;
+            wsfr = out_props.fescweighted_sfr;
+            stars = out_props.stellar_mass;
+            stars_mini = out_props.stellar_mini;
+            xray = out_props.halo_xray;
 
+            #if LOG_LEVEL >= ULTRA_DEBUG_LEVEL
             if(x+y+z == 0){
                 LOG_ULTRA_DEBUG("Cell 0 Halo %d: HM: %.2e SM: %.2e (%.2e) NI: %.2e SF: %.2e (%.2e) WS: %.2e",i_halo,m,stars,stars_mini,nion,sfr,sfr_mini,wsfr);
                 LOG_ULTRA_DEBUG("Mturn_a %.2e Mturn_m %.2e",M_turn_a,M_turn_m);
             }
+            #endif
 
             //update the grids
             #pragma omp atomic update
-            grids->halo_mass[HII_R_INDEX(x, y, z)] += m;
+            grids->halo_mass[i_cell] += m;
             #pragma omp atomic update
-            grids->halo_stars[HII_R_INDEX(x, y, z)] += stars;
+            grids->halo_stars[i_cell] += stars;
             #pragma omp atomic update
-            grids->halo_stars_mini[HII_R_INDEX(x, y, z)] += stars_mini;
+            grids->halo_stars_mini[i_cell] += stars_mini;
             #pragma omp atomic update
-            grids->n_ion[HII_R_INDEX(x, y, z)] += nion;
+            grids->n_ion[i_cell] += nion;
             #pragma omp atomic update
-            grids->halo_sfr[HII_R_INDEX(x, y, z)] += sfr;
+            grids->halo_sfr[i_cell] += sfr;
             #pragma omp atomic update
-            grids->halo_sfr_mini[HII_R_INDEX(x, y, z)] += sfr_mini;
+            grids->halo_sfr_mini[i_cell] += sfr_mini;
             #pragma omp atomic update
-            grids->whalo_sfr[HII_R_INDEX(x, y, z)] += wsfr;
+            grids->whalo_sfr[i_cell] += wsfr;
             #pragma omp atomic update
-            grids->halo_xray[HII_R_INDEX(x, y, z)] += xray;
+            grids->halo_xray[i_cell] += xray;
             #pragma omp atomic update
-            grids->count[HII_R_INDEX(x, y, z)] += 1;
+            grids->count[i_cell] += 1;
 
             M_turn_m_avg += M_turn_m;
             hm_avg += m;
@@ -638,6 +651,7 @@ void sum_halos_onto_grid(struct InitialConditions *ini_boxes, struct TsBox *prev
             sfr_avg_mini += sfr_mini;
             sm_avg += stars;
             sm_avg_mini += stars_mini;
+            xray_avg += xray;
             n_ion_avg += nion;
             wsfr_avg += wsfr;
             M_turn_a_avg += M_turn_a;
@@ -653,6 +667,7 @@ void sum_halos_onto_grid(struct InitialConditions *ini_boxes, struct TsBox *prev
             grids->halo_sfr_mini[i_cell] /= cell_volume;
             grids->halo_stars[i_cell] /= cell_volume;
             grids->halo_stars_mini[i_cell] /= cell_volume;
+            grids->halo_xray[i_cell] /= cell_volume;
             grids->whalo_sfr[i_cell] /= cell_volume;
         }
     }
@@ -677,17 +692,23 @@ void sum_halos_onto_grid(struct InitialConditions *ini_boxes, struct TsBox *prev
     grids->log10_Mcrit_LW_ave = log10(M_turn_m_avg);
 
     hm_avg /= VOLUME;
+    sm_avg /= VOLUME;
+    sm_avg_mini /= VOLUME;
     sfr_avg /= VOLUME;
     sfr_avg_mini /= VOLUME;
+    n_ion_avg /= VOLUME;
+    xray_avg / VOLUME;
 
     averages->halo_mass = hm_avg;
     averages->stellar_mass = sm_avg;
     averages->halo_sfr = sfr_avg;
     averages->stellar_mini = sm_avg_mini;
     averages->sfr_mini = sfr_avg_mini;
-    averages->m_turn_a = M_turn_a_avg;
-    averages->m_turn_m = M_turn_m_avg;
-    averages->m_turn_r = M_turn_r_avg;
+    averages->halo_xray = xray_avg;
+    averages->n_ion = n_ion_avg;
+    averages->m_turn_acg = M_turn_a_avg;
+    averages->m_turn_mcg = M_turn_m_avg;
+    averages->m_turn_reion = M_turn_r_avg;
 }
 
 //We grid a PERTURBED halofield into the necessary quantities for calculating radiative backgrounds
@@ -700,6 +721,7 @@ int ComputeHaloBox(double redshift, struct UserParams *user_params, struct Cosmo
         Broadcast_struct_global_UF(user_params,cosmo_params);
         Broadcast_struct_global_PS(user_params,cosmo_params);
         Broadcast_struct_global_STOC(user_params,cosmo_params,astro_params,flag_options);
+        Broadcast_struct_global_IT(user_params,cosmo_params,astro_params,flag_options);
 
         unsigned long long int idx;
 #pragma omp parallel for num_threads(user_params->N_THREADS) private(idx)
@@ -740,8 +762,8 @@ int ComputeHaloBox(double redshift, struct UserParams *user_params, struct Cosmo
         //Then we calculate the expected UMF integrals before doing the adjustment
         if(flag_options->FIXED_HALO_GRIDS){
             set_fixed_grids(M_min, M_cell, ini_boxes, perturbed_field, previous_spin_temp, previous_ionize_box, &hbox_consts, grids, &averages_box);
-            M_turn_a_global = averages_box.m_turn_a;
-            M_turn_m_global = averages_box.m_turn_m;
+            M_turn_a_global = averages_box.m_turn_acg;
+            M_turn_m_global = averages_box.m_turn_mcg;
             get_box_averages(M_min, M_cell, M_turn_a_global, M_turn_m_global, &hbox_consts, &averages_global);
             //This is the mean adjustment that happens in the rest of the code
             //NOTE: in the default mode, global averages are fixed separately for minihalo and regular parts
@@ -784,5 +806,105 @@ int ComputeHaloBox(double redshift, struct UserParams *user_params, struct Cosmo
         return(status);
     }
     LOG_DEBUG("Done.");
-    return 0.;
+    return 0;
+}
+
+//test function for getting halo properties from the wrapper, can use a lot of memory for large catalogs
+int halo_props_exposed(double redshift, struct UserParams *user_params, struct CosmoParams *cosmo_params, struct AstroParams *astro_params,
+                    struct FlagOptions * flag_options, struct InitialConditions *ini_boxes, struct PerturbedField * perturbed_field, struct PerturbHaloField *halos,
+                    struct TsBox *previous_spin_temp, struct IonizedBox *previous_ionize_box, float *halo_props){
+    int status;
+    Try{
+        //get parameters
+        Broadcast_struct_global_UF(user_params,cosmo_params);
+        Broadcast_struct_global_PS(user_params,cosmo_params);
+        Broadcast_struct_global_STOC(user_params,cosmo_params,astro_params,flag_options);
+
+        struct HaloBoxConstants hbox_consts;
+        set_hbox_constants(redshift,astro_params,flag_options,&hbox_consts);
+
+        LOG_DEBUG("Getting props for %llu halos...",halos->n_halos);
+        double M_min = minimum_source_mass(redshift,false,astro_params,flag_options);
+        double cell_volume = VOLUME/HII_TOT_NUM_PIXELS;
+        double M_cell = cosmo_params->OMm*RHOcrit*cell_volume;
+
+        #pragma omp parallel num_threads(user_params_stoc->N_THREADS)
+        {
+            int x,y,z;
+            unsigned long long int i_halo, i_cell;
+            double m,nion,sfr,wsfr,sfr_mini,stars_mini,stars,xray;
+            double J21_val, Gamma12_val, zre_val;
+
+            double curr_vcb = hbox_consts.vcb_norel;
+            double M_turn_m = hbox_consts.mturn_m_nofb;
+            double M_turn_a = hbox_consts.mturn_a_nofb;
+            double M_turn_r = 0.;
+
+            double in_props[3];
+            struct HaloProperties out_props;
+
+        #pragma omp for
+            for(i_halo=0; i_halo<halos->n_halos; i_halo++){
+                m = halos->halo_masses[i_halo];
+                //It is sometimes useful to make cuts to the halo catalogues before gridding.
+                //  We implement this in a simple way, if the user sets a halo's mass to zero we skip it
+                if(m == 0.){
+                    continue;
+                }
+                x = halos->halo_coords[0+3*i_halo];
+                y = halos->halo_coords[1+3*i_halo];
+                z = halos->halo_coords[2+3*i_halo];
+                i_cell = HII_R_INDEX(x,y,z);
+
+                //set values before reionisation feedback
+                //NOTE: I could easily apply reionization feedback without minihalos but this was not done previously
+                if(flag_options_stoc->USE_MINI_HALOS){
+                    if(!flag_options_stoc->FIX_VCB_AVG && user_params_stoc->USE_RELATIVE_VELOCITIES)
+                        curr_vcb = ini_boxes->lowres_vcb[i_cell];
+
+                    J21_val=Gamma12_val=zre_val=0.;
+                    if(redshift < global_params.Z_HEAT_MAX){
+                        J21_val = previous_spin_temp->J_21_LW_box[i_cell];
+                        Gamma12_val = previous_ionize_box->Gamma12_box[i_cell];
+                        zre_val = previous_ionize_box->z_re_box[i_cell];
+                    }
+                    M_turn_m = lyman_werner_threshold(redshift, J21_val, curr_vcb, astro_params_stoc);
+                    M_turn_r = reionization_feedback(redshift, Gamma12_val, zre_val);
+                }
+
+                //these are the halo property RNG sequences
+                in_props[0] = halos->star_rng[i_halo];
+                in_props[1] = halos->sfr_rng[i_halo];
+                in_props[2] = halos->xray_rng[i_halo];
+
+                set_halo_properties(m,M_turn_a,M_turn_m,M_turn_r,&hbox_consts,in_props,&out_props);
+
+                halo_props[10*i_halo + 0] = out_props.stellar_mass;
+                halo_props[10*i_halo + 1] = out_props.halo_sfr;
+                halo_props[10*i_halo + 2] = log(out_props.halo_xray); //float doesn't go up that high
+                halo_props[10*i_halo + 3] = out_props.n_ion;
+                halo_props[10*i_halo + 4] = out_props.fescweighted_sfr;
+                halo_props[10*i_halo + 5] = out_props.stellar_mini;
+                halo_props[10*i_halo + 6] = out_props.sfr_mini;
+                halo_props[10*i_halo + 7] = out_props.m_turn_acg;
+                halo_props[10*i_halo + 8] = out_props.m_turn_mcg;
+                halo_props[10*i_halo + 9] = out_props.m_turn_reion;
+
+                // LOG_ULTRA_DEBUG("HM %.2e SM %.2e SF %.2e NI %.2e LX %.2e",m,out_props.stellar_mass,out_props.halo_sfr,out_props.n_ion,out_props.halo_xray);
+                // LOG_ULTRA_DEBUG("MINI: SM %.2e SF %.2e WSF %.2e Mta %.2e Mtm %.2e Mtr %.2e",out_props.stellar_mini,out_props.sfr_mini,out_props.fescweighted_sfr,
+                //                 out_props.m_turn_acg,out_props.m_turn_mcg,out_props.m_turn_reion);
+                // LOG_ULTRA_DEBUG("RNG: STAR %.2e SFR %.2e XRAY %.2e",in_props[0],in_props[1],in_props[2]);
+            }
+        }
+
+        if(user_params->USE_INTERPOLATION_TABLES){
+            freeSigmaMInterpTable();
+        }
+    }
+    Catch(status){
+        return(status);
+    }
+    LOG_DEBUG("Done.");
+    return 0;
+
 }

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -1,3 +1,220 @@
+/* This file contains fucntions for calculating the HaloBox output for 21cmfast, containing the gridded
+ * source properties, either from integrating the conditional mass functions in a cell or from the halo sampler */
+
+//Parameters for the halo box calculations
+//  These are just the values which are calculated at the beginning of ComputeHaloBox and don't change
+//  using this reduces the use of the global parameter structs and allows fewer exp/log unit changes
+struct HaloBoxConstants{
+    double redshift;
+
+    double fstar_10;
+    double alpha_star;
+    double sigma_star;
+
+    double alpha_upper;
+    double pivot_upper;
+    double upper_pivot_ratio;
+
+    double fstar_7;
+    double alpha_star_mini;
+
+    double t_h;
+    double t_star;
+    double sigma_sfr_lim;
+    double sigma_sfr_idx;
+
+    double l_x;
+    double l_x_mini;
+    double sigma_xray;
+
+    double fesc_10;
+    double alpha_esc;
+    double fesc_7;
+
+    double vcb_norel;
+    double mturn_a_nofb;
+    double mturn_m_nofb;
+
+    double Mlim_Fstar;
+    double Mlim_Fesc;
+    double Mlim_Fstar_mini;
+    double Mlim_Fesc_mini;
+};
+
+//struct holding each halo property we currently need.
+//This is only used for both averages over the box/catalogues
+//  as well as an individual halo's properties
+struct HaloProperties{
+    double halo_mass;
+    double stellar_mass;
+    double halo_sfr;
+    double stellar_mini;
+    double sfr_mini;
+    double fescweighted_sfr;
+    double n_ion;
+    double halo_xray;
+    double m_turn_a;
+    double m_turn_m;
+    double m_turn_r;
+};
+
+void set_hbox_constants(double redshift, struct AstroParams *astro_params, struct FlagOptions *flag_options, struct HaloBoxConstants *consts){
+    consts->redshift = redshift;
+
+    consts->fstar_10 = astro_params->F_STAR10;
+    consts->alpha_star = astro_params->ALPHA_STAR;
+    consts->sigma_star = astro_params->SIGMA_STAR;
+
+    consts->alpha_upper = astro_params->UPPER_STELLAR_TURNOVER_INDEX;
+    consts->pivot_upper = astro_params->UPPER_STELLAR_TURNOVER_MASS;
+    consts->upper_pivot_ratio = pow(astro_params->UPPER_STELLAR_TURNOVER_MASS/1e10,astro_params->ALPHA_STAR);
+
+    consts->fstar_7 = astro_params->F_STAR7_MINI;
+    consts->alpha_star_mini = astro_params->ALPHA_STAR_MINI;
+
+    consts->t_h = 1/Hubble(redshift);
+    consts->t_star = astro_params->t_STAR;
+    consts->sigma_sfr_lim = astro_params->SFR_SIGMA_LIM;
+    consts->sigma_sfr_idx = astro_params->SFR_SIGMA_INDEX;
+
+    consts->l_x = astro_params->L_X;
+    consts->l_x_mini = astro_params->L_X_MINI;
+    consts->sigma_xray = astro_params->SIGMA_LX;
+
+    consts->alpha_esc = astro_params->ALPHA_ESC;
+    consts->fesc_10= astro_params->F_ESC10;
+    consts->fesc_7 = astro_params->F_ESC7_MINI;
+
+    consts->mturn_a_nofb= flag_options->USE_MINI_HALOS ? atomic_cooling_threshold(redshift) : astro_params->M_TURN;
+
+    if(flag_options->USE_MINI_HALOS){
+        consts->mturn_m_nofb = lyman_werner_threshold(redshift, 0., consts->vcb_norel, astro_params);
+        consts->vcb_norel = flag_options->FIX_VCB_AVG ? global_params.VAVG : 0;
+    }
+
+    if(flag_options->FIXED_HALO_GRIDS || user_params_stoc->AVG_BELOW_SAMPLER){
+        if(flag_options->PHOTON_CONS_TYPE == 2)
+            consts->alpha_esc = get_fesc_fit(redshift);
+        else if(flag_options->PHOTON_CONS_TYPE == 3)
+            consts->fesc_10 = get_fesc_fit(redshift);
+
+        consts->Mlim_Fstar = Mass_limit_bisection(global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL, consts->alpha_star, consts->fstar_10);
+        consts->Mlim_Fesc = Mass_limit_bisection(global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL, consts->alpha_esc, consts->fesc_10);
+
+        if(flag_options->USE_MINI_HALOS){
+            consts->Mlim_Fstar_mini = Mass_limit_bisection(global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL, consts->alpha_star_mini,
+                                                            consts->fstar_7 * pow(1e3,consts->alpha_star_mini));
+            consts->Mlim_Fesc_mini = Mass_limit_bisection(global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL, consts->alpha_esc,
+                                                            consts->fesc_7 * pow(1e3,consts->alpha_esc));
+        }
+    }
+}
+
+void get_halo_stellarmass(double halo_mass, double mturn_acg, double mturn_mcg, double star_rng,
+                             struct HaloBoxConstants *consts, double *star_acg, double *star_mcg){
+    //low-mass ACG power-law parameters
+    double f_10 = consts->fstar_10;//TODO: pass in log
+    double f_a = consts->alpha_star;
+    double sigma_star = consts->sigma_star;
+
+    //high-mass ACG power-law parameters
+    double fu_a = consts->alpha_upper;
+    double fu_p = consts->pivot_upper;//TODO: pass in log
+
+    //MCG parameters
+    double f_7 = consts->fstar_7;
+    double f_a_mini = consts->alpha_star_mini;
+
+    //intermediates
+    double fstar_mean;
+    double f_sample, f_sample_mini;
+    double sm_sample,sm_sample_mini;
+
+    double baryon_ratio = cosmo_params_stoc->OMb / cosmo_params_stoc->OMm;
+
+    /* Simply adding lognormal scatter to a delta increases the mean (2* is as likely as 0.5*)
+    * We multiply by exp(-sigma^2/2) so that X = exp(mu + N(0,1)*sigma) has the desired mean */
+    star_rng = -sigma_star*sigma_star/2 + star_rng*sigma_star;
+
+    //We don't want an upturn even with a negative ALPHA_STAR
+    if(flag_options_stoc->USE_UPPER_STELLAR_TURNOVER && (f_a > fu_a)){
+        fstar_mean = consts->upper_pivot_ratio / (pow(halo_mass/fu_p,-f_a)+pow(halo_mass/fu_p,-fu_a));
+    }
+    else{
+        fstar_mean = pow(halo_mass/1e10,f_a); //PL term
+    }
+    f_sample *= f_10 * exp(-mturn_acg/halo_mass + star_rng); //1e10 normalisation of stellar mass
+    if(f_sample > 1.) f_sample = 1.;
+
+    sm_sample = f_sample * halo_mass * baryon_ratio;
+    *star_acg = sm_sample;
+
+    if(!flag_options_stoc->USE_MINI_HALOS){
+        *star_mcg = 0.;
+        return;
+    }
+
+    f_sample_mini = pow(halo_mass/1e7,f_a_mini) * f_7 * exp(-mturn_mcg/halo_mass - halo_mass/mturn_acg + star_rng);
+    if(f_sample_mini > 1.) f_sample_mini = 1.;
+
+    sm_sample_mini = f_sample_mini * halo_mass * baryon_ratio;
+    *star_mcg = sm_sample_mini;
+}
+
+void get_halo_sfr(double stellar_mass, double stellar_mass_mini, double sfr_rng,
+                     struct HaloBoxConstants *consts, double *sfr, double *sfr_mini){
+    double sfr_mean,sfr_mean_mini;
+    double sfr_sample, sfr_sample_mini;
+
+    double sigma_sfr_lim = consts->sigma_sfr_lim;
+    double sigma_sfr_idx = consts->sigma_sfr_idx;
+    double sigma_sfr, sigma_sfr_mini;
+    double sfr_gauss, sfr_gauss_mini;
+
+    //set the scatter based on the total Stellar mass
+    //We use the total stellar mass (MCG + ACG) NOTE: it might be better to separate later
+    sigma_sfr = sigma_sfr_idx * log((stellar_mass+stellar_mass_mini)/1e10) + sigma_sfr_lim;
+    if(sigma_sfr < sigma_sfr_lim) sigma_sfr = sigma_sfr_lim;
+
+    sfr_mean = stellar_mass / (consts->t_star * consts->t_h);
+
+    //Since there's no clipping on t_STAR, we can apply the lognormal to SFR directly instead of t_STAR
+    sfr_gauss = exp(-sigma_sfr*sigma_sfr/2 + sfr_gauss*sigma_sfr);
+    sfr_sample = sfr_mean * sfr_gauss;
+    *sfr = sfr_sample;
+
+    if(!flag_options_stoc->USE_MINI_HALOS){
+        *sfr_mini = 0.;
+        return;
+    }
+
+    sfr_mean_mini = stellar_mass_mini / (consts->t_star * consts->t_h);
+    sfr_sample_mini = sfr_mean_mini * sfr_gauss;
+    *sfr_mini = sfr_sample_mini;
+}
+
+void get_halo_metallicity(double sfr, double stellar, double redshift, double *metallicity){
+    //Hardcoded for now: 6 extra fit parameters in the equation
+    double z_denom, z_sample;
+    z_denom = (1.28825e10 * pow(sfr*SperYR,0.56));
+    z_sample = 0.296 * (1 + pow(stellar/z_denom,2.1)) * pow(10,-0.056*redshift + 0.064);
+
+    *metallicity = z_sample;
+}
+
+void get_halo_xray(double sfr, double sfr_mini, double metallicity, double xray_rng, struct HaloBoxConstants *consts, double *xray_lum){
+    //Hardcoded for now (except the lx normalisation and the scatter): 3 extra fit parameters in the equation
+    double xray_mean, xray_mean_mini;
+    double sigma = consts->sigma_xray;
+
+    xray_rng = -sigma*sigma/2 + xray_rng*sigma;
+    xray_mean = (-0.11*log(metallicity) + 1.30)*log(sfr_mini*SperYR) + -0.31*log(metallicity) + consts->l_x;
+    xray_mean = exp(xray_mean + xray_rng);
+    xray_mean_mini = (-0.11*log(metallicity) + 1.30)*log(sfr_mini*SperYR) + -0.31*log(metallicity) + consts->l_x_mini;
+    xray_mean_mini = exp(xray_mean_mini + xray_rng);
+
+    *xray_lum = xray_mean + xray_mean_mini;
+}
 
 //calculates halo properties from astro parameters plus the correlated rng
 //The inputs include all properties with a separate RNG
@@ -11,95 +228,49 @@
 //in order to remain consistent with the minihalo treatment in default (Nion_a * exp(-M/M_a) + Nion_m * exp(-M/M_m - M_a/M))
 //  we treat the minihalos as a shift in the mean, where each halo will have both components, representing a smooth
 //  transition in halo mass from one set of SFR/emmissivity parameters to the other.
-void set_halo_properties(float halo_mass, float M_turn_a, float M_turn_m, float t_h, double norm_esc_var, double alpha_esc_var, float * input, float * output){
-    double f10 = astro_params_stoc->F_STAR10;
-    double fa = astro_params_stoc->ALPHA_STAR;
-    double sigma_star = astro_params_stoc->SIGMA_STAR;
-    double sigma_sfr = astro_params_stoc->SIGMA_SFR;
-
-    double f7 = astro_params_stoc->F_STAR7_MINI;
-    double fa_m = astro_params_stoc->ALPHA_STAR_MINI;
-    double fesc7 = astro_params_stoc->F_ESC7_MINI;
-
-    double fstar_mean, fstar_mean_mini, sfr_mean, sfr_mean_mini;
-    double f_sample, f_sample_mini, sm_sample, n_ion_sample, sfr_sample, wsfr_sample;
-    double f_rng, sfr_rng;
-    double sm_sample_mini, sfr_sample_mini;
+void set_halo_properties(double halo_mass, double M_turn_a, float M_turn_m, struct HaloBoxConstants *consts, double *input_rng, struct HaloProperties *output){
+    double n_ion_sample, wsfr_sample;
     double fesc,fesc_mini;
 
-    fesc = fmin(norm_esc_var*pow(halo_mass/1e10,alpha_esc_var),1);
+    double stellar_mass, stellar_mass_mini;
+    get_halo_stellarmass(halo_mass,M_turn_a,M_turn_m,input_rng[0],consts,&stellar_mass,&stellar_mass_mini);
 
-    //We don't want an upturn even with a negative ALPHA_STAR
-    if(flag_options_stoc->USE_UPPER_STELLAR_TURNOVER && (astro_params_stoc->ALPHA_STAR > astro_params_stoc->UPPER_STELLAR_TURNOVER_INDEX)){
-        fstar_mean = f10 * exp(-M_turn_a/halo_mass) * pow(astro_params_stoc->UPPER_STELLAR_TURNOVER_MASS/1e10,astro_params_stoc->ALPHA_STAR);
-        fstar_mean /= pow(halo_mass/astro_params_stoc->UPPER_STELLAR_TURNOVER_MASS,-astro_params_stoc->ALPHA_STAR)
-                        + pow(halo_mass/astro_params_stoc->UPPER_STELLAR_TURNOVER_MASS,-astro_params_stoc->UPPER_STELLAR_TURNOVER_INDEX);
-    }
-    else{
-        fstar_mean = f10 * pow(halo_mass/1e10,fa) * exp(-M_turn_a/halo_mass);
-    }
+    double sfr,sfr_mini;
+    get_halo_sfr(stellar_mass,stellar_mass_mini,input_rng[1],consts,&sfr,&sfr_mini);
 
-    if(flag_options_stoc->USE_MINI_HALOS){
-        fesc_mini = fmin(fesc7*pow(halo_mass/1e7,alpha_esc_var),1);
-        fstar_mean_mini = f7 * pow(halo_mass/1e7,fa_m) * exp(-M_turn_m/halo_mass - halo_mass/M_turn_a);
-    }
-    else{
-        fstar_mean_mini = 0;
-        fesc_mini = 0.;
-    }
+    double metallicity;
+    get_halo_metallicity(sfr+sfr_mini,stellar_mass+stellar_mass_mini,consts->redshift,&metallicity);
 
-    /* Simply adding lognormal scatter to a delta increases the mean (2* is as likely as 0.5*)
-    * We multiply by exp(-sigma^2/2) so that X = exp(mu + N(0,1)*sigma) has the desired mean */
-    f_rng = exp(-sigma_star*sigma_star/2 + input[0]*sigma_star);
+    double xray_lum;
+    get_halo_xray(sfr,sfr_mini,metallicity,input_rng[2],consts,&xray_lum);
 
-    //This clipping is normally done with the mass_limit_bisection root find. hard to do with stochastic
-    f_sample = fmin(fstar_mean * f_rng,1);
-    f_sample_mini = fmin(fstar_mean_mini * f_rng,1);
+    //no rng for escape fraction yet
+    fesc = fmin(consts->fesc_10*pow(halo_mass/1e10,consts->alpha_esc),1);
+    fesc_mini = fmin(consts->fesc_7*pow(halo_mass/1e7,consts->alpha_esc),1);
+    n_ion_sample = stellar_mass*global_params.Pop2_ion*fesc + stellar_mass_mini*global_params.Pop3_ion*fesc_mini;
+    wsfr_sample = sfr*global_params.Pop2_ion*fesc + sfr_mini*global_params.Pop3_ion*fesc_mini;
 
-    sm_sample = halo_mass * (cosmo_params_stoc->OMb / cosmo_params_stoc->OMm) * f_sample; //f_star is galactic GAS/star fraction, so OMb is needed
-    sm_sample_mini = halo_mass * (cosmo_params_stoc->OMb / cosmo_params_stoc->OMm) * f_sample_mini; //f_star is galactic GAS/star fraction, so OMb is needed
-
-    sfr_mean = sm_sample / (astro_params_stoc->t_STAR * t_h);
-    sfr_mean_mini = sm_sample_mini / (astro_params_stoc->t_STAR * t_h);
-
-    //Since there's no clipping on t_STAR, we can apply the lognormal to SFR directly instead of t_STAR
-    sfr_rng = exp(-sigma_sfr*sigma_sfr/2 + input[1]*sigma_sfr);
-    sfr_sample = sfr_mean * sfr_rng;
-    sfr_sample_mini = sfr_mean_mini * sfr_rng;
-
-    n_ion_sample = sm_sample*global_params.Pop2_ion*fesc + sm_sample_mini*global_params.Pop3_ion*fesc_mini;
-    wsfr_sample = sfr_sample*global_params.Pop2_ion*fesc + sfr_sample_mini*global_params.Pop3_ion*fesc_mini;
-
-    //LOG_ULTRA_DEBUG("HM %.3e | SM %.3e | SFR %.3e (%.3e) | F* %.3e (%.3e) | duty %.3e",halo_mass,sm_sample,sfr_sample,sfr_mean,f_sample,fstar_mean,dutycycle_term);
-
-    output[0] = sfr_sample;
-    output[1] = sfr_sample_mini;
-    output[2] = n_ion_sample;
-    output[3] = wsfr_sample;
-    output[4] = sm_sample;
-    output[5] = sm_sample_mini;
-    return 0;
+    output->halo_mass = halo_mass;
+    output->m_turn_a = M_turn_a;
+    output->m_turn_m = M_turn_m;
+    output->stellar_mass = stellar_mass;
+    output->stellar_mini = stellar_mass_mini;
+    output->halo_sfr = sfr;
+    output->sfr_mini = sfr_mini;
+    output->fescweighted_sfr = wsfr_sample;
+    output->n_ion = n_ion_sample;
+    output->halo_xray = xray_lum;
 }
 
 //Fixed halo grids, where each property is set as the integral of the CMF on the EULERIAN cell scale
 //As per default 21cmfast (strange pretending that the lagrangian density is eulerian and then *(1+delta))
 //This outputs the UN-NORMALISED grids (before mean-adjustment)
-int set_fixed_grids(double redshift, double norm_esc, double alpha_esc, double M_min, double M_max, struct InitialConditions * ini_boxes,
-                    struct PerturbedField * perturbed_field, struct TsBox *previous_spin_temp,
-                    struct IonizedBox *previous_ionize_box, struct HaloBox *grids, double *averages){
-    //There's quite a bit of re-calculation here but this only happens once per snapshot
+int set_fixed_grids(double M_min, double M_max, struct InitialConditions *ini_boxes,
+                    struct PerturbedField *perturbed_field, struct TsBox *previous_spin_temp,
+                    struct IonizedBox *previous_ionize_box, struct HaloBoxConstants *consts, struct HaloBox *grids, struct HaloProperties *averages){
     double cell_volume = VOLUME / HII_TOT_NUM_PIXELS;
     double M_cell = RHOcrit * cosmo_params_stoc->OMm * cell_volume; //mass in cell of mean dens
-    double growth_z = dicke(redshift);
-    double alpha_star = astro_params_stoc->ALPHA_STAR;
-    double norm_star = astro_params_stoc->F_STAR10;
-    double t_h = t_hubble(redshift);
-
-    double alpha_star_mini = astro_params_stoc->ALPHA_STAR_MINI;
-    double norm_star_mini = astro_params_stoc->F_STAR7_MINI;
-    double norm_esc_mini = astro_params_stoc->F_ESC7_MINI;
-
-    double t_star = astro_params_stoc->t_STAR;
+    double growth_z = dicke(consts->redshift);
 
     double lnMmin = log(M_min);
     double lnMcell = log(M_cell);
@@ -108,19 +279,19 @@ int set_fixed_grids(double redshift, double norm_esc, double alpha_esc, double M
     double sigma_cell = EvaluateSigma(lnMcell);
 
     double prefactor_mass = RHOcrit * cosmo_params_stoc->OMm;
-    double prefactor_nion = RHOcrit * cosmo_params_stoc->OMb * norm_star * norm_esc * global_params.Pop2_ion;
-    double prefactor_nion_mini = RHOcrit * cosmo_params_stoc->OMb * norm_star_mini * norm_esc_mini * global_params.Pop3_ion;
-    double prefactor_sfr = RHOcrit * cosmo_params_stoc->OMb * norm_star / t_star / t_h;
-    double prefactor_sfr_mini = RHOcrit * cosmo_params_stoc->OMb * norm_star_mini / t_star / t_h;
+    double prefactor_stars = RHOcrit * cosmo_params_stoc->OMb * consts->fstar_10;
+    double prefactor_stars_mini = RHOcrit * cosmo_params_stoc->OMb * consts->fstar_7;
+    double prefactor_sfr = prefactor_stars / consts->t_star / consts->t_h;
+    double prefactor_sfr_mini = prefactor_stars_mini / consts->t_star / consts->t_h;
+    double prefactor_nion = prefactor_stars * consts->fesc_10 * global_params.Pop2_ion;
+    double prefactor_nion_mini = prefactor_stars_mini * consts->fesc_7 * global_params.Pop3_ion;
+    double prefactor_wsfr = prefactor_sfr * consts->fesc_10;
+    double prefactor_wsfr_mini = prefactor_sfr_mini * consts->fesc_7;
+    double prefactor_xray = prefactor_sfr * astro_params_stoc->L_X;
+    double prefactor_xray_mini = prefactor_sfr_mini * astro_params_stoc->L_X_MINI;
 
-    double Mlim_Fstar = Mass_limit_bisection(global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL, alpha_star, norm_star);
-    double Mlim_Fesc = Mass_limit_bisection(global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL, alpha_esc, norm_esc);
-
-    double Mlim_Fstar_mini = Mass_limit_bisection(global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL, alpha_star_mini, norm_star_mini * pow(1e3,alpha_star_mini));
-    double Mlim_Fesc_mini = Mass_limit_bisection(global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL, alpha_esc, norm_esc_mini * pow(1e3,alpha_esc));
-
-    double hm_avg=0, nion_avg=0, sfr_avg=0, sfr_avg_mini=0, wsfr_avg=0;
-    double Mlim_a_avg=0, Mlim_m_avg=0, Mlim_r_avg=0;
+    double hm_avg=0, nion_avg=0, sfr_avg=0, sfr_avg_mini=0, wsfr_avg=0, xray_avg=0;
+    double Mlim_a_avg=0, Mlim_m_avg=0, Mlim_r_avg=0, sm_avg=0, sm_avg_mini=0;
 
     //find density grid limits
     double min_density = 0.;
@@ -138,16 +309,16 @@ int set_fixed_grids(double redshift, double norm_esc, double alpha_esc, double M
     }
 
     struct parameters_gsl_MF_integrals params = {
-            .redshift = redshift,
+            .redshift = consts->redshift,
             .growthf = growth_z,
             .sigma_cond = sigma_cell,
             .HMF = user_params_stoc->HMF,
     };
 
-    double M_turn_a_nofb = flag_options_stoc->USE_MINI_HALOS ? atomic_cooling_threshold(redshift) : astro_params_stoc->M_TURN;
+    double M_turn_a_nofb = consts->mturn_a_nofb;
 
-    LOG_DEBUG("Mean halo boxes || M = [%.2e %.2e] | Mcell = %.2e (s=%.2e) | z = %.2e | D = %.2e | cellvol = %.2e",M_min,M_max,M_cell,sigma_cell,redshift,growth_z,cell_volume);
-    LOG_DEBUG("Power law limits || Fstar = %.4e | Fesc =  %.4e",Mlim_Fstar,Mlim_Fesc);
+    LOG_DEBUG("Mean halo boxes || M = [%.2e %.2e] | Mcell = %.2e (s=%.2e) | z = %.2e | D = %.2e | cellvol = %.2e",M_min,M_max,M_cell,sigma_cell,
+                consts->redshift,growth_z,cell_volume);
 
     //These tables are coarser than needed, an initial loop for Mturn to find limits may help
     if(user_params_stoc->USE_INTERPOLATION_TABLES){
@@ -156,19 +327,20 @@ int set_fixed_grids(double redshift, double norm_esc, double alpha_esc, double M
         }
 
         //This table assumes no reionisation feedback
-        initialise_SFRD_Conditional_table(min_density,max_density,growth_z,M_turn_a_nofb,M_min,M_max,M_cell,
-                                                astro_params_stoc->ALPHA_STAR, astro_params_stoc->ALPHA_STAR_MINI, astro_params_stoc->F_STAR10,
-                                                astro_params_stoc->F_STAR7_MINI, user_params_stoc->INTEGRATION_METHOD_ATOMIC,
+        initialise_SFRD_Conditional_table(min_density,max_density,growth_z,consts->mturn_a_nofb,M_min,M_max,M_cell,
+                                                consts->alpha_star, consts->alpha_star_mini, consts->fstar_10,
+                                                consts->fstar_7, user_params_stoc->INTEGRATION_METHOD_ATOMIC,
                                                 user_params_stoc->INTEGRATION_METHOD_MINI,
                                                 flag_options_stoc->USE_MINI_HALOS);
 
         //This table includes reionisation feedback, but takes the atomic turnover anyway for the upper turnover
-        initialise_Nion_Conditional_spline(redshift,M_turn_a_nofb,min_density,max_density,M_min,M_max,M_cell,
+        initialise_Nion_Conditional_spline(consts->redshift,consts->mturn_a_nofb,min_density,max_density,M_min,M_max,M_cell,
                                 LOG10_MTURN_MIN,LOG10_MTURN_MAX,LOG10_MTURN_MIN,LOG10_MTURN_MAX,
-                                astro_params_stoc->ALPHA_STAR, astro_params_stoc->ALPHA_STAR_MINI,
-                                alpha_esc,astro_params_stoc->F_STAR10,
-                                norm_esc,Mlim_Fstar,Mlim_Fesc,astro_params_stoc->F_STAR7_MINI,
-                                astro_params_stoc->F_ESC7_MINI,Mlim_Fstar_mini, Mlim_Fesc_mini,  user_params_stoc->INTEGRATION_METHOD_ATOMIC,
+                                consts->alpha_star, consts->alpha_star_mini,
+                                consts->alpha_esc, consts->fstar_10,
+                                consts->fesc_10,consts->Mlim_Fstar,consts->Mlim_Fesc,consts->fstar_7,
+                                consts->fesc_7,consts->Mlim_Fstar_mini, consts->Mlim_Fesc_mini,
+                                user_params_stoc->INTEGRATION_METHOD_ATOMIC,
                                 user_params_stoc->INTEGRATION_METHOD_MINI,
                                 flag_options_stoc->USE_MINI_HALOS, false);
 
@@ -179,93 +351,71 @@ int set_fixed_grids(double redshift, double norm_esc, double alpha_esc, double M
     {
         int i;
         double dens;
-        double mass=0, nion=0, sfr=0, h_count=0;
-        double nion_mini=0, sfr_mini=0;
-        double wsfr=0;
         double J21_val, Gamma12_val, zre_val;
-        double curr_vcb = flag_options_stoc->FIX_VCB_AVG ? global_params.VAVG : 0;
-        double M_turn_m_nofb = lyman_werner_threshold(redshift, 0., curr_vcb, astro_params_stoc);
-        double M_turn_r, M_turn_m;
-        double M_turn_a = M_turn_a_nofb;
+        double curr_vcb = consts->vcb_norel;
+        double M_turn_m = consts->mturn_m_nofb;
+        double M_turn_a = consts->mturn_a_nofb;
+        double M_turn_r;
+        double mass_intgrl, h_count;
+        double intgrl_fesc_weighted, intgrl_stars_only;
+        double intgrl_fesc_weighted_mini=0., intgrl_stars_only_mini=0.;
 
 #pragma omp for reduction(+:hm_avg,nion_avg,sfr_avg,sfr_avg_mini,wsfr_avg,Mlim_a_avg,Mlim_m_avg)
         for(i=0;i<HII_TOT_NUM_PIXELS;i++){
             dens = perturbed_field->density[i];
             params.delta = dens;
-            if(!flag_options_stoc->FIX_VCB_AVG && user_params_stoc->USE_RELATIVE_VELOCITIES){
-                curr_vcb = ini_boxes->lowres_vcb[i];
-            }
 
             if(flag_options_stoc->USE_MINI_HALOS){
-                J21_val = redshift < global_params.Z_HEAT_MAX ? previous_spin_temp->J_21_LW_box[i] : 0.;
-                Gamma12_val = redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->Gamma12_box[i] : 0.;
-                zre_val = redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->z_re_box[i] : 0.;
-                M_turn_m_nofb = lyman_werner_threshold(redshift, J21_val, curr_vcb, astro_params_stoc);
-                M_turn_r = reionization_feedback(redshift, Gamma12_val, zre_val);
-                M_turn_a = M_turn_r > M_turn_a_nofb ? M_turn_r : M_turn_a_nofb;
-                M_turn_m = M_turn_r > M_turn_m_nofb ? M_turn_r : M_turn_m_nofb;
+                if(!flag_options_stoc->FIX_VCB_AVG && user_params_stoc->USE_RELATIVE_VELOCITIES){
+                    curr_vcb = ini_boxes->lowres_vcb[i];
+                }
+                J21_val = consts->redshift < global_params.Z_HEAT_MAX ? previous_spin_temp->J_21_LW_box[i] : 0.;
+                Gamma12_val = consts->redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->Gamma12_box[i] : 0.;
+                zre_val = consts->redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->z_re_box[i] : 0.;
+                M_turn_m = lyman_werner_threshold(consts->redshift, J21_val, curr_vcb, astro_params_stoc);
+                M_turn_r = reionization_feedback(consts->redshift, Gamma12_val, zre_val);
+                M_turn_a = M_turn_r > M_turn_a_nofb ? M_turn_r : M_turn_a_nofb; //since ACG turnover not reassigned
+                M_turn_m = M_turn_r > M_turn_m ? M_turn_r : M_turn_m;
             }
 
             h_count = EvaluateNhalo(dens, growth_z, lnMmin, lnMmax, M_cell, sigma_cell, dens);
-            mass = EvaluateMcoll(dens, growth_z, lnMmin, lnMmax, M_cell, sigma_cell, dens);
-            nion = EvaluateNion_Conditional(dens,log10(M_turn_a),growth_z,M_min,M_max,M_cell,sigma_cell,Mlim_Fstar,Mlim_Fesc,false);
-            sfr = EvaluateSFRD_Conditional(dens,growth_z,M_min,M_max,M_cell,sigma_cell,log10(M_turn_a),Mlim_Fstar);
+            mass_intgrl = EvaluateMcoll(dens, growth_z, lnMmin, lnMmax, M_cell, sigma_cell, dens);
+            intgrl_fesc_weighted = EvaluateNion_Conditional(dens,log10(M_turn_a),growth_z,M_min,M_max,M_cell,sigma_cell,
+                                            consts->Mlim_Fstar,consts->Mlim_Fesc,false);
+            intgrl_stars_only = EvaluateSFRD_Conditional(dens,growth_z,M_min,M_max,M_cell,sigma_cell,
+                                            log10(M_turn_a),consts->Mlim_Fstar);
             if(flag_options_stoc->USE_MINI_HALOS){
-                sfr_mini = EvaluateSFRD_Conditional_MINI(dens,log10(M_turn_m),growth_z,M_min,M_max,M_cell,sigma_cell,log10(M_turn_a),Mlim_Fstar);
-                nion_mini = EvaluateNion_Conditional_MINI(dens,log10(M_turn_m),growth_z,M_min,M_max,M_cell,sigma_cell,log10(M_turn_a),Mlim_Fstar,Mlim_Fesc,false);
+                intgrl_fesc_weighted_mini = EvaluateSFRD_Conditional_MINI(dens,log10(M_turn_m),growth_z,M_min,M_max,M_cell,sigma_cell,
+                                                            log10(M_turn_a),consts->Mlim_Fstar);
+                intgrl_stars_only_mini = EvaluateNion_Conditional_MINI(dens,log10(M_turn_m),growth_z,M_min,M_max,M_cell,sigma_cell,
+                                                            log10(M_turn_a),consts->Mlim_Fstar,consts->Mlim_Fesc,false);
             }
 
-            grids->halo_mass[i] = mass * prefactor_mass * (1+dens);
-            grids->n_ion[i] = (nion*prefactor_nion + nion_mini*prefactor_nion_mini) * (1+dens);
-            grids->halo_sfr[i] = (sfr*prefactor_sfr) * (1+dens);
-            grids->whalo_sfr[i] = grids->n_ion[i] / t_star / t_h; //no stochasticity so they're the same to a constant
             grids->count[i] = (int)(h_count * prefactor_mass * (1+dens)); //NOTE: truncated
-            grids->halo_sfr_mini[i] = sfr_mini*prefactor_sfr_mini * (1+dens); //zero if !Minihalos
-
-            if(i==0 && user_params_stoc->USE_INTERPOLATION_TABLES){
-                LOG_SUPER_DEBUG("Cell 0 tables: count %.2e mass %.2e nion %.2e sfr %.2e delta %.2f",h_count,mass,nion,sfr,dens);
-                LOG_SUPER_DEBUG("Cell 0 intgrl: count %.2e mass %.2e nion %.2e sfr %.2e",
-                                IntegratedNdM(lnMmin,lnMmax,params,-1,user_params_stoc->INTEGRATION_METHOD_ATOMIC),
-                                IntegratedNdM(lnMmin,lnMmax,params,-2,user_params_stoc->INTEGRATION_METHOD_ATOMIC),
-                                Nion_ConditionalM(growth_z, lnMmin, lnMmax, M_cell, sigma_cell, dens, M_turn_a
-                                            , astro_params_stoc->ALPHA_STAR, alpha_esc, astro_params_stoc->F_STAR10, norm_esc
-                                            , Mlim_Fstar, Mlim_Fesc, user_params_stoc->INTEGRATION_METHOD_ATOMIC),
-                                Nion_ConditionalM(growth_z, lnMmin, lnMmax, M_cell, sigma_cell, dens, M_turn_a
-                                            , alpha_star, 0., norm_star, 1., Mlim_Fstar, 0.
-                                            , user_params_stoc->INTEGRATION_METHOD_ATOMIC));
-                LOG_SUPER_DEBUG("Cell 0 grids: count %d mass %.2e nion %.2e sfr %.2e", grids->count[i],
-                                    grids->halo_mass[i],grids->n_ion[i],grids->halo_sfr[i]);
-                if(flag_options_stoc->USE_MINI_HALOS){
-                    LOG_SUPER_DEBUG("MINI tables: nion %.2e sfr %.2e",nion_mini,sfr_mini);
-                    LOG_SUPER_DEBUG("MINI intgrl: nion %.2e sfr %.2e",
-                                    Nion_ConditionalM_MINI(growth_z, lnMmin, lnMmax, M_cell, sigma_cell,
-                                                            dens, M_turn_m, M_turn_a, alpha_star_mini,
-                                                            alpha_esc, norm_star_mini, norm_esc_mini, Mlim_Fstar_mini,
-                                                            Mlim_Fesc_mini, user_params_stoc->INTEGRATION_METHOD_MINI),
-                                    Nion_ConditionalM_MINI(growth_z, lnMmin, lnMmax, M_cell, sigma_cell,
-                                                dens, M_turn_m, M_turn_a, alpha_star_mini,
-                                                0., norm_star_mini, 1., Mlim_Fstar_mini, 0.,
-                                                user_params_stoc->INTEGRATION_METHOD_MINI));
-                }
-                LOG_SUPER_DEBUG("ACG MTURN %.3e (%.3e) MCG MTURN %.3e (%.3e) REION %.3e",M_turn_a_nofb,M_turn_a,M_turn_m_nofb,M_turn_m,M_turn_r);
-            }
+            grids->halo_mass[i] = mass_intgrl * prefactor_mass * (1+dens);
+            grids->halo_sfr[i] = (intgrl_stars_only*prefactor_sfr) * (1+dens);
+            grids->halo_sfr_mini[i] = intgrl_stars_only_mini*prefactor_sfr_mini * (1+dens);
+            grids->n_ion[i] = (intgrl_fesc_weighted*prefactor_nion + intgrl_fesc_weighted_mini*prefactor_nion_mini) * (1+dens);
+            grids->whalo_sfr[i] = (intgrl_fesc_weighted*prefactor_wsfr + intgrl_fesc_weighted_mini*prefactor_wsfr_mini) * (1+dens);
+            grids->halo_xray[i] = (intgrl_stars_only*prefactor_xray + intgrl_stars_only_mini*prefactor_xray_mini) * (1+dens);
+            grids->halo_stars[i] = intgrl_stars_only*prefactor_stars * (1+dens);
+            grids->halo_stars_mini[i] = intgrl_stars_only_mini*prefactor_stars_mini * (1+dens);
 
             hm_avg += grids->halo_mass[i];
             nion_avg += grids->n_ion[i];
             sfr_avg += grids->halo_sfr[i];
             wsfr_avg += grids->whalo_sfr[i];
             sfr_avg_mini += grids->halo_sfr_mini[i];
+            xray_avg += grids->halo_xray[i];
+            sm_avg += grids->halo_stars[i];
+            sm_avg_mini += grids->halo_stars_mini[i];
             Mlim_a_avg += M_turn_a;
             Mlim_m_avg += M_turn_m;
             Mlim_r_avg += M_turn_r;
         }
     }
 
-    free_RGTable1D_f(&Nion_conditional_table1D);
-    free_RGTable2D_f(&Nion_conditional_table2D);
-    free_RGTable2D_f(&Nion_conditional_table_MINI);
-    free_RGTable1D_f(&SFRD_conditional_table);
-    free_RGTable2D_f(&SFRD_conditional_table_MINI);
+    free_conditional_tables();
 
     hm_avg /= HII_TOT_NUM_PIXELS;
     nion_avg /= HII_TOT_NUM_PIXELS;
@@ -276,51 +426,49 @@ int set_fixed_grids(double redshift, double norm_esc, double alpha_esc, double M
     Mlim_m_avg /= HII_TOT_NUM_PIXELS;
     Mlim_r_avg /= HII_TOT_NUM_PIXELS;
 
-    averages[0] = hm_avg;
-    averages[1] = sfr_avg;
-    averages[2] = sfr_avg_mini;
-    averages[3] = nion_avg;
-    averages[4] = wsfr_avg;
-    averages[5] = Mlim_a_avg;
-    averages[6] = Mlim_m_avg;
-    averages[7] = Mlim_r_avg;
+    double stellar_mass;
+    double stellar_mini;
+    double halo_xray;
+
+    averages->halo_mass = hm_avg;
+    averages->halo_sfr = sfr_avg;
+    averages->sfr_mini = sfr_avg_mini;
+    averages->n_ion = nion_avg;
+    averages->fescweighted_sfr = wsfr_avg;
+    averages->m_turn_a = Mlim_a_avg;
+    averages->m_turn_m = Mlim_m_avg;
+    averages->m_turn_r = Mlim_r_avg;
 
     return 0;
 }
 
 //Expected global averages for box quantities for mean adjustment
 //WARNING: THESE AVERAGE BOXES ARE WRONG, CHECK THEM
-int get_box_averages(double redshift, double norm_esc, double alpha_esc, double M_min, double M_max, double M_turn_a, double M_turn_m, double *averages){
-    double alpha_star = astro_params_stoc->ALPHA_STAR;
-    double norm_star = astro_params_stoc->F_STAR10;
-    double t_star = astro_params_stoc->t_STAR;
-    double t_h = t_hubble(redshift);
-
-    LOG_SUPER_DEBUG("Getting Box averages z=%.2f M [%.2e %.2e] Mt [%.2e %.2e]",redshift,M_min,M_max,M_turn_a,M_turn_m);
-
-    double alpha_star_mini = astro_params_stoc->ALPHA_STAR_MINI;
-    double norm_star_mini = astro_params_stoc->F_STAR7_MINI;
-    double norm_esc_mini = astro_params_stoc->F_ESC7_MINI;
-    //There's quite a bit of re-calculation here but this only happens once per snapshot
+int get_box_averages(double M_min, double M_max, double M_turn_a, double M_turn_m, struct HaloBoxConstants *consts, struct HaloProperties *averages){
+    LOG_SUPER_DEBUG("Getting Box averages z=%.2f M [%.2e %.2e] Mt [%.2e %.2e]",consts->redshift,M_min,M_max,M_turn_a,M_turn_m);
+    double t_h = t_hubble(consts->redshift);
     double lnMmax = log(M_max);
     double lnMmin = log(M_min);
-    double growth_z = dicke(redshift);
+    double growth_z = dicke(consts->redshift);
 
     double prefactor_mass = RHOcrit * cosmo_params_stoc->OMm;
-    double prefactor_nion = RHOcrit * cosmo_params_stoc->OMb * norm_star * norm_esc * global_params.Pop2_ion;
-    double prefactor_nion_mini = RHOcrit * cosmo_params_stoc->OMb * norm_star_mini * norm_esc_mini * global_params.Pop3_ion;
-    double prefactor_sfr = RHOcrit * cosmo_params_stoc->OMb * norm_star / t_star / t_h;
-    double prefactor_sfr_mini = RHOcrit * cosmo_params_stoc->OMb * norm_star_mini / t_star / t_h;
+    double prefactor_stars = RHOcrit * cosmo_params_stoc->OMb * consts->fstar_10;
+    double prefactor_stars_mini = RHOcrit * cosmo_params_stoc->OMb * consts->fstar_7;
+    double prefactor_sfr = prefactor_stars / consts->t_star / t_h;
+    double prefactor_sfr_mini = prefactor_stars_mini / consts->t_star / t_h;
+    double prefactor_nion = prefactor_stars * consts->fesc_10 * global_params.Pop2_ion;
+    double prefactor_nion_mini = prefactor_stars_mini * consts->fesc_7 * global_params.Pop3_ion;
+    double prefactor_wsfr = prefactor_sfr * consts->fesc_10;
+    double prefactor_wsfr_mini = prefactor_sfr_mini * consts->fesc_7;
+    double prefactor_xray = prefactor_sfr * astro_params_stoc->L_X;
+    double prefactor_xray_mini = prefactor_sfr_mini * astro_params_stoc->L_X_MINI;
 
-    double hm_expected,nion_expected,sfr_expected,wsfr_expected,sfr_expected_mini=0;
-
-    double Mlim_Fstar = Mass_limit_bisection(M_min, M_max, alpha_star, norm_star);
-    double Mlim_Fesc = Mass_limit_bisection(M_min, M_max, alpha_esc, norm_esc);
-    double Mlim_Fstar_mini = Mass_limit_bisection(M_min, M_max, alpha_star, norm_star * pow(1e3,alpha_star_mini));
-    double Mlim_Fesc_mini = Mass_limit_bisection(M_min, M_max, alpha_esc, norm_esc_mini * pow(1e3,alpha_esc));
+    double mass_intgrl, h_count;
+    double intgrl_fesc_weighted, intgrl_stars_only;
+    double intgrl_fesc_weighted_mini=0., intgrl_stars_only_mini=0.;
 
     struct parameters_gsl_MF_integrals params = {
-            .redshift = redshift,
+            .redshift = consts->redshift,
             .growthf = growth_z,
             .HMF = user_params_stoc->HMF,
     };
@@ -329,30 +477,217 @@ int get_box_averages(double redshift, double norm_esc, double alpha_esc, double 
         initialise_GL(NGL_INT, lnMmin, lnMmax);
 
     //NOTE: we use the atomic method for all halo mass/count here
-    hm_expected = FgtrM_General(redshift,M_min) * prefactor_mass;
-    nion_expected = Nion_General(redshift, lnMmin, lnMmax, M_turn_a, alpha_star, alpha_esc, norm_star,
-                                 norm_esc, Mlim_Fstar, Mlim_Fesc) * prefactor_nion;
-    sfr_expected = Nion_General(redshift, lnMmin, lnMmax, M_turn_a, alpha_star, 0., norm_star, 1.,
-                                 Mlim_Fstar, 0.) * prefactor_sfr;
+    mass_intgrl = FgtrM_General(consts->redshift,M_min);
+    intgrl_fesc_weighted = Nion_General(consts->redshift, lnMmin, lnMmax, M_turn_a, consts->alpha_star, consts->alpha_esc, consts->fesc_10,
+                                 consts->fesc_10, consts->Mlim_Fstar, consts->Mlim_Fesc);
+    intgrl_stars_only = Nion_General(consts->redshift, lnMmin, lnMmax, M_turn_a, consts->alpha_star, 0., consts->fesc_10, 1.,
+                                 consts->Mlim_Fstar, 0.);
     if(flag_options_stoc->USE_MINI_HALOS){
-        nion_expected += Nion_General_MINI(redshift, lnMmin, lnMmax, M_turn_m, M_turn_a,
-                                            alpha_star_mini, alpha_esc, norm_star_mini,
-                                            norm_esc_mini, Mlim_Fstar_mini, Mlim_Fesc_mini) * prefactor_nion_mini;
+        intgrl_fesc_weighted_mini = Nion_General_MINI(consts->redshift, lnMmin, lnMmax, M_turn_m, M_turn_a,
+                                            consts->alpha_star_mini, consts->alpha_esc, consts->fstar_7,
+                                            consts->fesc_7, consts->Mlim_Fstar_mini, consts->Mlim_Fesc_mini);
 
-        sfr_expected_mini = Nion_General_MINI(redshift, lnMmin, lnMmax, M_turn_m, M_turn_a,
-                                            alpha_star_mini, 0., norm_star_mini,
-                                            1., Mlim_Fstar_mini, 0.) * prefactor_sfr_mini;
+        intgrl_stars_only_mini = Nion_General_MINI(consts->redshift, lnMmin, lnMmax, M_turn_m, M_turn_a,
+                                            consts->alpha_star_mini, 0., consts->fstar_7,
+                                            1., consts->Mlim_Fstar_mini, 0.);
     }
 
-    wsfr_expected = nion_expected / t_star / t_h; //same integral, different prefactors, different in the stochastic grids due to scatter
-
-    averages[0] = hm_expected;
-    averages[1] = sfr_expected;
-    averages[2] = sfr_expected_mini;
-    averages[3] = nion_expected;
-    averages[4] = wsfr_expected;
+    averages->halo_mass = mass_intgrl * prefactor_mass;
+    averages->stellar_mass = intgrl_stars_only * prefactor_stars;
+    averages->halo_sfr = intgrl_stars_only * prefactor_sfr;
+    averages->stellar_mini = intgrl_stars_only_mini * prefactor_stars_mini;
+    averages->sfr_mini = intgrl_stars_only_mini * prefactor_sfr_mini;
+    averages->n_ion = intgrl_fesc_weighted*prefactor_nion + intgrl_fesc_weighted_mini*prefactor_nion_mini;
+    averages->fescweighted_sfr = intgrl_fesc_weighted*prefactor_wsfr + intgrl_fesc_weighted_mini*prefactor_wsfr_mini;
+    averages->halo_xray = intgrl_stars_only*prefactor_xray + intgrl_stars_only*prefactor_xray_mini;
+    averages->m_turn_a = M_turn_a;
+    averages->m_turn_m = M_turn_m;
 
     return 0;
+}
+
+void halobox_debug_print_avg(struct HaloProperties *averages_box, struct HaloProperties *averages_subsampler, struct HaloBoxConstants *consts, double M_min, double M_cell){
+    if(LOG_LEVEL < DEBUG_LEVEL)
+        return;
+    struct HaloProperties averages_sub_expected, averages_global;
+    if(!flag_options_stoc->FIXED_HALO_GRIDS){
+        get_box_averages(M_min, M_cell, averages_box->m_turn_a, averages_box->m_turn_m, consts, &averages_global);
+    }
+    else{
+        get_box_averages(user_params_stoc->SAMPLER_MIN_MASS, M_cell, averages_box->m_turn_a, averages_box->m_turn_m, consts, &averages_global);
+        if(user_params_stoc->AVG_BELOW_SAMPLER){
+            get_box_averages(M_min, user_params_stoc->SAMPLER_MIN_MASS, averages_box->m_turn_a, averages_box->m_turn_m, consts, &averages_subsampler);
+        }
+    }
+
+    LOG_DEBUG("HALO BOXES REDSHIFT %.2f",consts->redshift);
+    LOG_DEBUG("Exp. averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e)",averages_global.halo_mass,averages_global.n_ion,
+                                                                                                averages_global.halo_sfr,averages_global.sfr_mini);
+    LOG_DEBUG("Box  averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e)",averages_box->halo_mass,averages_box->n_ion,
+                                                                                                averages_box->halo_sfr,averages_box->sfr_mini);
+    if(user_params_stoc->AVG_BELOW_SAMPLER && M_min < user_params_stoc->SAMPLER_MIN_MASS){
+        LOG_DEBUG("SUB-SAMPLER",consts->redshift);
+        LOG_DEBUG("Exp. averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e)",averages_sub_expected.halo_mass,averages_sub_expected.n_ion,
+                                                                                                averages_sub_expected.halo_sfr,averages_sub_expected.sfr_mini);
+        LOG_DEBUG("Box  averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e)",averages_subsampler->halo_mass,averages_subsampler->n_ion,
+                                                                                                averages_subsampler->halo_sfr,averages_subsampler->sfr_mini);
+    }
+    LOG_DEBUG("Turnovers: ACG %11.3e global %11.3e",averages_box->m_turn_a,consts->mturn_a_nofb);
+    LOG_DEBUG("MCG  %11.3e nofb %11.3e",averages_box->m_turn_a,consts->mturn_m_nofb);
+    LOG_DEBUG("Reion %11.3e",averages_box->m_turn_r);
+}
+
+void sum_halos_onto_grid(struct InitialConditions *ini_boxes, struct TsBox *previous_spin_temp, struct IonizedBox * previous_ionize_box,
+                          struct PerturbHaloField *halos, struct HaloBoxConstants *consts, struct HaloBox *grids, struct HaloProperties *averages){
+    double redshift = consts->redshift;
+    //averages
+    double hm_avg=0.,sm_avg=0.,sfr_avg=0.;
+    double sm_avg_mini=0.,sfr_avg_mini=0.;
+    double M_turn_a_avg=0.,M_turn_m_avg=0.,M_turn_r_avg=0.;
+    double n_ion_avg=0., wsfr_avg=0., xray_avg=0.;
+    //counts
+    unsigned long long int total_n_halos, n_halos_cut=0.;
+
+    double cell_volume = VOLUME / HII_TOT_NUM_PIXELS;
+    #pragma omp parallel num_threads(user_params_stoc->N_THREADS)
+    {
+        int x,y,z;
+        unsigned long long int i_halo,i_cell;
+        double m,nion,sfr,wsfr,sfr_mini,stars_mini,stars,xray;
+        double J21_val, Gamma12_val, zre_val;
+
+        double curr_vcb = consts->vcb_norel;
+        double M_turn_m = consts->mturn_m_nofb;
+        double M_turn_a = consts->mturn_a_nofb;
+        double M_turn_r;
+
+        float in_props[3];
+        float out_props[7];
+
+    #pragma omp for reduction(+:hm_avg,sm_avg,sm_avg_mini,sfr_avg,sfr_avg_mini,M_turn_a_avg,M_turn_m_avg,M_turn_r_avg,n_halos_cut)
+        for(i_halo=0; i_halo<halos->n_halos; i_halo++){
+            m = halos->halo_masses[i_halo];
+            //It is sometimes useful to make cuts to the halo catalogues before gridding.
+            //  We implement this in a simple way, if the user sets a halo's mass to zero we skip it
+            if(m == 0.){
+                n_halos_cut++;
+                continue;
+            }
+            x = halos->halo_coords[0+3*i_halo]; //NOTE:PerturbHaloField is on HII_DIM, HaloField is on DIM
+            y = halos->halo_coords[1+3*i_halo];
+            z = halos->halo_coords[2+3*i_halo];
+
+            //set values before reionisation feedback
+            //NOTE: I could easily apply reionization feedback without minihalos but this was not done previously
+            if(flag_options_stoc->USE_MINI_HALOS){
+                if(!flag_options_stoc->FIX_VCB_AVG && user_params_stoc->USE_RELATIVE_VELOCITIES)
+                    curr_vcb = ini_boxes->lowres_vcb[HII_R_INDEX(x,y,z)];
+
+                J21_val = redshift < global_params.Z_HEAT_MAX ? previous_spin_temp->J_21_LW_box[HII_R_INDEX(x,y,z)] : 0.;
+                Gamma12_val = redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->Gamma12_box[HII_R_INDEX(x, y, z)] : 0.;
+                zre_val = redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->z_re_box[HII_R_INDEX(x, y, z)] : 0.;
+                M_turn_m = lyman_werner_threshold(redshift, J21_val, curr_vcb, astro_params_stoc);
+                M_turn_r = reionization_feedback(redshift, Gamma12_val, zre_val);
+                M_turn_a = consts->mturn_a_nofb < M_turn_r ? M_turn_r : consts->mturn_a_nofb; //since ACG turnover not reassigned
+                if(M_turn_m < M_turn_r)M_turn_m = M_turn_r;
+            }
+
+            //these are the halo property RNG sequences
+            in_props[0] = halos->star_rng[i_halo];
+            in_props[1] = halos->sfr_rng[i_halo];
+            in_props[2] = halos->xray_rng[i_halo];
+
+            set_halo_properties(m,M_turn_a,M_turn_m,consts,in_props,out_props);
+
+            sfr = out_props[0];
+            sfr_mini = out_props[1];
+            nion = out_props[2];
+            wsfr = out_props[3];
+            stars = out_props[4];
+            stars_mini = out_props[5];
+            xray = out_props[6];
+
+            if(x+y+z == 0){
+                LOG_ULTRA_DEBUG("Cell 0 Halo %d: HM: %.2e SM: %.2e (%.2e) NI: %.2e SF: %.2e (%.2e) WS: %.2e",i_halo,m,stars,stars_mini,nion,sfr,sfr_mini,wsfr);
+                LOG_ULTRA_DEBUG("Mturn_a %.2e Mturn_m %.2e",M_turn_a,M_turn_m);
+            }
+
+            //update the grids
+            #pragma omp atomic update
+            grids->halo_mass[HII_R_INDEX(x, y, z)] += m;
+            #pragma omp atomic update
+            grids->halo_stars[HII_R_INDEX(x, y, z)] += stars;
+            #pragma omp atomic update
+            grids->halo_stars_mini[HII_R_INDEX(x, y, z)] += stars_mini;
+            #pragma omp atomic update
+            grids->n_ion[HII_R_INDEX(x, y, z)] += nion;
+            #pragma omp atomic update
+            grids->halo_sfr[HII_R_INDEX(x, y, z)] += sfr;
+            #pragma omp atomic update
+            grids->halo_sfr_mini[HII_R_INDEX(x, y, z)] += sfr_mini;
+            #pragma omp atomic update
+            grids->whalo_sfr[HII_R_INDEX(x, y, z)] += wsfr;
+            #pragma omp atomic update
+            grids->halo_xray[HII_R_INDEX(x, y, z)] += xray;
+            #pragma omp atomic update
+            grids->count[HII_R_INDEX(x, y, z)] += 1;
+
+            M_turn_m_avg += M_turn_m;
+            hm_avg += m;
+            sfr_avg += sfr;
+            sfr_avg_mini += sfr_mini;
+            sm_avg += stars;
+            sm_avg_mini += stars_mini;
+            n_ion_avg += nion;
+            wsfr_avg += wsfr;
+            M_turn_a_avg += M_turn_a;
+            M_turn_r_avg += M_turn_r;
+            M_turn_m_avg += M_turn_m;
+        }
+
+        #pragma omp for
+        for (i_cell=0; i_cell<HII_TOT_NUM_PIXELS; i_cell++) {
+            grids->halo_mass[i_cell] /= cell_volume;
+            grids->n_ion[i_cell] /= cell_volume;
+            grids->halo_sfr[i_cell] /= cell_volume;
+            grids->halo_sfr_mini[i_cell] /= cell_volume;
+            grids->halo_stars[i_cell] /= cell_volume;
+            grids->halo_stars_mini[i_cell] /= cell_volume;
+            grids->whalo_sfr[i_cell] /= cell_volume;
+        }
+    }
+    total_n_halos = halos->n_halos - n_halos_cut;
+    LOG_SUPER_DEBUG("Cell 0: HM: %.2e SM: %.2e (%.2e) NI: %.2e SF: %.2e (%.2e) WS: %.2e ct : %d",grids->halo_mass[HII_R_INDEX(0,0,0)],
+                        grids->halo_stars[HII_R_INDEX(0,0,0)],grids->halo_stars_mini[HII_R_INDEX(0,0,0)],
+                        grids->n_ion[HII_R_INDEX(0,0,0)],grids->halo_sfr[HII_R_INDEX(0,0,0)],grids->halo_sfr_mini[HII_R_INDEX(0,0,0)],
+                        grids->whalo_sfr[HII_R_INDEX(0,0,0)],grids->count[HII_R_INDEX(0,0,0)]);
+
+    //NOTE: There is an inconsistency here, the sampled grids use a halo-averaged turnover mass
+    //  whereas the fixed grids / default 21cmfast uses the volume averaged LOG10(turnover mass).
+    //  Neither of these are a perfect representation due to the nonlinear way turnover mass affects N_ion
+    if(total_n_halos > 0){
+        M_turn_r_avg /= total_n_halos;
+        M_turn_a_avg /= total_n_halos;
+        M_turn_m_avg /= total_n_halos;
+    }
+    //If we have no halos, assume the turnover has no reion feedback & no LW
+    if(total_n_halos == 0){
+        M_turn_m_avg = lyman_werner_threshold(redshift, 0., consts->vcb_norel, astro_params_stoc);
+    }
+    grids->log10_Mcrit_LW_ave = log10(M_turn_m_avg);
+
+    hm_avg /= VOLUME;
+    sfr_avg /= VOLUME;
+    sfr_avg_mini /= VOLUME;
+
+    averages->halo_mass = hm_avg;
+    averages->stellar_mass = sm_avg;
+    averages->halo_sfr = sfr_avg;
+    averages->stellar_mini = sm_avg_mini;
+    averages->sfr_mini = sfr_avg_mini;
+    averages->m_turn_a = M_turn_a_avg;
+    averages->m_turn_m = M_turn_m_avg;
+    averages->m_turn_r = M_turn_r_avg;
 }
 
 //We grid a PERTURBED halofield into the necessary quantities for calculating radiative backgrounds
@@ -379,29 +714,19 @@ int ComputeHaloBox(double redshift, struct UserParams *user_params, struct Cosmo
             grids->count[idx] = 0;
         }
 
+        struct HaloBoxConstants hbox_consts;
+
+        set_hbox_constants(redshift,astro_params,flag_options,&hbox_consts);
+
         LOG_DEBUG("Gridding %llu halos...",halos->n_halos);
 
-        double alpha_esc = astro_params->ALPHA_ESC;
-        double norm_esc = astro_params->F_ESC10;
-        if(flag_options->PHOTON_CONS_TYPE == 2)
-            alpha_esc = get_fesc_fit(redshift);
-        else if(flag_options->PHOTON_CONS_TYPE == 3)
-            norm_esc = get_fesc_fit(redshift);
-
-        double hm_avg=0,nion_avg=0,sfr_avg=0,wsfr_avg=0,sfr_avg_mini=0;
-
         double M_min = minimum_source_mass(redshift,false,astro_params,flag_options);
-        double t_h = t_hubble(redshift);
         double cell_volume = VOLUME/HII_TOT_NUM_PIXELS;
         double M_cell = cosmo_params->OMm*RHOcrit*cell_volume;
-        double M_turn_a_avg = 0, M_turn_m_avg = 0, M_turn_r_avg = 0.;
-        double M_turn_m_nofb_avg=0;
-        double M_turn_a_nofb = flag_options_stoc->USE_MINI_HALOS ? atomic_cooling_threshold(redshift) : astro_params_stoc->M_TURN;
 
-        double curr_vcb = flag_options->FIX_VCB_AVG ? global_params.VAVG : 0;
+        double M_turn_a_global, M_turn_m_global;
 
-        double averages_box[8], averages_global[5], averages_subsampler[5], averages_nofb[5], averages_nofb_sub[5];
-        unsigned long long int total_n_halos, n_halos_cut=0.;
+        struct HaloProperties averages_box, averages_subsampler, averages_global;
 
         init_ps();
         if(user_params->USE_INTERPOLATION_TABLES){
@@ -414,32 +739,27 @@ int ComputeHaloBox(double redshift, struct UserParams *user_params, struct Cosmo
         //Since we need the average turnover masses before we can calculate the global means, we do the CMF integrals first
         //Then we calculate the expected UMF integrals before doing the adjustment
         if(flag_options->FIXED_HALO_GRIDS){
-            set_fixed_grids(redshift, norm_esc, alpha_esc, M_min, M_cell, ini_boxes, perturbed_field, previous_spin_temp, previous_ionize_box, grids, averages_box);
-            M_turn_a_avg = averages_box[5];
-            M_turn_m_avg = averages_box[6];
-            get_box_averages(redshift, norm_esc, alpha_esc, M_min, M_cell, M_turn_a_avg, M_turn_m_avg, averages_global);
+            set_fixed_grids(M_min, M_cell, ini_boxes, perturbed_field, previous_spin_temp, previous_ionize_box, &hbox_consts, grids, &averages_box);
+            M_turn_a_global = averages_box.m_turn_a;
+            M_turn_m_global = averages_box.m_turn_m;
+            get_box_averages(M_min, M_cell, M_turn_a_global, M_turn_m_global, &hbox_consts, &averages_global);
             //This is the mean adjustment that happens in the rest of the code
             //NOTE: in the default mode, global averages are fixed separately for minihalo and regular parts
-#pragma omp parallel for num_threads(user_params->N_THREADS)
+            #pragma omp parallel for num_threads(user_params->N_THREADS)
             for(idx=0;idx<HII_TOT_NUM_PIXELS;idx++){
-                grids->halo_mass[idx] *= averages_global[0]/averages_box[0];
-                grids->halo_sfr[idx] *= averages_global[1]/averages_box[1];
-                grids->halo_sfr_mini[idx] *= averages_global[2]/averages_box[2];
-                grids->n_ion[idx] *= averages_global[3]/averages_box[3];
-                grids->whalo_sfr[idx] *= averages_global[4]/averages_box[4];
+                grids->halo_mass[idx] *= averages_global.halo_mass/averages_box.halo_mass;
+                grids->halo_sfr[idx] *= averages_global.halo_sfr/averages_box.halo_sfr;
+                grids->halo_sfr_mini[idx] *= averages_global.sfr_mini/averages_box.sfr_mini;
+                grids->n_ion[idx] *= averages_global.n_ion/averages_box.n_ion;
+                grids->whalo_sfr[idx] *= averages_global.fescweighted_sfr/averages_box.fescweighted_sfr;
             }
-
-            hm_avg = averages_global[0];
-            sfr_avg = averages_global[1];
-            sfr_avg_mini = averages_global[2];
-            nion_avg = averages_global[3];
-            wsfr_avg = averages_global[4];
         }
         else{
             //set below-resolution properties
             if(user_params->AVG_BELOW_SAMPLER && M_min < user_params->SAMPLER_MIN_MASS){
-                set_fixed_grids(redshift, norm_esc, alpha_esc, M_min, user_params->SAMPLER_MIN_MASS, ini_boxes,
-                                perturbed_field, previous_spin_temp, previous_ionize_box, grids, averages_box);
+                set_fixed_grids(M_min, user_params->SAMPLER_MIN_MASS, ini_boxes,
+                                perturbed_field, previous_spin_temp, previous_ionize_box,
+                                &hbox_consts, grids, &averages_subsampler);
                 //This is pretty redundant, but since the fixed grids have density units (X Mpc-3) I have to re-multiply before adding the halos.
                 //      I should instead have a flag to output the summed values in cell. (2*N_pixel > N_halo so generally i don't want to do it in the halo loop)
                 for (idx=0; idx<HII_TOT_NUM_PIXELS; idx++) {
@@ -451,184 +771,18 @@ int ComputeHaloBox(double redshift, struct UserParams *user_params, struct Cosmo
                 }
                 LOG_DEBUG("finished subsampler M[%.2e %.2e]",M_min,user_params->SAMPLER_MIN_MASS);
             }
-#pragma omp parallel num_threads(user_params->N_THREADS) private(idx)
-            {
-                int x,y,z;
-                unsigned long long int i_halo;
-                double m,nion,sfr,wsfr,sfr_mini,stars_mini,stars;
-                double J21_val, Gamma12_val, zre_val;
-
-                double curr_vcb = flag_options_stoc->FIX_VCB_AVG ? global_params.VAVG : 0;
-                double M_turn_m_nofb = lyman_werner_threshold(redshift, 0., curr_vcb, astro_params_stoc);
-                double M_turn_r, M_turn_m;
-                double M_turn_a = M_turn_a_nofb;
-
-                float in_props[2];
-                float out_props[6];
-
-#pragma omp for reduction(+:hm_avg,nion_avg,sfr_avg,wsfr_avg,sfr_avg_mini,M_turn_a_avg,M_turn_m_avg,M_turn_r_avg,M_turn_m_nofb_avg,n_halos_cut)
-                for(i_halo=0; i_halo<halos->n_halos; i_halo++){
-                    x = halos->halo_coords[0+3*i_halo]; //NOTE:PerturbedHaloField is on HII_DIM, HaloField is on DIM
-                    y = halos->halo_coords[1+3*i_halo];
-                    z = halos->halo_coords[2+3*i_halo];
-
-                    if(!flag_options_stoc->FIX_VCB_AVG && user_params->USE_RELATIVE_VELOCITIES){
-                        curr_vcb = ini_boxes->lowres_vcb[HII_R_INDEX(x,y,z)];
-                    }
-
-                    //set values before reionisation feedback
-                    //NOTE: I could easily apply reionization feedback without minihalos but this was not done previously
-                    if(flag_options->USE_MINI_HALOS){
-                        J21_val = redshift < global_params.Z_HEAT_MAX ? previous_spin_temp->J_21_LW_box[HII_R_INDEX(x,y,z)] : 0.;
-                        Gamma12_val = redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->Gamma12_box[HII_R_INDEX(x, y, z)] : 0.;
-                        zre_val = redshift < global_params.Z_HEAT_MAX ? previous_ionize_box->z_re_box[HII_R_INDEX(x, y, z)] : 0.;
-                        M_turn_m_nofb = lyman_werner_threshold(redshift, J21_val, curr_vcb, astro_params_stoc);
-                        M_turn_r = reionization_feedback(redshift, Gamma12_val, zre_val);
-                        M_turn_a = M_turn_r > M_turn_a_nofb ? M_turn_r : M_turn_a_nofb;
-                        M_turn_m = M_turn_r > M_turn_m_nofb ? M_turn_r : M_turn_m_nofb;
-                    }
-
-                    m = halos->halo_masses[i_halo];
-
-                    //It is sometimes useful to make cuts to the halo catalogues before gridding.
-                    //  We implement this in a simple way, if the user sets a halo's mass to zero we skip it
-                    if(m == 0.){
-                        n_halos_cut++;
-                        continue;
-                    }
-
-                    //these are the halo property RNG sequences
-                    in_props[0] = halos->star_rng[i_halo];
-                    in_props[1] = halos->sfr_rng[i_halo];
-
-                    set_halo_properties(m,M_turn_a,M_turn_m,t_h,norm_esc,alpha_esc,in_props,out_props);
-
-                    sfr = out_props[0];
-                    sfr_mini = out_props[1];
-                    nion = out_props[2];
-                    wsfr = out_props[3];
-                    stars = out_props[4];
-                    stars_mini = out_props[5];
-
-                    if(x+y+z == 0){
-                        LOG_ULTRA_DEBUG("Cell 0 Halo %d: HM: %.2e SM: %.2e (%.2e) NI: %.2e SF: %.2e (%.2e) WS: %.2e",i_halo,m,stars,stars_mini,nion,sfr,sfr_mini,wsfr);
-                        LOG_ULTRA_DEBUG("Mturn_a %.2e Mturn_m %.2e",M_turn_a,M_turn_m);
-                    }
-
-
-#pragma omp atomic update
-                    grids->halo_mass[HII_R_INDEX(x, y, z)] += m;
-#pragma omp atomic update
-                    grids->halo_stars[HII_R_INDEX(x, y, z)] += stars;
-#pragma omp atomic update
-                    grids->halo_stars_mini[HII_R_INDEX(x, y, z)] += stars_mini;
-#pragma omp atomic update
-                    grids->n_ion[HII_R_INDEX(x, y, z)] += nion;
-#pragma omp atomic update
-                    grids->halo_sfr[HII_R_INDEX(x, y, z)] += sfr;
-#pragma omp atomic update
-                    grids->halo_sfr_mini[HII_R_INDEX(x, y, z)] += sfr_mini;
-#pragma omp atomic update
-                    grids->whalo_sfr[HII_R_INDEX(x, y, z)] += wsfr;
-#pragma omp atomic update
-                        grids->count[HII_R_INDEX(x, y, z)] += 1;
-
-                    M_turn_m_avg += M_turn_m;
-                    if(LOG_LEVEL >= DEBUG_LEVEL){
-                        hm_avg += m;
-                        sfr_avg += sfr;
-                        sfr_avg_mini += sfr_mini;
-                        wsfr_avg += wsfr;
-                        nion_avg += nion;
-                        M_turn_a_avg += M_turn_a;
-                        M_turn_r_avg += M_turn_r;
-                        M_turn_m_nofb_avg += M_turn_m_nofb;
-                    }
-                }
-#pragma omp for
-                for (idx=0; idx<HII_TOT_NUM_PIXELS; idx++) {
-                    grids->halo_mass[idx] /= cell_volume;
-                    grids->n_ion[idx] /= cell_volume;
-                    grids->halo_sfr[idx] /= cell_volume;
-                    grids->halo_sfr_mini[idx] /= cell_volume;
-                    grids->halo_stars[idx] /= cell_volume;
-                    grids->halo_stars_mini[idx] /= cell_volume;
-                    grids->whalo_sfr[idx] /= cell_volume;
-                }
-            }
-            total_n_halos = halos->n_halos - n_halos_cut;
-            LOG_SUPER_DEBUG("Cell 0: HM: %.2e SM: %.2e (%.2e) NI: %.2e SF: %.2e (%.2e) WS: %.2e ct : %d",grids->halo_mass[HII_R_INDEX(0,0,0)],
-                                grids->halo_stars[HII_R_INDEX(0,0,0)],grids->halo_stars_mini[HII_R_INDEX(0,0,0)],
-                                grids->n_ion[HII_R_INDEX(0,0,0)],grids->halo_sfr[HII_R_INDEX(0,0,0)],grids->halo_sfr_mini[HII_R_INDEX(0,0,0)],
-                                grids->whalo_sfr[HII_R_INDEX(0,0,0)],grids->count[HII_R_INDEX(0,0,0)]);
-
-            M_turn_m_avg = M_turn_m_avg / total_n_halos;
-            //If we have no halos, assume the turnover has no reion feedback & no LW
-            if(total_n_halos == 0){
-                M_turn_m_avg = lyman_werner_threshold(redshift, 0., flag_options_stoc->FIX_VCB_AVG ? global_params.VAVG : 0, astro_params);
-                M_turn_a_avg = flag_options_stoc->USE_MINI_HALOS ? atomic_cooling_threshold(redshift) : astro_params_stoc->M_TURN;
-                M_turn_r_avg = 0.;
-                M_turn_m_nofb_avg = M_turn_m_avg;
-            }
-            grids->log10_Mcrit_LW_ave = log10(M_turn_m_avg);
-
-            if(LOG_LEVEL >= DEBUG_LEVEL){
-                hm_avg /= VOLUME;
-                sfr_avg /= VOLUME;
-                sfr_avg_mini /= VOLUME;
-                wsfr_avg /= VOLUME;
-                nion_avg /= VOLUME;
-
-                //NOTE: There is an inconsistency here, the sampled grids use a halo-averaged turnover mass
-                //  whereas the fixed grids / default 21cmfast uses the volume averaged LOG10(turnover mass).
-                //  Neither of these are a perfect representation due to the nonlinear way turnover mass affects N_ion
-                if(total_n_halos > 0){
-                    M_turn_r_avg /= total_n_halos;
-                    M_turn_m_nofb_avg /= total_n_halos;
-                    M_turn_a_avg /= total_n_halos;
-                }
-
-                get_box_averages(redshift, norm_esc, alpha_esc, user_params->SAMPLER_MIN_MASS, global_params.M_MAX_INTEGRAL, M_turn_a_avg, M_turn_m_avg, averages_global);
-                get_box_averages(redshift, norm_esc, alpha_esc, M_min, user_params->SAMPLER_MIN_MASS, M_turn_a_avg, M_turn_m_avg, averages_subsampler);
-                get_box_averages(redshift, norm_esc, alpha_esc, user_params->SAMPLER_MIN_MASS, global_params.M_MAX_INTEGRAL, M_turn_a_nofb, M_turn_m_nofb_avg, averages_nofb);
-                get_box_averages(redshift, norm_esc, alpha_esc, M_min, user_params->SAMPLER_MIN_MASS, M_turn_a_nofb, M_turn_m_nofb_avg, averages_nofb_sub);
-            }
+            sum_halos_onto_grid(ini_boxes, previous_spin_temp, previous_ionize_box,
+                                halos, &hbox_consts, grids, &averages_box);
         }
 
         if(user_params->USE_INTERPOLATION_TABLES){
                 freeSigmaMInterpTable();
         }
-
-        LOG_DEBUG("HALO BOXES REDSHIFT %.2f",redshift);
-        LOG_DEBUG("Exp. averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e, WSFR %11.3e)",averages_global[0],averages_global[3],averages_global[1],
-                                                                                                    averages_global[2],averages_global[4]);
-        LOG_DEBUG("Box  averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e, WSFR %11.3e)",hm_avg,nion_avg,sfr_avg,sfr_avg_mini,wsfr_avg);
-        LOG_DEBUG("nof  averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e, WSFR %11.3e)",averages_nofb[0],averages_nofb[3],
-                                                                                                    averages_nofb[1],averages_nofb[2],averages_nofb[4]);
-        LOG_DEBUG("Ratio:         (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e, WSFR %11.3e)",hm_avg/averages_global[0],nion_avg/averages_global[3],
-                                                                                                    sfr_avg/averages_global[1],sfr_avg_mini/averages_global[2],
-                                                                                                    wsfr_avg/averages_global[4]);
-        if(user_params->AVG_BELOW_SAMPLER && M_min < user_params->SAMPLER_MIN_MASS){
-            LOG_DEBUG("SUB-SAMPLER",redshift);
-            LOG_DEBUG("Exp. averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e, WSFR %11.3e)",averages_subsampler[0],averages_subsampler[3],averages_subsampler[1],
-                                                                                                        averages_subsampler[2],averages_subsampler[4]);
-            LOG_DEBUG("Box  averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e, WSFR %11.3e)",averages_box[0],averages_box[3],
-                                                                                                        averages_box[1],averages_box[2],averages_box[4]);
-            LOG_DEBUG("nof  averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e, WSFR %11.3e)",averages_nofb_sub[0],averages_nofb_sub[3],
-                                                                                                        averages_nofb_sub[1],averages_nofb_sub[2],averages_nofb_sub[4]);
-            LOG_DEBUG("Ratio:         (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e, WSFR %11.3e)",averages_box[0]/averages_subsampler[0],
-                                                                                                        averages_box[3]/averages_subsampler[3],
-                                                                                                        averages_box[1]/averages_subsampler[1],
-                                                                                                        averages_box[2]/averages_subsampler[2],
-                                                                                                        averages_box[4]/averages_subsampler[4]);
-        }
-        LOG_DEBUG("Turnovers: ACG %11.3e global %11.3e Cell %11.3e",M_turn_a_avg,atomic_cooling_threshold(redshift),averages_box[5]);
-        LOG_DEBUG("MCG  %11.3e nofb %11.3e Cell %11.3e",M_turn_m_avg,M_turn_m_nofb_avg,averages_box[6]);
-        LOG_DEBUG("Reion %11.3e Cell %11.3e",M_turn_r_avg,averages_box[7]);
+        halobox_debug_print_avg(&averages_box,&averages_subsampler,&hbox_consts,M_min,M_cell);
     }
     Catch(status){
         return(status);
     }
     LOG_DEBUG("Done.");
-    return(0);
+    return 0.;
 }

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -364,7 +364,7 @@ int set_fixed_grids(double M_min, double M_max, struct InitialConditions *ini_bo
         double intgrl_fesc_weighted, intgrl_stars_only;
         double intgrl_fesc_weighted_mini=0., intgrl_stars_only_mini=0.;
 
-#pragma omp for reduction(+:hm_avg,nion_avg,sfr_avg,sfr_avg_mini,wsfr_avg,Mlim_a_avg,Mlim_m_avg)
+#pragma omp for reduction(+:hm_avg,sm_avg,sfr_avg,xray_avg,nion_avg,wsfr_avg,sm_avg_mini,wsfr_avg,Mlim_a_avg,Mlim_m_avg,Mlim_r_avg)
         for(i=0;i<HII_TOT_NUM_PIXELS;i++){
             dens = perturbed_field->density[i];
             params.delta = dens;
@@ -426,22 +426,24 @@ int set_fixed_grids(double M_min, double M_max, struct InitialConditions *ini_bo
     free_conditional_tables();
 
     hm_avg /= HII_TOT_NUM_PIXELS;
+    sm_avg /= HII_TOT_NUM_PIXELS;
+    sm_avg_mini /= HII_TOT_NUM_PIXELS;
     nion_avg /= HII_TOT_NUM_PIXELS;
     sfr_avg /= HII_TOT_NUM_PIXELS;
     sfr_avg_mini /= HII_TOT_NUM_PIXELS;
     wsfr_avg /= HII_TOT_NUM_PIXELS;
+    xray_avg /= HII_TOT_NUM_PIXELS;
     Mlim_a_avg /= HII_TOT_NUM_PIXELS;
     Mlim_m_avg /= HII_TOT_NUM_PIXELS;
     Mlim_r_avg /= HII_TOT_NUM_PIXELS;
 
-    double stellar_mass;
-    double stellar_mini;
-    double halo_xray;
-
     averages->halo_mass = hm_avg;
+    averages->stellar_mass = sm_avg;
+    averages->stellar_mini = sm_avg_mini
     averages->halo_sfr = sfr_avg;
     averages->sfr_mini = sfr_avg_mini;
     averages->n_ion = nion_avg;
+    averages->halo_xray = xray_avg
     averages->fescweighted_sfr = wsfr_avg;
     averages->m_turn_acg = Mlim_a_avg;
     averages->m_turn_mcg = Mlim_m_avg;
@@ -529,16 +531,20 @@ void halobox_debug_print_avg(struct HaloProperties *averages_box, struct HaloPro
     }
 
     LOG_DEBUG("HALO BOXES REDSHIFT %.2f",consts->redshift);
-    LOG_DEBUG("Exp. averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e)",averages_global.halo_mass,averages_global.n_ion,
-                                                                                                averages_global.halo_sfr,averages_global.sfr_mini);
-    LOG_DEBUG("Box  averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e)",averages_box->halo_mass,averages_box->n_ion,
-                                                                                                averages_box->halo_sfr,averages_box->sfr_mini);
+    LOG_DEBUG("Exp. averages: (HM %11.3e, SM %11.3e SM_MINI %11.3e SFR %11.3e, SFR_MINI %11.3e, XRAY %11.3e, NION %11.3e)",
+                averages_global.halo_mass,averages_global.stellar_mass, averages_global.stellar_mini, averages_global.halo_sfr,
+                averages_global.sfr_mini,averages_global.halo_xray,averages_global.n_ion);
+    LOG_DEBUG("Box. averages: (HM %11.3e, SM %11.3e SM_MINI %11.3e SFR %11.3e, SFR_MINI %11.3e, XRAY %11.3e, NION %11.3e)",
+                averages_box->halo_mass,averages_box->stellar_mass,averages_box->stellar_mini,averages_box->halo_sfr,
+                averages_box->sfr_mini,averages_box->halo_xray,averages_box->n_ion);
     if(user_params_stoc->AVG_BELOW_SAMPLER && M_min < user_params_stoc->SAMPLER_MIN_MASS){
         LOG_DEBUG("SUB-SAMPLER",consts->redshift);
-        LOG_DEBUG("Exp. averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e)",averages_sub_expected.halo_mass,averages_sub_expected.n_ion,
-                                                                                                averages_sub_expected.halo_sfr,averages_sub_expected.sfr_mini);
-        LOG_DEBUG("Box  averages: (HM %11.3e, NION %11.3e, SFR %11.3e, SFR_MINI %11.3e)",averages_subsampler->halo_mass,averages_subsampler->n_ion,
-                                                                                                averages_subsampler->halo_sfr,averages_subsampler->sfr_mini);
+    LOG_DEBUG("Exp. averages: (HM %11.3e, SM %11.3e SM_MINI %11.3e SFR %11.3e, SFR_MINI %11.3e, XRAY %11.3e, NION %11.3e)",
+                averages_sub_expected.halo_mass,averages_sub_expected.stellar_mass, averages_sub_expected.stellar_mini, averages_sub_expected.halo_sfr,
+                averages_sub_expected.sfr_mini,averages_sub_expected.halo_xray,averages_sub_expected.n_ion);
+    LOG_DEBUG("Box. averages: (HM %11.3e, SM %11.3e SM_MINI %11.3e SFR %11.3e, SFR_MINI %11.3e, XRAY %11.3e, NION %11.3e)",
+                averages_subsampler->halo_mass,averages_subsampler->stellar_mass, averages_subsampler->stellar_mini, averages_subsampler->halo_sfr,
+                averages_subsampler->sfr_mini,averages_subsampler->halo_xray,averages_subsampler->n_ion);
     }
     LOG_DEBUG("Turnovers: ACG %11.3e global %11.3e",averages_box->m_turn_acg,consts->mturn_a_nofb);
     LOG_DEBUG("MCG  %11.3e nofb %11.3e",averages_box->m_turn_acg,consts->mturn_m_nofb);

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -1559,11 +1559,7 @@ LOG_DEBUG("global_xH = %e",global_xH);
     }
 
     //These functions check for allocation
-    free_RGTable1D_f(&Nion_conditional_table1D);
-    free_RGTable2D_f(&Nion_conditional_table2D);
-    free_RGTable2D_f(&Nion_conditional_table_MINI);
-    free_RGTable2D_f(&Nion_conditional_table_prev);
-    free_RGTable2D_f(&Nion_conditional_table_MINI_prev);
+    free_conditional_tables();
 
     free(overdense_int_boundexceeded_threaded);
 

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -260,6 +260,8 @@ LOG_SUPER_DEBUG("erfc interpolation done");
     fftwf_complex *stars_unfiltered,*stars_filtered;
     fftwf_complex *sfr_unfiltered,*sfr_filtered;
 
+    //NOTE FOR REFACTOR: These don't need to be allocated/filtered if (USE_HALO FIELD && CELL_RECOMB)
+    // Also, I don't think deltax_unfiltered_original is useful at all since we have the PerturbedField
     deltax_unfiltered = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
     deltax_unfiltered_original = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
     deltax_filtered = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex)*HII_KSPACE_NUM_PIXELS);
@@ -574,7 +576,7 @@ LOG_SUPER_DEBUG("sigma table has been initialised");
     }
     else {
         LOG_DEBUG("Setting mean collapse fraction");
-        box->mean_f_coll = FgtrM_General(redshift, M_MIN);
+        box->mean_f_coll = Fcoll_General(redshift, lnMmin, lnMmax);
     }
 
     if(isfinite(box->mean_f_coll)==0) {
@@ -1210,7 +1212,13 @@ LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll_MINI: %e", box->mean_f
                     for (y = 0; y < user_params->HII_DIM; y++) {
                         for (z = 0; z < HII_D_PARA; z++) {
 
-                            curr_dens = *((float *)deltax_filtered + HII_R_FFT_INDEX(x,y,z));
+                            //Use unfiltered density for CELL_RECOMB case, since the "Fcoll" represents photons
+                            //  reaching the central cell rather than photons in the entire sphere
+                            if(flag_options->CELL_RECOMB)
+                                curr_dens = *((float *)deltax_filtered + HII_R_FFT_INDEX(x,y,z));
+                            else
+                                curr_dens = perturbed_field->density[HII_R_INDEX(x,y,z)];
+
 
                             Splined_Fcoll = box->Fcoll[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)];
 
@@ -1251,16 +1259,14 @@ LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll_MINI: %e", box->mean_f
                             }
 
                             if (flag_options->INHOMO_RECO) {
-                                if(flag_options->CELL_RECOMB){
+                                if(flag_options->CELL_RECOMB)
                                     rec = previous_ionize_box->dNrec_box[HII_R_INDEX(x,y,z)];
-                                    rec /= (1 + perturbed_field->density[HII_R_INDEX(x,y,z)]);
-                                }
-                                else{
-                                    rec = (*((float *) N_rec_filtered +
-                                            HII_R_FFT_INDEX(x, y, z))); // number of recombinations per mean baryon
-                                    rec /= (1. + curr_dens); // number of recombinations per baryon inside cell/filter
-                                }
-                            } else {
+                                else
+                                    rec = (*((float *) N_rec_filtered + HII_R_FFT_INDEX(x, y, z))); // number of recombinations per mean baryon
+
+                                rec /= (1. + curr_dens); // number of recombinations per baryon inside cell/filter
+                            }
+                            else {
                                 rec = 0.;
                             }
 

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -1215,10 +1215,9 @@ LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll_MINI: %e", box->mean_f
                             //Use unfiltered density for CELL_RECOMB case, since the "Fcoll" represents photons
                             //  reaching the central cell rather than photons in the entire sphere
                             if(flag_options->CELL_RECOMB)
-                                curr_dens = *((float *)deltax_filtered + HII_R_FFT_INDEX(x,y,z));
-                            else
                                 curr_dens = perturbed_field->density[HII_R_INDEX(x,y,z)];
-
+                            else
+                                curr_dens = *((float *)deltax_filtered + HII_R_FFT_INDEX(x,y,z));
 
                             Splined_Fcoll = box->Fcoll[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)];
 

--- a/src/py21cmfast/src/PerturbHaloField.c
+++ b/src/py21cmfast/src/PerturbHaloField.c
@@ -199,6 +199,7 @@ LOG_DEBUG("Begin Initialisation");
                 halos_perturbed->halo_masses[i_halo] = halos->halo_masses[i_halo];
                 halos_perturbed->star_rng[i_halo] = halos->star_rng[i_halo];
                 halos_perturbed->sfr_rng[i_halo] = halos->sfr_rng[i_halo];
+                halos_perturbed->xray_rng[i_halo] = halos->xray_rng[i_halo];
             }
         }
 
@@ -255,6 +256,7 @@ void free_phf(struct PerturbHaloField* halos){
     free(halos->halo_coords);
     free(halos->star_rng);
     free(halos->sfr_rng);
+    free(halos->xray_rng);
     LOG_DEBUG("Done Freeing PerturbHaloField");
     halos->n_halos = 0;
 }

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -708,8 +708,10 @@ int UpdateXraySourceBox(struct UserParams *user_params, struct CosmoParams *cosm
         if(R_ct == global_params.NUM_FILTER_STEPS_FOR_Ts - 1){
             LOG_DEBUG("finished XraySourceBox");
         }
-        LOG_SUPER_DEBUG("R = %8.3f | mean filtered sfr = %10.3e (%10.3e MINI) unfiltered %10.3e (%10.3e MINI) mean log10McritLW %.4e",
+        LOG_SUPER_DEBUG("R = %8.3f | mean filtered sfr  = %10.3e (%10.3e MINI) unfiltered %10.3e (%10.3e MINI) mean log10McritLW %.4e",
                             R_outer,fsfr_avg,fsfr_avg_mini,sfr_avg,sfr_avg_mini,source_box->mean_log10_Mcrit_LW[R_ct]);
+        LOG_SUPER_DEBUG("R = %8.3f | mean filtered xray = %10.3e (%10.3e MINI) unfiltered %10.3e (%10.3e MINI)",
+                            fxray_avg,fxray_avg_mini,xray_avg,xray_avg_mini);
 
         fftwf_forget_wisdom();
         fftwf_cleanup_threads();

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -1499,7 +1499,7 @@ void ts_main(float redshift, float prev_redshift, struct UserParams *user_params
                     if(flag_options->USE_HALO_FIELD){
                         sfr_term = source_box->filtered_sfr[R_index*HII_TOT_NUM_PIXELS + box_ct] * z_edge_factor;
                         //Minihalos and s->yr conversion are already included here
-                        xray_sfr = source_box->filtered_xray[R_index*HII_TOT_NUM_PIXELS + box_ct] * z_edge_factor * xray_R_factor * 1e40;
+                        xray_sfr = source_box->filtered_xray[R_index*HII_TOT_NUM_PIXELS + box_ct] * z_edge_factor * xray_R_factor * 1e38;
                     }
                     else{
                         //NOTE: for !USE_MASS_DEPENDENT_ZETA, F_STAR10 is still used for constant stellar fraction

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -1498,8 +1498,8 @@ void ts_main(float redshift, float prev_redshift, struct UserParams *user_params
 
                     if(flag_options->USE_HALO_FIELD){
                         sfr_term = source_box->filtered_sfr[R_index*HII_TOT_NUM_PIXELS + box_ct] * z_edge_factor;
-                        //Minihalos and s->yr conversion are included here, but multiplied by the ratio of L_X_MINI to L_X
-                        xray_sfr = source_box->filtered_xray[R_index*HII_TOT_NUM_PIXELS + box_ct] * z_edge_factor * xray_R_factor * astro_params->L_X;
+                        //Minihalos and s->yr conversion are already included here
+                        xray_sfr = source_box->filtered_xray[R_index*HII_TOT_NUM_PIXELS + box_ct] * z_edge_factor * xray_R_factor * 1e40;
                     }
                     else{
                         //NOTE: for !USE_MASS_DEPENDENT_ZETA, F_STAR10 is still used for constant stellar fraction

--- a/src/py21cmfast/src/Stochasticity.c
+++ b/src/py21cmfast/src/Stochasticity.c
@@ -20,6 +20,7 @@ struct HaloSamplingConstants{
     int from_catalog; //flag for first box or updating halos
     double corr_sfr;
     double corr_star;
+    double corr_xray;
 
     double z_in;
     double z_out;
@@ -133,6 +134,10 @@ void stoc_set_consts_z(struct HaloSamplingConstants *const_struct, double redshi
             const_struct->corr_star = exp(-(redshift - redshift_desc)/astro_params_stoc->CORR_STAR);
         else
             const_struct->corr_star = 0;
+        if(astro_params_stoc->CORR_LX > 0)
+            const_struct->corr_xray = exp(-(redshift - redshift_desc)/astro_params_stoc->CORR_LX);
+        else
+            const_struct->corr_xray = 0;
 
         const_struct->from_catalog = 1;
         initialise_dNdM_tables(log(user_params_stoc->SAMPLER_MIN_MASS), const_struct->lnM_max_tb, const_struct->lnM_min, const_struct->lnM_max_tb,
@@ -232,6 +237,7 @@ int set_prop_rng(gsl_rng *rng, int from_catalog, double *interp, float * input, 
     //find log(property/variance) / mean
     double prop1 = gsl_ran_ugaussian(rng);
     double prop2 = gsl_ran_ugaussian(rng);
+    double prop3 = gsl_ran_ugaussian(rng);
 
     //Correlate properties by interpolating between the sampled and descendant gaussians
     //THIS ASSUMES THAT THE SELF-CORRELATION IS IN THE LOG PROPRETY, NOT THE PROPERTY ITSELF
@@ -239,10 +245,12 @@ int set_prop_rng(gsl_rng *rng, int from_catalog, double *interp, float * input, 
     if(from_catalog){
         prop1 = (1-interp[0])*prop1 + interp[0]*input[0];
         prop2 = (1-interp[1])*prop1 + interp[1]*input[1];
+        prop3 = (1-interp[2])*prop1 + interp[2]*input[2];
     }
 
     output[0] = prop1;
     output[1] = prop2;
+    output[2] = prop3;
 
     return;
 }
@@ -263,9 +271,9 @@ int add_properties_cat(struct UserParams *user_params, struct CosmoParams *cosmo
 
     //loop through the halos and assign properties
     int i;
-    float buf[2];
+    float buf[3];
     //dummy
-    float inbuf[2];
+    float inbuf[3];
 #pragma omp parallel for private(buf)
     for(i=0;i<nhalos;i++){
         // LOG_ULTRA_DEBUG("halo %d hm %.2e crd %d %d %d",i,halos->halo_masses[i],halos->halo_coords[3*i+0],halos->halo_coords[3*i+1],halos->halo_coords[3*i+2]);
@@ -273,6 +281,7 @@ int add_properties_cat(struct UserParams *user_params, struct CosmoParams *cosmo
         // LOG_ULTRA_DEBUG("stars %.2e sfr %.2e",buf[0],buf[1]);
         halos->star_rng[i] = buf[0];
         halos->sfr_rng[i] = buf[1];
+        halos->xray_rng[i] = buf[2];
     }
 
     free_rng_threads(rng_stoc);
@@ -695,7 +704,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field, flo
 
         int nh_buf;
         double delta;
-        float prop_buf[2], prop_dummy[2];
+        float prop_buf[3], prop_dummy[3];
         int crd_hi[3];
 
         double mass_defc;
@@ -767,6 +776,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field, flo
 
                         halofield_out->star_rng[istart + count] = prop_buf[0];
                         halofield_out->sfr_rng[istart + count] = prop_buf[1];
+                        halofield_out->xray_rng[istart + count] = prop_buf[2];
                         count++;
 
                         M_tot_cell += hm_buf[i];
@@ -796,6 +806,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field, flo
         memmove(&halofield_out->halo_masses[count_total],&halofield_out->halo_masses[istart_threads[i]],sizeof(float)*nhalo_threads[i]);
         memmove(&halofield_out->star_rng[count_total],&halofield_out->star_rng[istart_threads[i]],sizeof(float)*nhalo_threads[i]);
         memmove(&halofield_out->sfr_rng[count_total],&halofield_out->sfr_rng[istart_threads[i]],sizeof(float)*nhalo_threads[i]);
+        memmove(&halofield_out->xray_rng[count_total],&halofield_out->xray_rng[istart_threads[i]],sizeof(float)*nhalo_threads[i]);
         memmove(&halofield_out->halo_coords[3*count_total],&halofield_out->halo_coords[3*istart_threads[i]],sizeof(int)*3*nhalo_threads[i]);
         LOG_SUPER_DEBUG("Moved array (start,count) (%llu, %llu) to position %llu",istart_threads[i],nhalo_threads[i],count_total);
         count_total += nhalo_threads[i];
@@ -807,6 +818,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field, flo
     memset(&halofield_out->halo_coords[3*count_total],0,3*(arraysize_total-count_total)*sizeof(int));
     memset(&halofield_out->star_rng[count_total],0,(arraysize_total-count_total)*sizeof(float));
     memset(&halofield_out->sfr_rng[count_total],0,(arraysize_total-count_total)*sizeof(float));
+    memset(&halofield_out->xray_rng[count_total],0,(arraysize_total-count_total)*sizeof(float));
     LOG_SUPER_DEBUG("Set %llu elements beyond %llu to zero",arraysize_total-count_total,count_total);
     return 0;
 }
@@ -842,7 +854,7 @@ int sample_halo_progenitors(gsl_rng ** rng_arr, double z_in, double z_out, struc
     LOG_DEBUG("z = %f, Mmin = %e, d = %.3e",z_out,Mmin,delta);
     LOG_DEBUG("Total Array Size %llu, array size per thread %llu (~%.3e GB total)",arraysize_total,arraysize_local,6.*arraysize_total*sizeof(int)/1e9);
 
-    double corr_arr[2] = {hs_constants->corr_star,hs_constants->corr_sfr};
+    double corr_arr[3] = {hs_constants->corr_star,hs_constants->corr_sfr,hs_constants->corr_xray};
 
 #pragma omp parallel num_threads(user_params_stoc->N_THREADS)
     {
@@ -850,8 +862,8 @@ int sample_halo_progenitors(gsl_rng ** rng_arr, double z_in, double z_out, struc
         int n_prog;
         double M_prog;
 
-        float propbuf_in[2];
-        float propbuf_out[2];
+        float propbuf_in[3];
+        float propbuf_out[3];
 
         int threadnum = omp_get_thread_num();
         double M2;
@@ -880,6 +892,7 @@ int sample_halo_progenitors(gsl_rng ** rng_arr, double z_in, double z_out, struc
 
             propbuf_in[0] = halofield_in->star_rng[ii];
             propbuf_in[1] = halofield_in->sfr_rng[ii];
+            propbuf_in[2] = halofield_in->xray_rng[ii];
 
             //place progenitors in local list
             M_prog = 0;
@@ -904,6 +917,7 @@ int sample_halo_progenitors(gsl_rng ** rng_arr, double z_in, double z_out, struc
 
                 halofield_out->star_rng[istart + count] = propbuf_out[0];
                 halofield_out->sfr_rng[istart + count] = propbuf_out[1];
+                halofield_out->xray_rng[istart + count] = propbuf_out[2];
                 count++;
 
                 if(ii==0){

--- a/src/py21cmfast/src/Stochasticity.c
+++ b/src/py21cmfast/src/Stochasticity.c
@@ -687,6 +687,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field, flo
     double total_volume_excluded=0.;
     double total_volume_dexm=0.;
     double vol_conversion = pow((double)user_params_stoc->HII_DIM / (double)user_params_stoc->DIM,3);
+    double cell_volume = VOLUME / pow((double)user_params_stoc->HII_DIM,3);
 
 #pragma omp parallel num_threads(user_params_stoc->N_THREADS)
     {
@@ -724,7 +725,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field, flo
             halofield_out->halo_coords[1 + 3*(istart+count)] = halofield_large->halo_coords[1 + 3*halo_idx];
             halofield_out->halo_coords[2 + 3*(istart+count)] = halofield_large->halo_coords[2 + 3*halo_idx];
 
-            total_volume_dexm += halofield_large->halo_masses[halo_idx] / (RHOcrit * cosmo_params_stoc->OMm) * vol_conversion;
+            total_volume_dexm += halofield_large->halo_masses[halo_idx] / (RHOcrit * cosmo_params_stoc->OMm) / cell_volume;
             count++;
         }
 
@@ -992,8 +993,8 @@ int stochastic_halofield(struct UserParams *user_params, struct CosmoParams *cos
 
     if(halos->n_halos > 3){
         LOG_DEBUG("First few Masses:  %11.3e %11.3e %11.3e",halos->halo_masses[0],halos->halo_masses[1],halos->halo_masses[2]);
-        LOG_DEBUG("First few Stellar: %11.3e %11.3e %11.3e",halos->star_rng[0],halos->star_rng[1],halos->star_rng[2]);
-        LOG_DEBUG("First few SFR:     %11.3e %11.3e %11.3e",halos->sfr_rng[0],halos->sfr_rng[1],halos->sfr_rng[2]);
+        LOG_DEBUG("First few Stellar RNG: %11.3e %11.3e %11.3e",halos->star_rng[0],halos->star_rng[1],halos->star_rng[2]);
+        LOG_DEBUG("First few SFR RNG:     %11.3e %11.3e %11.3e",halos->sfr_rng[0],halos->sfr_rng[1],halos->sfr_rng[2]);
     }
 
     if(user_params_stoc->USE_INTERPOLATION_TABLES){

--- a/src/py21cmfast/src/UsefulFunctions.c
+++ b/src/py21cmfast/src/UsefulFunctions.c
@@ -716,7 +716,7 @@ float ComputeTau(struct UserParams *user_params, struct CosmoParams *cosmo_param
     return tau;
 }
 
-
+//TODO: THESE NEED UPDATING
 void writeUserParams(struct UserParams *p){
     LOG_INFO("UserParams: [HII_DIM=%d, DIM=%d, BOX_LEN=%f, NON_CUBIC_FACTOR=%f, HMF=%d, POWER_SPECTRUM=%d, USE_RELATIVE_VELOCITIES=%d, N_THREADS=%d, PERTURB_ON_HIGH_RES=%d, NO_RNG=%d, USE_FFTW_WISDOM=%d, USE_INTERPOLATION_TABLES=%d]",
              p->HII_DIM, p->DIM, p->BOX_LEN, p->NON_CUBIC_FACTOR, p->HMF, p->POWER_SPECTRUM, p->USE_RELATIVE_VELOCITIES, p->N_THREADS, p->PERTURB_ON_HIGH_RES, p->NO_RNG, p->USE_FFTW_WISDOM, p->USE_INTERPOLATION_TABLES);
@@ -733,7 +733,7 @@ void writeAstroParams(struct FlagOptions *fo, struct AstroParams *p){
         LOG_INFO("AstroParams: [HII_EFF_FACTOR=%f, ALPHA_STAR=%f, ALPHA_STAR_MINI=%f, F_ESC10=%f (F_ESC7_MINI=%f), ALPHA_ESC=%f, M_TURN=%f, R_BUBBLE_MAX=%f, L_X=%e (L_X_MINI=%e), NU_X_THRESH=%f, X_RAY_SPEC_INDEX=%f, F_STAR10=%f (F_STAR7_MINI=%f), t_STAR=%f, N_RSD_STEPS=%f, SIGMA_STAR=%f, SIGMA_SFR %f CORR_STAR %f CORR_SFR %f]",
              p->HII_EFF_FACTOR, p->ALPHA_STAR, p->ALPHA_STAR_MINI, p->F_ESC10,p->F_ESC7_MINI, p->ALPHA_ESC, p->M_TURN,
              p->R_BUBBLE_MAX, p->L_X, p->L_X_MINI, p->NU_X_THRESH, p->X_RAY_SPEC_INDEX, p->F_STAR10, p->F_STAR7_MINI, p->t_STAR, p->N_RSD_STEPS,
-             p->SIGMA_STAR, p->SIGMA_SFR, p->CORR_STAR, p->CORR_SFR);
+             p->SIGMA_STAR, p->SIGMA_SFR_LIM, p->CORR_STAR, p->CORR_SFR);
     }
     else {
         LOG_INFO("AstroParams: [HII_EFF_FACTOR=%f, ION_Tvir_MIN=%f, X_RAY_Tvir_MIN=%f, R_BUBBLE_MAX=%f, L_X=%e, NU_X_THRESH=%f, X_RAY_SPEC_INDEX=%f, F_STAR10=%f, t_STAR=%f, N_RSD_STEPS=%f]",

--- a/src/py21cmfast/src/UsefulFunctions.c
+++ b/src/py21cmfast/src/UsefulFunctions.c
@@ -716,35 +716,76 @@ float ComputeTau(struct UserParams *user_params, struct CosmoParams *cosmo_param
     return tau;
 }
 
-//TODO: THESE NEED UPDATING
 void writeUserParams(struct UserParams *p){
-    LOG_INFO("UserParams: [HII_DIM=%d, DIM=%d, BOX_LEN=%f, NON_CUBIC_FACTOR=%f, HMF=%d, POWER_SPECTRUM=%d, USE_RELATIVE_VELOCITIES=%d, N_THREADS=%d, PERTURB_ON_HIGH_RES=%d, NO_RNG=%d, USE_FFTW_WISDOM=%d, USE_INTERPOLATION_TABLES=%d]",
-             p->HII_DIM, p->DIM, p->BOX_LEN, p->NON_CUBIC_FACTOR, p->HMF, p->POWER_SPECTRUM, p->USE_RELATIVE_VELOCITIES, p->N_THREADS, p->PERTURB_ON_HIGH_RES, p->NO_RNG, p->USE_FFTW_WISDOM, p->USE_INTERPOLATION_TABLES);
+    LOG_INFO("\n        UserParams:\n"
+                "       HII_DIM=%4d, DIM=%4d, BOX_LEN=%8.3f, NON_CUBIC_FACTOR=%8.3f,\n"
+                "       HMF=%2d, POWER_SPECTRUM=%2d, USE_RELATIVE_VELOCITIES=%1d, N_THREADS=%2d,\n"
+                "       PERTURB_ON_HIGH_RES=%1d, NO_RNG=%1d, USE_FFTW_WISDOM=%1d, USE_INTERPOLATION_TABLES=%1d,\n"
+                "       INTEGRATION_METHOD_ATOMIC=%2d, INTEGRATION_METHOD_MINI=%2d, USE_2LPT=%1d, MINIMIZE_MEMORY=%1d,\n"
+                "       KEEP_3D_VELOCITIES=%1d, SAMPLER_MIN_MASS=%10.3e, SAMPLER_BUFFER_FACTOR=%8.3f, MAXHALO_FACTOR=%8.3f,\n"
+                "       N_COND_INTERP=%4d, N_PROB_INTERP=%4d, MIN_LOGPROB=%8.3f, SAMPLE_METHOD=%2d, AVG_BELOW_SAMPLER=%1d,\n"
+                "       HALOMASS_CORRECTION=%8.3f",
+             p->HII_DIM, p->DIM, p->BOX_LEN, p->NON_CUBIC_FACTOR, p->HMF, p->POWER_SPECTRUM, p->USE_RELATIVE_VELOCITIES,
+             p->N_THREADS, p->PERTURB_ON_HIGH_RES, p->NO_RNG, p->USE_FFTW_WISDOM, p->USE_INTERPOLATION_TABLES,
+             p->INTEGRATION_METHOD_ATOMIC,p->INTEGRATION_METHOD_MINI,p->USE_2LPT,p->MINIMIZE_MEMORY,p->KEEP_3D_VELOCITIES,
+             p->SAMPLER_MIN_MASS,p->SAMPLER_BUFFER_FACTOR,p->MAXHALO_FACTOR,p->N_COND_INTERP,p->N_PROB_INTERP,p->MIN_LOGPROB,
+             p->SAMPLE_METHOD,p->AVG_BELOW_SAMPLER,p->HALOMASS_CORRECTION);
 }
 
 void writeCosmoParams(struct CosmoParams *p){
-    LOG_INFO("CosmoParams: [SIGMA_8=%f, hlittle=%f, OMm=%f, OMl=%f, OMb=%f, POWER_INDEX=%f]",
+    LOG_INFO("\n        CosmoParams:\n"
+            "       SIGMA_8=%8.3f, hlittle=%8.3f, OMm=%8.3f, OMl=%8.3f, OMb=%8.3f, POWER_INDEX=%8.3f",
              p->SIGMA_8, p->hlittle, p->OMm, p->OMl, p->OMb, p->POWER_INDEX);
 }
 
 void writeAstroParams(struct FlagOptions *fo, struct AstroParams *p){
-
     if(fo->USE_MASS_DEPENDENT_ZETA) {
-        LOG_INFO("AstroParams: [HII_EFF_FACTOR=%f, ALPHA_STAR=%f, ALPHA_STAR_MINI=%f, F_ESC10=%f (F_ESC7_MINI=%f), ALPHA_ESC=%f, M_TURN=%f, R_BUBBLE_MAX=%f, L_X=%e (L_X_MINI=%e), NU_X_THRESH=%f, X_RAY_SPEC_INDEX=%f, F_STAR10=%f (F_STAR7_MINI=%f), t_STAR=%f, N_RSD_STEPS=%f, SIGMA_STAR=%f, SIGMA_SFR %f CORR_STAR %f CORR_SFR %f]",
-             p->HII_EFF_FACTOR, p->ALPHA_STAR, p->ALPHA_STAR_MINI, p->F_ESC10,p->F_ESC7_MINI, p->ALPHA_ESC, p->M_TURN,
-             p->R_BUBBLE_MAX, p->L_X, p->L_X_MINI, p->NU_X_THRESH, p->X_RAY_SPEC_INDEX, p->F_STAR10, p->F_STAR7_MINI, p->t_STAR, p->N_RSD_STEPS,
-             p->SIGMA_STAR, p->SIGMA_SFR_LIM, p->CORR_STAR, p->CORR_SFR);
+        LOG_INFO("\n        AstroParams:\n"
+        "       M_TURN=%10.3e, R_BUBBLE_MAX=%8.3f, N_RSD_STEPS=%5d\n"
+        "       F_STAR10=%8.3f, ALPHA_STAR=%8.3f, F_ESC10=%8.3f, ALPHA_ESC=%8.3f,\n"
+        "       t_STAR=%8.3f, L_X=%10.3e, NU_X_THRESH=%8.3f, X_RAY_SPEC_INDEX=%8.3f,\n"
+        "       UPPER_STELLAR_TURNOVER_MASS=%10.3e, UPPER_STELLAR_TURNOVER_INDEX=%8.3e",
+             p->M_TURN, p->R_BUBBLE_MAX, p->N_RSD_STEPS, p->F_STAR10, p->ALPHA_STAR, p->F_ESC10,
+             p->ALPHA_ESC, p->t_STAR, p->L_X, p->NU_X_THRESH, p->X_RAY_SPEC_INDEX,
+             p->UPPER_STELLAR_TURNOVER_MASS,p->UPPER_STELLAR_TURNOVER_INDEX);
+        if(fo->USE_HALO_FIELD){
+            LOG_INFO("\n        HaloField AstroParams:\n"
+            "      SIGMA_STAR=%8.3f, CORR_STAR=%8.3f, \n"
+            "       SIGMA_SFR_LIM=%8.3f (SIGMA_SFR_INDEX=%8.3f), CORR_SFR=%8.3f\n"
+            "       SIGMA_LX=%8.3f, CORR_LX=%8.3f",
+            p->SIGMA_STAR, p->CORR_STAR, p->SIGMA_SFR_LIM, p->SIGMA_SFR_INDEX, p->CORR_SFR,
+            p->SIGMA_LX, p->CORR_LX);
+        }
+        if(fo->USE_MINI_HALOS){
+            LOG_INFO("\n        MiniHalo AstroParams:\n"
+            "       ALPHA_STAR_MINI=%8.3f, F_ESC7_MINI=%8.3f, L_X_MINI=%10.3e, F_STAR7_MINI=%8.3f,\n"
+            "       F_H2_SHIELD=%8.3f, A_LW=%8.3f, BETA_LW=%8.3f, A_VCB=%8.3f, BETA_VCB=%8.3f",
+                p->ALPHA_STAR_MINI,p->F_ESC7_MINI, p->L_X_MINI, p->F_STAR7_MINI,
+                p->F_H2_SHIELD, p->A_LW, p->BETA_LW, p->A_VCB, p->BETA_VCB);
+
+        }
     }
     else {
-        LOG_INFO("AstroParams: [HII_EFF_FACTOR=%f, ION_Tvir_MIN=%f, X_RAY_Tvir_MIN=%f, R_BUBBLE_MAX=%f, L_X=%e, NU_X_THRESH=%f, X_RAY_SPEC_INDEX=%f, F_STAR10=%f, t_STAR=%f, N_RSD_STEPS=%f]",
+        LOG_INFO("\n        AstroParams:\n"
+        "       HII_EFF_FACTOR=%10.3e, ION_Tvir_MIN=%10.3e, X_RAY_Tvir_MIN=%10.3e,\n"
+        "       R_BUBBLE_MAX=%8.3f, L_X=%10.3e, NU_X_THRESH=%8.3f, X_RAY_SPEC_INDEX=%8.3f,\n"
+        "       F_STAR10=%8.3f, t_STAR=%8.3f, N_RSD_STEPS=%5d]",
              p->HII_EFF_FACTOR, p->ION_Tvir_MIN, p->X_RAY_Tvir_MIN,
              p->R_BUBBLE_MAX, p->L_X, p->NU_X_THRESH, p->X_RAY_SPEC_INDEX, p->F_STAR10, p->t_STAR, p->N_RSD_STEPS);
     }
 }
 
 void writeFlagOptions(struct FlagOptions *p){
-    LOG_INFO("FlagOptions: [USE_HALO_FIELD=%d, USE_MINI_HALOS=%d, USE_MASS_DEPENDENT_ZETA=%d, SUBCELL_RSD=%d, INHOMO_RECO=%d, USE_TS_FLUCT=%d, M_MIN_in_Mass=%d, PHOTON_CONS=%d, HALO_STOCHASTICITY=%d, FIXED_HALO_GRIDS=%d, USE_EXP_FILTER=%d]",
-           p->USE_HALO_FIELD, p->USE_MINI_HALOS, p->USE_MASS_DEPENDENT_ZETA, p->SUBCELL_RSD, p->INHOMO_RECO, p->USE_TS_FLUCT, p->M_MIN_in_Mass, p->PHOTON_CONS_TYPE, p->HALO_STOCHASTICITY, p->FIXED_HALO_GRIDS, p->USE_EXP_FILTER);
+    LOG_INFO("\n        FlagOptions:\n"
+            "       USE_HALO_FIELD=%1d, USE_MINI_HALOS=%1d, USE_MASS_DEPENDENT_ZETA=%1d, SUBCELL_RSD=%1d,\n"
+            "       INHOMO_RECO=%1d, USE_TS_FLUCT=%1d, M_MIN_in_Mass=%1d, PHOTON_CONS=%1d,\n"
+            "       HALO_STOCHASTICITY=%1d, FIXED_HALO_GRIDS=%1d, USE_EXP_FILTER=%1d\n"
+            "       USE_CMB_HEATING=%1d, USE_LYA_HEATING=%1d, APPLY_RSDS=%1d, FIX_VCB_AVG=%1d\n"
+            "       CELL_RECOMB=%1d, PHOTON_CONS_TYPE=%2d, USE_UPPER_STELLAR_TURNOVER=%1d",
+           p->USE_HALO_FIELD, p->USE_MINI_HALOS, p->USE_MASS_DEPENDENT_ZETA, p->SUBCELL_RSD,
+           p->INHOMO_RECO, p->USE_TS_FLUCT, p->M_MIN_in_Mass, p->PHOTON_CONS_TYPE, p->HALO_STOCHASTICITY,
+           p->FIXED_HALO_GRIDS, p->USE_EXP_FILTER,p->USE_CMB_HEATING,p->USE_LYA_HEATING,p->APPLY_RSDS,
+           p->FIX_VCB_AVG,p->CELL_RECOMB,p->PHOTON_CONS_TYPE,p->USE_UPPER_STELLAR_TURNOVER);
 }
 
 

--- a/src/py21cmfast/src/interp_tables.c
+++ b/src/py21cmfast/src/interp_tables.c
@@ -712,11 +712,22 @@ void initialise_J_split_table(int Nbin, double umin, double umax, double gamma1)
 }
 
 void free_dNdM_tables(){
-    int i;
     free_RGTable2D(&Nhalo_inv_table);
     free_RGTable1D(&Nhalo_table);
     free_RGTable1D(&Mcoll_table);
     free_RGTable1D(&J_split_table);
+}
+
+void free_conditional_tables(){
+    free_RGTable1D_f(&fcoll_conditional_table);
+    free_RGTable1D_f(&dfcoll_conditional_table);
+    free_RGTable1D_f(&SFRD_conditional_table);
+    free_RGTable2D_f(&SFRD_conditional_table_MINI);
+    free_RGTable1D_f(&Nion_conditional_table1D);
+    free_RGTable2D_f(&Nion_conditional_table2D);
+    free_RGTable2D_f(&Nion_conditional_table_MINI);
+    free_RGTable2D_f(&Nion_conditional_table_prev);
+    free_RGTable2D_f(&Nion_conditional_table_MINI_prev);
 }
 
 //JD: moving the interp table evaluations here since some of them are needed in nu_tau_one

--- a/src/py21cmfast/src/interp_tables.c
+++ b/src/py21cmfast/src/interp_tables.c
@@ -760,6 +760,12 @@ double EvaluateNionTs(double redshift, double Mlim_Fstar, double Mlim_Fesc){
 
 double EvaluateNionTs_MINI(double redshift, double log10_Mturn_LW_ave, double Mlim_Fstar_MINI, double Mlim_Fesc_MINI){
     if(user_params_it->USE_INTERPOLATION_TABLES){
+        // LOG_SUPER_DEBUG("z %.3f l10M %.3e result %.3e",redshift,log10_Mturn_LW_ave,EvaluateRGTable2D(redshift,log10_Mturn_LW_ave,&Nion_z_table_MINI));
+        // LOG_SUPER_DEBUG("Table N (%d,%d) min (%.2e %.2e) width (%.2e %.2e) max (%.2e %.2e)",Nion_z_table.nx_bin,Nion_z_table.ny_bin,
+        //                 Nion_z_table.x_min,Nion_z_table.y_min,
+        //                 Nion_z_table.x_width,Nion_z_table.y_width,
+        //                 Nion_z_table.x_min + (Nion_z_table.nx_bin-1)*Nion_z_table.x_width,
+        //                 Nion_z_table.y_min + (Nion_z_table.ny_bin-1)*Nion_z_table.y_width);
         return EvaluateRGTable2D(redshift,log10_Mturn_LW_ave,&Nion_z_table_MINI);
     }
 

--- a/src/py21cmfast/src/photoncons.c
+++ b/src/py21cmfast/src/photoncons.c
@@ -169,8 +169,8 @@ int InitialisePhotonCons(struct UserParams *user_params, struct CosmoParams *cos
                   }
                 }
 
-                Nion0 = ION_EFF_FACTOR*FgtrM_General(z0,M_MIN_z0);
-                Nion1 = ION_EFF_FACTOR*FgtrM_General(z1,M_MIN_z1);
+                Nion0 = ION_EFF_FACTOR*Fcoll_General(z0,log(M_MIN_z0),lnMmax);
+                Nion1 = ION_EFF_FACTOR*Fcoll_General(z1,log(M_MIN_z1),lnMmax);
                 freeSigmaMInterpTable();
             }
 

--- a/src/py21cmfast/src/ps.c
+++ b/src/py21cmfast/src/ps.c
@@ -138,7 +138,7 @@ double FgtrM_wsigma(double z, double sig);
 double FgtrM_st(double z, double M);
 double FgtrM_Watson(double growthf, double M);
 double FgtrM_Watson_z(double z, double growthf, double M);
-double FgtrM_General(double z, double M);
+double Fcoll_General(double z, double lnM_min, double lnM_max);
 
 float erfcc(float x);
 double splined_erfc(double x);
@@ -1188,7 +1188,7 @@ double IntegratedNdM_QAG(double lnM_lo, double lnM_hi, struct parameters_gsl_MF_
     double result, error, lower_limit, upper_limit;
     gsl_function F;
     // double rel_tol = FRACT_FLOAT_ERR*128; //<- relative tolerance
-    double rel_tol = 1e-4; //<- relative tolerance
+    double rel_tol = 1e-3; //<- relative tolerance
     int w_size = 1000;
     gsl_integration_workspace * w
     = gsl_integration_workspace_alloc (w_size);
@@ -1481,18 +1481,16 @@ double FgtrM_wsigma(double z, double sig){
     return splined_erfc(del / (sqrt(2)*sig));
 }
 
-double FgtrM_General(double z, double M){
+double Fcoll_General(double z, double lnM_min, double lnM_max){
     double lower_limit, upper_limit, growthf;
 
     growthf = dicke(z);
-    lower_limit = log(M);
-    upper_limit = log(fmax(global_params.M_MAX_INTEGRAL, M*100));
     struct parameters_gsl_MF_integrals integral_params = {
                 .redshift = z,
                 .growthf = growthf,
                 .HMF = user_params_ps->HMF,
     };
-    return IntegratedNdM(lower_limit, upper_limit, integral_params, 2, 0) / (cosmo_params_ps->OMm*RHOcrit);
+    return IntegratedNdM(lnM_min, lnM_max, integral_params, 2, 0) / (cosmo_params_ps->OMm*RHOcrit);
 }
 
 double Nion_General(double z, double lnM_Min, double lnM_Max, double MassTurnover, double Alpha_star, double Alpha_esc, double Fstar10,

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -1796,7 +1796,7 @@ def xray_source(
 
             hbox_interp, idx_desc, interp_param = interp_haloboxes(
                 hboxes[::-1],
-                ["halo_sfr", "halo_sfr_mini", "log10_Mcrit_LW_ave"],
+                ["halo_sfr", "halo_xray", "halo_sfr_mini", "log10_Mcrit_LW_ave"],
                 z_halos[::-1],
                 zpp_avg[i],
             )
@@ -1804,6 +1804,8 @@ def xray_source(
             # if we have no halos we ignore the whole shell
             if np.all(hbox_interp.halo_sfr + hbox_interp.halo_sfr_mini == 0):
                 box.filtered_sfr[i, ...] = 0
+                box.filtered_sfr_mini[i, ...] = 0
+                box.filtered_xray[i, ...] = 0
                 logger.debug(f"ignoring Radius {i} due to no stars")
                 continue
 
@@ -2914,7 +2916,12 @@ def run_coeval(
             if hb is not None:
                 try:
                     hb.prepare(
-                        keep=["halo_sfr", "halo_sfr_mini", "log10_Mcrit_LW_ave"],
+                        keep=[
+                            "halo_sfr",
+                            "halo_sfr_mini",
+                            "halo_xray",
+                            "log10_Mcrit_LW_ave",
+                        ],
                         force=always_purge,
                     )
                 except OSError:

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -336,11 +336,14 @@ def _setup_inputs(
     # This turns params into a dict with all the input parameters in it.
     params = dict(zip(pkeys + list(input_params.keys()), list(p) + params[4:]))
 
+    # Sort the params back into input order and ignore params not in input_params.
+    params = dict(zip(keys, [params[k] for k in keys]))
+
     # Perform validation between different sets of inputs.
     validate_all_inputs(**{k: v for k, v in params.items() if k != "random_seed"})
 
-    # Sort the params back into input order.
-    params = [params[k] for k in keys]
+    # return as list of values
+    params = list(params.values())
 
     out = params
     if redshift != -1:

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -3554,7 +3554,7 @@ def run_lightcone(
                         )
 
             perturb_files.append((z, os.path.join(direc, pf2.filename)))
-            if flag_options.USE_HALO_FIELD:
+            if flag_options.USE_HALO_FIELD and not flag_options.FIXED_HALO_GRIDS:
                 hbox_files.append((z, os.path.join(direc, hbox2.filename)))
                 pth_files.append((z, os.path.join(direc, ph.filename)))
             if flag_options.USE_TS_FLUCT:

--- a/src/py21cmfast/wrapper.py
+++ b/src/py21cmfast/wrapper.py
@@ -1799,7 +1799,7 @@ def xray_source(
 
             hbox_interp, idx_desc, interp_param = interp_haloboxes(
                 hboxes[::-1],
-                ["halo_sfr", "halo_xray", "halo_sfr_mini", "log10_Mcrit_LW_ave"],
+                ["halo_sfr", "halo_xray", "halo_sfr_mini", "log10_Mcrit_MCG_ave"],
                 z_halos[::-1],
                 zpp_avg[i],
             )
@@ -2923,7 +2923,7 @@ def run_coeval(
                             "halo_sfr",
                             "halo_sfr_mini",
                             "halo_xray",
-                            "log10_Mcrit_LW_ave",
+                            "log10_Mcrit_MCG_ave",
                         ],
                         force=always_purge,
                     )
@@ -3609,7 +3609,12 @@ def run_lightcone(
             if hbox is not None:
                 try:
                     hbox.prepare(
-                        keep=["halo_sfr", "halo_sfr_mini", "log10_Mcrit_LW_ave"],
+                        keep=[
+                            "halo_sfr",
+                            "halo_sfr_mini",
+                            "halo_xray",
+                            "log10_Mcrit_MCG_ave",
+                        ],
                         force=always_purge,
                     )
                 except OSError:


### PR DESCRIPTION
Currently WIP PR for adding the xray luminosity scatter, I am currently testing the outputs to make sure we get what we expect.

#### Changes:
- Added another RNG field to `HaloField` and `PerturbHaloField` for the scatter in xray luminosity
- Added another field to the `HaloBox` and `XraySourceBox` to represent the xrays
- Added scaling relations for Metallicity, xray luminosity and mass-dependent SFR scatter to `HaloBox.c`
- Replaced the SFR field with the xray field in `SpinTemperature.c` for the xray calculations (lyman alpha / lyman werner still uses SFR)
- Refactored `HaloBox.c` to be more easily extendable and readable