### PR TITLE
don't save HaloField by default in high level functions

### DIFF
--- a/src/py21cmfast/outputs.py
+++ b/src/py21cmfast/outputs.py
@@ -129,15 +129,6 @@ class InitialConditions(_OutputStruct):
 
         self.prepare(keep=keep, force=force)
 
-    def prepare_for_halos(self, flag_options: FlagOptions, force: bool = False):
-        """Ensure ICs have all boxes required for the halos, and no more."""
-        keep = ["hires_density"]  # for dexm
-        if flag_options.HALO_STOCHASTICITY:
-            keep.append("lowres_density")  # for the sampler
-        if self.user_params.USE_RELATIVE_VELOCITIES:
-            keep.append("lowres_vcb")
-        self.prepare(keep=keep, force=force)
-
     def prepare_for_spin_temp(self, flag_options: FlagOptions, force: bool = False):
         """Ensure ICs have all boxes required for spin_temp, and no more."""
         keep = []


### PR DESCRIPTION
Since halo fields can get quite large, and since the classes `HaloFIeld` and `PerturbHaloField` hold similar information, we really only want to cache one most of the time. So I've changed the default behaviour in `run_coeval` and `run_lightcone` to only write `PerturbHaloField`. This could save up to ~10% time and halve the cache requirements.

- `_get_config_options` is now only called on the lower-level structures, this was done to have more control over writing behaviour.
- If `hooks` are passed or `write` is set to true or false, the behaviour is the same as before
- if `write==None` (default) we write everything except for `HaloField`.

This also fixes an unrelated problem where we overpurged the ICs for the halofield since we need the velocity fields for `perturb_halo_list`.