### PR TITLE
change default behaviour of from_file and read methods

### DIFF
--- a/src/py21cmfast/_utils.py
+++ b/src/py21cmfast/_utils.py
@@ -1135,7 +1135,7 @@ class OutputStruct(StructWrapper, metaclass=ABCMeta):
         self,
         direc: Union[str, Path, None] = None,
         fname: Union[str, Path, None, h5py.File, h5py.Group] = None,
-        keys: Optional[Sequence[str]] = [],
+        keys: Optional[Sequence[str]] = (),
     ):
         """
         Try find and read existing boxes from cache, which match the parameters of this instance.
@@ -1217,7 +1217,7 @@ class OutputStruct(StructWrapper, metaclass=ABCMeta):
         fname,
         direc=None,
         h5_group: Union[str, None] = None,
-        arrays_to_load=[],
+        arrays_to_load=(),
     ):
         """Create an instance from a file on disk.
 

--- a/src/py21cmfast/_utils.py
+++ b/src/py21cmfast/_utils.py
@@ -1135,7 +1135,7 @@ class OutputStruct(StructWrapper, metaclass=ABCMeta):
         self,
         direc: Union[str, Path, None] = None,
         fname: Union[str, Path, None, h5py.File, h5py.Group] = None,
-        keys: Optional[Sequence[str]] = None,
+        keys: Optional[Sequence[str]] = [],
     ):
         """
         Try find and read existing boxes from cache, which match the parameters of this instance.
@@ -1149,7 +1149,8 @@ class OutputStruct(StructWrapper, metaclass=ABCMeta):
             The filename to read. By default, use the filename associated with this
             object. Can be an open h5py File or Group, which will be directly written to.
         keys
-            The names of boxes to read in (can be a subset). By default, read everything.
+            The names of boxes to read in (can be a subset). By default, read nothing.
+            If `None` is explicitly passed, read everything
         """
         if not isinstance(fname, (h5py.File, h5py.Group)):
             pth = self._get_path(direc, fname)
@@ -1157,7 +1158,8 @@ class OutputStruct(StructWrapper, metaclass=ABCMeta):
         else:
             fl = fname
 
-        keys = keys or []
+        if keys is None:
+            keys = self._array_structure
         try:
             try:
                 boxes = fl[self._name]
@@ -1214,9 +1216,8 @@ class OutputStruct(StructWrapper, metaclass=ABCMeta):
         cls,
         fname,
         direc=None,
-        load_data=True,
         h5_group: Union[str, None] = None,
-        arrays_to_load=None,
+        arrays_to_load=[],
     ):
         """Create an instance from a file on disk.
 
@@ -1227,12 +1228,13 @@ class OutputStruct(StructWrapper, metaclass=ABCMeta):
         direc : str, optional
             The directory from which fname is relative to (if it is relative). By
             default, will be the cache directory in config.
-        load_data : bool, optional
-            Whether to read in the data when creating the instance. If False, a bare
-            instance is created with input parameters -- the instance can read data
-            with the :func:`read` method.
         h5_group
             The path to the group within the file in which the object is stored.
+        arrays_to_load : list of str, optional
+            A list of array names to load into memory
+            If the list is empty (default), a bare instance is created with input parameters
+            -- the instance can read data with the :func:`read` method.
+            If `None` is explicitly passed, all arrays are loaded into memory
         """
         direc = path.expanduser(direc or config["direc"])
 
@@ -1244,9 +1246,6 @@ class OutputStruct(StructWrapper, metaclass=ABCMeta):
                 self = cls(**cls._read_inputs(fl[h5_group]))
             else:
                 self = cls(**cls._read_inputs(fl))
-
-        if not load_data:
-            arrays_to_load = []
 
         if h5_group is not None:
             with h5py.File(fname, "r") as fl:


### PR DESCRIPTION
File loading keywords were confusing and the docstrings were incorrect.

I've changed the default reading behaviour to not load any arrays, and the keyword `arrays_to_load` or `keys` for `from_file` or `read` respectively works as follows:

Passing empty array `[]`: load nothing
Passing `None`: load everything
Passing a list of array names: load that subset of arrays

This is _technically_ API breaking so I'm placing this PR in v4-prep