### PR TITLE
small changes for the upcoming database

### DIFF
--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -83,7 +83,7 @@ struct HaloProperties{
 
 void set_hbox_constants(double redshift, AstroParams *astro_params, FlagOptions *flag_options, struct HaloBoxConstants *consts){
     consts->redshift = redshift;
-    
+
     //whether to fix *integrated* (not sampled) galaxy properties to the expected mean
     //Set on for the fixed grid case since we are missing halos above the cell mass
     consts->fix_mean = flag_options->FIXED_HALO_GRIDS;

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -496,7 +496,7 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes,
             if(eulerian)
                 dens = perturbed_field->density[i];
             else
-                dens = ini_boxes->lowres_density[i];
+                dens = ini_boxes->lowres_density[i] * growth_z;
             if(dens > max_density) max_density = dens;
             if(dens < min_density) min_density = dens;
 
@@ -584,7 +584,7 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes,
                 dens_fac = (1.+dens);
             }
             else{
-                dens = ini_boxes->lowres_density[i];
+                dens = ini_boxes->lowres_density[i] * growth_z;
                 dens_fac = 1.;
             }
             l10_mturn_a = mturn_a_grid[i];

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -83,8 +83,9 @@ struct HaloProperties{
 
 void set_hbox_constants(double redshift, AstroParams *astro_params, FlagOptions *flag_options, struct HaloBoxConstants *consts){
     consts->redshift = redshift;
+    
     //whether to fix *integrated* (not sampled) galaxy properties to the expected mean
-    //  constant for now, to be a flag later
+    //Set on for the fixed grid case since we are missing halos above the cell mass
     consts->fix_mean = flag_options->FIXED_HALO_GRIDS;
 
     consts->fstar_10 = astro_params->F_STAR10;

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -85,7 +85,7 @@ void set_hbox_constants(double redshift, AstroParams *astro_params, FlagOptions 
     consts->redshift = redshift;
     //whether to fix *integrated* (not sampled) galaxy properties to the expected mean
     //  constant for now, to be a flag later
-    consts->fix_mean = true;
+    consts->fix_mean = flag_options->FIXED_HALO_GRIDS;
 
     consts->fstar_10 = astro_params->F_STAR10;
     consts->alpha_star = astro_params->ALPHA_STAR;
@@ -445,7 +445,7 @@ void mean_fix_grids(double M_min, double M_max, HaloBox *grids, struct HaloPrope
 //This outputs the UN-NORMALISED grids (before mean-adjustment)
 int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes,
                     PerturbedField *perturbed_field, TsBox *previous_spin_temp, IonizedBox *previous_ionize_box,
-                    struct HaloBoxConstants *consts, HaloBox *grids, struct HaloProperties *averages){
+                    struct HaloBoxConstants *consts, HaloBox *grids, struct HaloProperties *averages, const bool eulerian){
     double M_cell = RHOcrit * cosmo_params_global->OMm * VOLUME / HII_TOT_NUM_PIXELS; //mass in cell of mean dens
     double growth_z = dicke(consts->redshift);
 
@@ -493,8 +493,10 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes,
             reduction(max:max_density,max_log10_mturn_a,max_log10_mturn_m)\
             reduction(+:l10_mlim_m_sum,l10_mlim_a_sum,l10_mlim_r_sum)
         for(i=0;i<HII_TOT_NUM_PIXELS;i++){
-            // dens = perturbed_field->density[i];
-            dens = euler_to_lagrangian_delta(perturbed_field->density[i]);
+            if(eulerian)
+                dens = perturbed_field->density[i];
+            else
+                dens = ini_boxes->lowres_density[i];
             if(dens > max_density) max_density = dens;
             if(dens < min_density) min_density = dens;
 
@@ -573,11 +575,18 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes,
         double mass_intgrl, h_count;
         double intgrl_fesc_weighted, intgrl_stars_only;
         double intgrl_fesc_weighted_mini=0., intgrl_stars_only_mini=0.;
+        double dens_fac;
 
 #pragma omp for reduction(+:hm_sum,sm_sum,sm_sum_mini,sfr_sum,sfr_sum_mini,xray_sum,nion_sum,wsfr_sum)
         for(i=0;i<HII_TOT_NUM_PIXELS;i++){
-            // dens = perturbed_field->density[i];
-            dens = euler_to_lagrangian_delta(perturbed_field->density[i]);
+            if(eulerian){
+                dens = perturbed_field->density[i];
+                dens_fac = (1.+dens);
+            }
+            else{
+                dens = ini_boxes->lowres_density[i];
+                dens_fac = 1.;
+            }
             l10_mturn_a = mturn_a_grid[i];
             l10_mturn_m = mturn_m_grid[i];
 
@@ -594,15 +603,15 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes,
                                                             l10_mturn_a,consts->Mlim_Fstar,consts->Mlim_Fesc,false);
             }
 
-            grids->count[i] = (int)(h_count * M_cell * (1+dens)); //NOTE: truncated
-            grids->halo_mass[i] = mass_intgrl * prefactor_mass * (1+dens);
-            grids->halo_sfr[i] = (intgrl_stars_only*prefactor_sfr) * (1+dens);
-            grids->halo_sfr_mini[i] = intgrl_stars_only_mini*prefactor_sfr_mini * (1+dens);
-            grids->n_ion[i] = (intgrl_fesc_weighted*prefactor_nion + intgrl_fesc_weighted_mini*prefactor_nion_mini) * (1+dens);
-            grids->whalo_sfr[i] = (intgrl_fesc_weighted*prefactor_wsfr + intgrl_fesc_weighted_mini*prefactor_wsfr_mini) * (1+dens);
-            grids->halo_xray[i] = (intgrl_stars_only*prefactor_xray + intgrl_stars_only_mini*prefactor_xray_mini) * (1+dens);
-            grids->halo_stars[i] = intgrl_stars_only*prefactor_stars * (1+dens);
-            grids->halo_stars_mini[i] = intgrl_stars_only_mini*prefactor_stars_mini * (1+dens);
+            grids->count[i] = (int)(h_count * M_cell * dens_fac); //NOTE: truncated
+            grids->halo_mass[i] = mass_intgrl * prefactor_mass * dens_fac;
+            grids->halo_sfr[i] = (intgrl_stars_only*prefactor_sfr) * dens_fac;
+            grids->halo_sfr_mini[i] = intgrl_stars_only_mini*prefactor_sfr_mini * dens_fac;
+            grids->n_ion[i] = (intgrl_fesc_weighted*prefactor_nion + intgrl_fesc_weighted_mini*prefactor_nion_mini) * dens_fac;
+            grids->whalo_sfr[i] = (intgrl_fesc_weighted*prefactor_wsfr + intgrl_fesc_weighted_mini*prefactor_wsfr_mini) * dens_fac;
+            grids->halo_xray[i] = (intgrl_stars_only*prefactor_xray + intgrl_stars_only_mini*prefactor_xray_mini) * dens_fac;
+            grids->halo_stars[i] = intgrl_stars_only*prefactor_stars * dens_fac;
+            grids->halo_stars_mini[i] = intgrl_stars_only_mini*prefactor_stars_mini * dens_fac;
 
             hm_sum += grids->halo_mass[i];
             nion_sum += grids->n_ion[i];
@@ -954,14 +963,14 @@ int ComputeHaloBox(double redshift, UserParams *user_params, CosmoParams *cosmo_
         //Since we need the average turnover masses before we can calculate the global means, we do the CMF integrals first
         //Then we calculate the expected UMF integrals before doing the adjustment
         if(flag_options->FIXED_HALO_GRIDS){
-            set_fixed_grids(M_min, M_max, ini_boxes, perturbed_field, previous_spin_temp, previous_ionize_box, &hbox_consts, grids, &averages_box);
+            set_fixed_grids(M_min, M_max, ini_boxes, perturbed_field, previous_spin_temp, previous_ionize_box, &hbox_consts, grids, &averages_box, true);
         }
         else{
             //set below-resolution properties
             if(user_params->AVG_BELOW_SAMPLER && M_min < user_params->SAMPLER_MIN_MASS){
                 set_fixed_grids(M_min, user_params->SAMPLER_MIN_MASS, ini_boxes,
                                 perturbed_field, previous_spin_temp, previous_ionize_box,
-                                &hbox_consts, grids, &averages_subsampler);
+                                &hbox_consts, grids, &averages_subsampler, false);
                 //This is pretty redundant, but since the fixed grids have density units (X Mpc-3) I have to re-multiply before adding the halos.
                 //      I should instead have a flag to output the summed values in cell. (2*N_pixel > N_halo so generally i don't want to do it in the halo loop)
                 #pragma omp parallel for num_threads(user_params->N_THREADS) private(idx)

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -1220,8 +1220,7 @@ LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll_MINI: %e", box->mean_f
 
                             //TODO: There may be a reason to use unfiltered density for CELL_RECOMB case,
                             // since the "Fcoll" represents photons reaching the central cell rather than
-                            // photons in the entire sphere, but it makes reionisation look stranger so
-                            // more investigation is needed
+                            // photons in the entire sphere (See issue #434)
                             // if(flag_options->CELL_RECOMB)
                             //     curr_dens = perturbed_field->density[HII_R_INDEX(x,y,z)];
                             // else

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -152,12 +152,14 @@ LOG_SUPER_DEBUG("defined parameters");
 
     //Yuxiang's evolving Rmax for MFP in ionised regions
     double exp_mfp;
-    if(flag_options->USE_EXP_FILTER){
-        if (redshift > 6)
-            exp_mfp = 25.483241248322766 / cosmo_params->hlittle;
-        else
-            exp_mfp = 112 / cosmo_params->hlittle * pow( (1.+redshift) / 5. , -4.4);
-    }
+    // if(flag_options->USE_EXP_FILTER){
+    //     if (redshift > 6)
+    //         exp_mfp = 25.483241248322766 / cosmo_params->hlittle;
+    //     else
+    //         exp_mfp = 112 / cosmo_params->hlittle * pow( (1.+redshift) / 5. , -4.4);
+    // }
+    //constant for now, the pow(4.4) makes kinks in reionisation
+    exp_mfp = 25.483241248322766 / cosmo_params->hlittle;
 
     // For recombinations
     bool recomb_filter_flag = flag_options->INHOMO_RECO && !flag_options->CELL_RECOMB;
@@ -1216,12 +1218,14 @@ LOG_SUPER_DEBUG("excursion set normalisation, mean_f_coll_MINI: %e", box->mean_f
                     for (y = 0; y < user_params->HII_DIM; y++) {
                         for (z = 0; z < HII_D_PARA; z++) {
 
-                            //Use unfiltered density for CELL_RECOMB case, since the "Fcoll" represents photons
-                            //  reaching the central cell rather than photons in the entire sphere
-                            if(flag_options->CELL_RECOMB)
-                                curr_dens = perturbed_field->density[HII_R_INDEX(x,y,z)];
-                            else
-                                curr_dens = *((float *)deltax_filtered + HII_R_FFT_INDEX(x,y,z));
+                            //TODO: There may be a reason to use unfiltered density for CELL_RECOMB case,
+                            // since the "Fcoll" represents photons reaching the central cell rather than
+                            // photons in the entire sphere, but it makes reionisation look stranger so
+                            // more investigation is needed
+                            // if(flag_options->CELL_RECOMB)
+                            //     curr_dens = perturbed_field->density[HII_R_INDEX(x,y,z)];
+                            // else
+                            curr_dens = *((float *)deltax_filtered + HII_R_FFT_INDEX(x,y,z));
 
                             Splined_Fcoll = box->Fcoll[counter * HII_TOT_NUM_PIXELS + HII_R_INDEX(x,y,z)];
 


### PR DESCRIPTION
A few changes mainly for the upcoming database:

- Setting a constant mfp instead of the power-law fit, which resulted in kinks in reionisation history at z=6
- Using the filtered density instead of local when using the exponential filter, as done in (Davies+22)
    - There are some questions here about what our model should be with this filter + recombinations but this choice seems better for now
- For unresolved halos in the sampler, use the Lagrangian density instead of Eulerian to be more consistent with the halo sampler. In future we also want to move these as particles with the 2LPT but that will take some time to develop so for now we assume they don't move.