### PR TITLE
Fixing bugs in HaloBox.c

### DIFF
--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -1130,7 +1130,7 @@ class AstroParams(StructWithDefaults):
             "UPPER_STELLAR_TURNOVER_MASS",
         ]:
             return 10**val  # log10 to linear conversion
-        if key in ["SIMGA_STAR" "SIGMA_SFR_LIM" "SIGMA_LX"]:
+        if key in ["SIGMA_STAR", "SIGMA_SFR_LIM", "SIGMA_LX"]:
             return 2.3025851 * val  # dex to base e conversion
         else:
             return val

--- a/src/py21cmfast/src/hmf.c
+++ b/src/py21cmfast/src/hmf.c
@@ -61,6 +61,12 @@ double get_delta_crit(int HMF, double sigma, double growthf){
     return Deltac;
 }
 
+//Mo & White 1996 fit
+double euler_to_lagrangian_delta(double delta){
+    double dp1 = delta + 1;
+    return -1.35*pow(dp1,-2./3.) + 0.78785*pow(dp1,-0.58661) - 1.12431*pow(dp1,-0.5) + 1.68647;
+}
+
 /*
 Unconditional Mass function from Delos 2023 (https://arxiv.org/pdf/2311.17986.pdf)
 Matches well with N-bodies (M200), has a corresponding Conditional Mass Function (below) and

--- a/src/py21cmfast/src/hmf.h
+++ b/src/py21cmfast/src/hmf.h
@@ -65,5 +65,6 @@ double atomic_cooling_threshold(float z);
 double minimum_source_mass(double redshift, bool xray, AstroParams *astro_params, FlagOptions *flag_options);
 double sheth_delc_dexm(double del, double sig);
 float Mass_limit_bisection(float Mmin, float Mmax, float PL, float FRAC);
+double euler_to_lagrangian_delta(double delta);
 
 #endif

--- a/src/py21cmfast/src/interp_tables.c
+++ b/src/py21cmfast/src/interp_tables.c
@@ -483,8 +483,8 @@ void initialise_dNdM_tables(double xmin, double xmax, double ymin, double ymax, 
     int nx;
     double lnM_cond=0.;
     double sigma_cond=0.;
-    LOG_DEBUG("Initialising dNdM Tables from [%.2e,%.2e] (Intg. Limits %.2e %.2e)",xmin,xmax,ymin,ymax);
-    LOG_DEBUG("D_out %.2e P %.2e from_cat %d",growth_out,param,from_catalog);
+    LOG_SUPER_DEBUG("Initialising dNdM Tables from [%.2e,%.2e] (Intg. Limits %.2e %.2e)",xmin,xmax,ymin,ymax);
+    LOG_SUPER_DEBUG("D_out %.2e P %.2e from_cat %d",growth_out,param,from_catalog);
 
     if(!from_catalog){
         lnM_cond = param;


### PR DESCRIPTION
This fixes a few bugs in the lognormal galaxy distributions which erroneously reduced the amount of scatter. I've also added the Mo & White 1996 conversion between Eulerian and Lagrangian density to use with the below-resolution halos and fixed grids. I find this produces better results near delta=-1 and delta=delta_crit.