### PR TITLE
Reading compatibility

### DIFF
--- a/src/py21cmfast/cache_tools.py
+++ b/src/py21cmfast/cache_tools.py
@@ -82,9 +82,11 @@ def readbox(
     cls = getattr(outputs, kind)
 
     if hasattr(cls, "from_file"):
-        inst = cls.from_file(fname, direc=direc, load_data=load_data)
+        inst = cls.from_file(
+            fname, direc=direc, load_data=load_data
+        )  # for OutputStruct
     else:
-        inst = cls.read(fname, direc=direc)
+        inst = cls.read(fname, direc=direc)  # for HighlevelOutputStruct
 
     return inst
 
@@ -236,12 +238,9 @@ def clear_cache(**kwargs):
     kwargs :
         All options passed through to :func:`query_cache`.
     """
-    if "show" not in kwargs:
-        kwargs["show"] = False
-
     direc = kwargs.get("direc", path.expanduser(config["direc"]))
     number = 0
-    for fname, _ in query_cache(**kwargs):
+    for fname in list_datasets(**kwargs):
         if kwargs.get("show", True):
             logger.info(f"Removing {fname}")
         os.remove(path.join(direc, fname))

--- a/src/py21cmfast/inputs.py
+++ b/src/py21cmfast/inputs.py
@@ -335,7 +335,11 @@ class GlobalParams(StructInstanceWrapper):
 
         for k, val in kwargs.items():
             if k.upper() not in this_attr_upper:
-                raise ValueError(f"{k} is not a valid parameter of global_params")
+                warnings.warn(
+                    f"{k} is not a valid parameter of global_params, and will be ignored",
+                    UserWarning,
+                )
+                continue
             key = this_attr_upper[k.upper()]
             prev[key] = getattr(self, key)
             setattr(self, key, val)

--- a/src/py21cmfast/outputs.py
+++ b/src/py21cmfast/outputs.py
@@ -983,6 +983,10 @@ class _HighLevelOutput:
             If fname, is relative, the directory in which to find the file. By default,
             both the current directory and default cache and the  will be searched, in
             that order.
+        safe : bool
+            If safe is true, we throw an error if the parameter structures in the file do not
+            match the structures in the `inputs.py` module. If false, we allow extra and missing
+            items, setting the missing items to the default values and ignoring extra items.
 
         Returns
         -------

--- a/src/py21cmfast/outputs.py
+++ b/src/py21cmfast/outputs.py
@@ -1294,11 +1294,11 @@ class LightCone(_HighLevelOutput):
                 ("astro_params", AstroParams),
             ]:
                 dct = dict(fl[k].attrs)
-                if kls.__defaults__.keys() != dct.keys():
+                if kls._defaults_.keys() != dct.keys():
                     message = (
                         f"There are extra or missing global params in the file to be read.\n"
-                        f"EXTRAS: {[(k,v) for k,v in dct.items() if k not in kls.__defaults__.keys()]}\n"
-                        f"MISSING: {[(k,v) for k,v in kls.__defaults__.items() if k not in dct.keys()]}\n"
+                        f"EXTRAS: {[(k,v) for k,v in dct.items() if k not in kls._defaults_.keys()]}\n"
+                        f"MISSING: {[(k,v) for k,v in kls._defaults_.items() if k not in dct.keys()]}\n"
                     )
                     if safe:
                         raise ValueError(message)
@@ -1313,7 +1313,7 @@ class LightCone(_HighLevelOutput):
             kwargs["current_index"] = fl.attrs.get("current_index", None)
 
         # Get the standard inputs.
-        kw, glbls = _HighLevelOutput._read_inputs(fname)
+        kw, glbls = _HighLevelOutput._read_inputs(fname, safe=safe)
         return {**kw, **kwargs}, glbls
 
     @classmethod

--- a/tests/test_high_level_io.py
+++ b/tests/test_high_level_io.py
@@ -57,11 +57,11 @@ def ang_lightcone(ic, lc):
     )
 
 
-def test_read_bad_file_lc(test_direc, lc_xh):
+def test_read_bad_file_lc(test_direc, lc):
     # create a bad hdf5 file with some good fields,
     #  some bad fields, and some missing fields
     #  in both input parameters and box structures
-    fname = lc_xh.save(direc=test_direc)
+    fname = lc.save(direc=test_direc)
     with h5py.File(fname, "r+") as f:
         # make gluts, these should be ignored on reading
         f["user_params"].attrs["NotARealParameter"] = "fake_param"
@@ -81,18 +81,18 @@ def test_read_bad_file_lc(test_direc, lc_xh):
 
     # check that the fake fields didn't show up in the struct
     assert not hasattr(lc2.user_params, "NotARealParameter")
-    assert not hasattr(lc2.global_params, "NotARealGlobal")
+    assert "NotARealGlobal" not in lc2.global_params.keys()
 
     # check that missing fields are set to default
     assert lc2.user_params.BOX_LEN == UserParams._defaults_["BOX_LEN"]
-    assert lc2.global_params.OPTIMIZE_MIN_MASS == global_params.OPTIMIZE_MIN_MASS
+    assert lc2.global_params["OPTIMIZE_MIN_MASS"] == global_params.OPTIMIZE_MIN_MASS
 
     # check that the fields which are good are read in the struct
-    lc2.user_params.BOX_LEN = lc_xh.user_params.BOX_LEN
-    assert lc2.user_params == lc_xh.user_params
+    lc2.user_params.BOX_LEN = lc.user_params.BOX_LEN
+    assert lc2.user_params == lc.user_params
     for k, v in lc2.global_params.items():
         if k != "OPTIMIZE_MIN_MASS":
-            assert v == lc_xh.global_params[k]
+            assert v == lc.global_params[k]
 
 
 def test_read_bad_file_coev(test_direc, coeval):

--- a/tests/test_high_level_io.py
+++ b/tests/test_high_level_io.py
@@ -88,11 +88,16 @@ def test_read_bad_file_lc(test_direc, lc):
     assert lc2.global_params["OPTIMIZE_MIN_MASS"] == global_params.OPTIMIZE_MIN_MASS
 
     # check that the fields which are good are read in the struct
-    lc2.user_params.BOX_LEN = lc.user_params.BOX_LEN
-    assert lc2.user_params == lc.user_params
-    for k, v in lc2.global_params.items():
-        if k != "OPTIMIZE_MIN_MASS":
-            assert v == lc.global_params[k]
+    assert all(
+        getattr(lc2.user_params, k) == getattr(lc.user_params, k)
+        for k in UserParams._defaults_.keys()
+        if k != "BOX_LEN"
+    )
+    assert all(
+        lc2.global_params[k] == lc.global_params[k]
+        for k in global_params.keys()
+        if k != "OPTIMIZE_MIN_MASS"
+    )
 
 
 def test_read_bad_file_coev(test_direc, coeval):
@@ -125,11 +130,16 @@ def test_read_bad_file_coev(test_direc, coeval):
     assert cv2.global_params["OPTIMIZE_MIN_MASS"] == global_params.OPTIMIZE_MIN_MASS
 
     # check that the fields which are good are read in the struct
-    cv2.user_params.BOX_LEN = coeval.user_params.BOX_LEN
-    assert cv2.user_params == coeval.user_params
-    for k, v in cv2.global_params.items():
-        if k != "OPTIMIZE_MIN_MASS":
-            assert v == coeval.global_params[k]
+    assert all(
+        getattr(cv2.user_params, k) == getattr(coeval.user_params, k)
+        for k in UserParams._defaults_.keys()
+        if k != "BOX_LEN"
+    )
+    assert all(
+        cv2.global_params[k] == coeval.global_params[k]
+        for k in global_params.keys()
+        if k != "OPTIMIZE_MIN_MASS"
+    )
 
 
 def test_lightcone_roundtrip(test_direc, lc):


### PR DESCRIPTION
There is currently a behaviour in `global_params.use()` which, unlike other parameter structures, raises an error when a keyword not in the parameter set is passed. This made it impossible to read in boxes from different versions that had differing parameters. I've made it behave like the other parameter sets now, which simply send out a warning.

However, to keep things safer, I've added a flag to the high-level output reading functions which ensure that all the parameters are there, if the flag is on and the parameters are mismatched it raises an error. if the flag is off it emits a warning detailing which parameters are missing / extra.

Tests have also been written to ensure the desired behaviour.