### PR TITLE
Fixing Tests

### DIFF
--- a/src/py21cmfast/src/InputParameters.c
+++ b/src/py21cmfast/src/InputParameters.c
@@ -39,7 +39,7 @@ GlobalParams global_params = {
     .OPTIMIZE_MIN_MASS = 1e11,
 
 
-    .CRIT_DENS_TRANSITION = 1.5,
+    .CRIT_DENS_TRANSITION = 1.2,
     .MIN_DENSITY_LOW_LIMIT = 9e-8,
 
     .RecombPhotonCons = 0,

--- a/src/py21cmfast/src/Stochasticity.c
+++ b/src/py21cmfast/src/Stochasticity.c
@@ -1072,6 +1072,7 @@ int single_test_sample(UserParams *user_params, CosmoParams *cosmo_params, Astro
         }
 
         out_n_tot[0] = n_halo_tot;
+        LOG_DEBUG("Found %d halos", n_halo_tot);
 
         //get expected values from the saved mass range
         if(hs_constants->from_catalog){

--- a/src/py21cmfast/src/hmf.h
+++ b/src/py21cmfast/src/hmf.h
@@ -4,7 +4,7 @@
 #include "InputParameters.h"
 //integrals
 
-#define MAX_DELTAC_FRAC (float)0.99 //max delta/deltac for the mass function integrals
+#define MAX_DELTAC_FRAC (float)0.98 //max delta/deltac for the mass function integrals
 #define DELTA_MIN -1 //minimum delta for Lagrangian mass function integrals
 
 //Parameters used for gsl integral on the mass function

--- a/src/py21cmfast/src/hmf.h
+++ b/src/py21cmfast/src/hmf.h
@@ -4,7 +4,7 @@
 #include "InputParameters.h"
 //integrals
 
-#define MAX_DELTAC_FRAC (float)0.98 //max delta/deltac for the mass function integrals
+#define MAX_DELTAC_FRAC (float)0.99 //max delta/deltac for the mass function integrals
 #define DELTA_MIN -1 //minimum delta for Lagrangian mass function integrals
 
 //Parameters used for gsl integral on the mass function

--- a/src/py21cmfast/src/interp_tables.c
+++ b/src/py21cmfast/src/interp_tables.c
@@ -632,6 +632,11 @@ void initialise_dNdM_inverse_table(double xmin, double xmax, double lnM_min, dou
             }
             else{
                 delta = x;
+                if(delta >= MAX_DELTAC_FRAC*get_delta_crit(user_params_global->HMF,sigma_cond,growth_out)){
+                    for(k=1;k<np;k++)
+                        Nhalo_inv_table.z_arr[i][k] = 1.;
+                    continue;
+                }
             }
 
             M_cond = exp(lnM_cond);
@@ -674,7 +679,7 @@ void initialise_dNdM_inverse_table(double xmin, double xmax, double lnM_min, dou
                     if (status == GSL_SUCCESS){
                         lnM_init = lnM_lo;
                         Nhalo_inv_table.z_arr[i][k] = exp(lnM_guess)/M_cond;
-                        // LOG_ULTRA_DEBUG("Found %.6e --> %.6e",lnM_guess,exp(lnM_guess)/M_cond);
+                        // LOG_ULTRA_DEBUG("Found (M %.2e d %.2f p %.3e) %.6e --> %.6e",M_cond,delta,exp(pa[k]),lnM_guess,exp(lnM_guess)/M_cond);
                     }
 
                 }while((status == GSL_CONTINUE) && (iter < MAX_ITER_RF));

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -373,7 +373,14 @@ def construct_fftw_wisdoms(
 def get_delta_crit(user_params, cosmo_params, mass, redshift):
     """Gets the critical collapse density given a mass, redshift and parameters."""
     sigma, _ = evaluate_sigma(user_params, cosmo_params, mass)
+    # evaluate_sigma already broadcasts the paramters so we don't need to repeat
     growth = lib.dicke(redshift)
+    return get_delta_crit_nu(user_params, sigma, growth)
+
+
+def get_delta_crit_nu(user_params, sigma, growth):
+    """Uses the nu paramters (sigma and growth factor) to get critical density."""
+    # None of the parameter structs are used in this function so we don't need a broadcast
     return np.vectorize(lib.get_delta_crit)(user_params.cdict["HMF"], sigma, growth)
 
 

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -603,7 +603,6 @@ def evaluate_inv_massfunc_cond(
         )
         * cond_mass
     )
-
     return masses
 
 
@@ -927,7 +926,8 @@ def evaluate_SFRD_cond(
     )
 
     growthf = lib.dicke(redshift)
-    SFRD_mcg = 0.0
+    if not flag_options.USE_MINI_HALOS:
+        SFRD_mcg = np.zeros((densities.size, l10mturns.size))
     # Unfortunately we have to do this until we sort out the USE_INTERPOLATION_TABLES flag
     # Since these integrals take forever if the flag is false
     if return_integral:
@@ -1072,8 +1072,9 @@ def evaluate_Nion_cond(
         else 0.0
     )
 
+    if not flag_options.USE_MINI_HALOS:
+        Nion_mcg = np.zeros((densities.size, l10mturns.size))
     growthf = lib.dicke(redshift)
-    Nion_mcg = 0.0
     # Unfortunately we have to do this until we sort out the USE_INTERPOLATION_TABLES flag
     # Since these integrals take forever if the flag is false
     if return_integral:

--- a/src/py21cmfast/wrapper/structs.py
+++ b/src/py21cmfast/wrapper/structs.py
@@ -608,7 +608,18 @@ class OutputStruct(metaclass=ABCMeta):
                     and not isinstance(q, StructInstanceWrapper)
                     and f.attrs[kfile] != q
                 ):
-                    return False
+                    if not isinstance(q, (float, np.float32)) or not (
+                        float_to_string_precision(q, config["cache_param_sigfigs"])
+                        == float_to_string_precision(
+                            f.attrs[kfile], config["cache_param_sigfigs"]
+                        )
+                    ):
+                        logger.debug(f"For file {fname}:")
+                        logger.debug(
+                            f"\tThough md5 and seed matched, the parameter {kfile} did not match,"
+                            f" with values {f.attrs[kfile]} and {q} in file and user respectively"
+                        )
+                        return False
                 elif isinstance(q, (InputStruct, StructInstanceWrapper)):
                     grp = f[kfile]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,8 @@ def perturbed_field(ic, redshift):
 @pytest.fixture(scope="session")
 def rectlcn(perturbed_field, max_redshift) -> RectilinearLightconer:
     return RectilinearLightconer.with_equal_cdist_slices(
-        min_redshift=perturbed_field.redshift,
+        min_redshift=perturbed_field.redshift
+        + 0.1,  # we don't want to overwrite pertubed_field
         max_redshift=max_redshift,
         resolution=perturbed_field.user_params.cell_size,
         cosmo=perturbed_field.cosmo_params.cosmo,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,11 @@ def redshift():
 
 
 @pytest.fixture(scope="session")
+def lightcone_min_redshift(redshift):
+    return redshift + 0.1
+
+
+@pytest.fixture(scope="session")
 def max_redshift():
     """A default redshift to evaluate at. Not too high, not too low."""
     return 25
@@ -206,13 +211,12 @@ def perturbed_field(ic, redshift):
 
 
 @pytest.fixture(scope="session")
-def rectlcn(perturbed_field, max_redshift) -> RectilinearLightconer:
+def rectlcn(lightcone_min_redshift, ic, max_redshift) -> RectilinearLightconer:
     return RectilinearLightconer.with_equal_cdist_slices(
-        min_redshift=perturbed_field.redshift
-        + 0.1,  # we don't want to overwrite pertubed_field
+        min_redshift=lightcone_min_redshift,
         max_redshift=max_redshift,
-        resolution=perturbed_field.user_params.cell_size,
-        cosmo=perturbed_field.cosmo_params.cosmo,
+        resolution=ic.user_params.cell_size,
+        cosmo=ic.cosmo_params.cosmo,
     )
 
 

--- a/tests/test_drivers_lc.py
+++ b/tests/test_drivers_lc.py
@@ -12,15 +12,17 @@ import numpy as np
 import py21cmfast as p21c
 
 
-def test_lightcone(lc, default_user_params, redshift, max_redshift):
+def test_lightcone(lc, default_user_params, lightcone_min_redshift, max_redshift):
     assert lc.lightcone_redshifts[-1] >= max_redshift
-    assert np.isclose(lc.lightcone_redshifts[0], redshift, atol=1e-4)
+    assert np.isclose(lc.lightcone_redshifts[0], lightcone_min_redshift, atol=1e-4)
     assert lc.cell_size == default_user_params.BOX_LEN / default_user_params.HII_DIM
 
 
-def test_lightcone_quantities(ic, default_flag_options, redshift, max_redshift):
+def test_lightcone_quantities(
+    ic, default_flag_options, lightcone_min_redshift, max_redshift
+):
     lcn = p21c.RectilinearLightconer.with_equal_cdist_slices(
-        min_redshift=redshift,
+        min_redshift=lightcone_min_redshift,
         max_redshift=max_redshift,
         resolution=ic.user_params.cell_size,
         cosmo=ic.cosmo_params.cosmo,
@@ -52,7 +54,7 @@ def test_lightcone_quantities(ic, default_flag_options, redshift, max_redshift):
     assert lc.density.min() != lc.brightness_temp.min() != lc.brightness_temp.max()
 
     lcn_ts = p21c.RectilinearLightconer.with_equal_cdist_slices(
-        min_redshift=redshift,
+        min_redshift=lightcone_min_redshift,
         max_redshift=max_redshift,
         resolution=ic.user_params.cell_size,
         cosmo=ic.cosmo_params.cosmo,

--- a/tests/test_halo_sampler.py
+++ b/tests/test_halo_sampler.py
@@ -17,6 +17,7 @@ from py21cmfast.wrapper import cfuncs as cf
 
 from . import produce_integration_test_data as prd
 from . import test_c_interpolation_tables as cint
+from .test_c_interpolation_tables import print_failure_stats
 
 RELATIVE_TOLERANCE = 1e-1
 
@@ -99,6 +100,8 @@ def test_sampler(name, cond, from_cat, plt):
     mf_out = hist / volume_total_m / dlnm
     binned_cmf = binned_cmf / dlnm * mass_dens
 
+    one_in_box = 1 / volume_total_m / dlnm[0]
+
     if plt == mpl.pyplot:
         plot_sampler_comparison(
             edges,
@@ -125,9 +128,22 @@ def test_sampler(name, cond, from_cat, plt):
         rtol=RELATIVE_TOLERANCE,
     )
     sel_compare_bins = edges[:-1] < (0.9 * mass)
+
+    print_failure_stats(
+        mf_out[sel_compare_bins],
+        binned_cmf[sel_compare_bins],
+        [
+            edges[:-1][sel_compare_bins],
+        ],
+        one_in_box,
+        5e-1,
+        "binned_cmf",
+    )
+
     np.testing.assert_allclose(
         mf_out[sel_compare_bins],
         binned_cmf[sel_compare_bins],
+        atol=one_in_box,
         rtol=5e-1,
     )
 

--- a/tests/test_halo_sampler.py
+++ b/tests/test_halo_sampler.py
@@ -2,6 +2,7 @@ import pytest
 
 import matplotlib as mpl
 import numpy as np
+from astropy import units as u
 
 from py21cmfast import (
     AstroParams,
@@ -12,6 +13,7 @@ from py21cmfast import (
     global_params,
 )
 from py21cmfast.c_21cmfast import ffi, lib
+from py21cmfast.wrapper import cfuncs as cf
 
 from . import produce_integration_test_data as prd
 from . import test_c_interpolation_tables as cint
@@ -21,225 +23,104 @@ RELATIVE_TOLERANCE = 1e-1
 options_hmf = list(cint.OPTIONS_HMF.keys())
 
 options_delta = [-0.9, -0.5, 0, 1, 1.45]  # cell densities to draw samples from
-options_mass = [9, 10, 11, 12]  # halo masses to draw samples from
+options_log10mass = [9, 10, 11, 12]  # halo masses to draw samples from
 
 
 @pytest.mark.parametrize("name", options_hmf)
-@pytest.mark.parametrize("mass", options_mass)
-def test_sampler_from_catalog(name, mass, plt):
+@pytest.mark.parametrize("from_cat", ["cat", "grid"])
+@pytest.mark.parametrize("cond", range(len(options_delta)))
+def test_sampler(name, cond, from_cat, plt):
     redshift, kwargs = cint.OPTIONS_HMF[name]
     opts = prd.get_all_options(redshift, **kwargs)
-
     up = opts["user_params"]
     cp = opts["cosmo_params"]
     ap = opts["astro_params"]
     fo = opts["flag_options"]
 
-    lib.Broadcast_struct_global_all(up.cstruct, cp.cstruct, ap.cstruct, fo.cstruct)
+    from_cat = "cat" in from_cat
 
-    mass = 10**mass
+    n_cond = 2000
+    if from_cat:
+        mass = 10 ** options_log10mass[cond]
+        cond = mass
+        z_desc = (1 + redshift) / global_params.ZPRIME_STEP_FACTOR - 1
+        delta = None
+    else:
+        mass = (
+            (
+                cp.cosmo.critical_density(0)
+                * cp.OMm
+                * u.Mpc**3
+                * (up.BOX_LEN / up.HII_DIM) ** 3
+            )
+            .to("M_sun")
+            .value
+        )
+        z_desc = None
+        delta = options_delta[cond]
 
+    sample_dict = cf.halo_sample_test(
+        user_params=up,
+        cosmo_params=cp,
+        astro_params=ap,
+        flag_options=fo,
+        redshift=redshift,
+        from_cat=from_cat,
+        cond_array=np.full(n_cond, cond),
+    )
+
+    # set up histogram
     l10min = np.log10(up.SAMPLER_MIN_MASS)
-    l10max = np.log10(mass)
+    l10max = np.log10(global_params.M_MAX_INTEGRAL)
     edges = np.logspace(l10min, l10max, num=int(10 * (l10max - l10min)))
     bin_minima = edges[:-1]
     bin_maxima = edges[1:]
-    dlnm = np.log(edges[1:]) - np.log(edges[:-1])
-
-    lib.init_ps()
-    lib.initialiseSigmaMInterpTable(
-        global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL
-    )
-
-    n_cond = 10000
-
-    z = 6.0
-    z_prev = 5.8
-    growth_prev = lib.dicke(z_prev)
-    growthf = lib.dicke(z)
-
-    sigma_cond_m = lib.sigma_z0(mass)
-    delta_cond_m = (
-        lib.get_delta_crit(up.cdict["HMF"], sigma_cond_m, growth_prev)
-        * growthf
-        / growth_prev
-    )
-    mass_dens = cp.cosmo.Om0 * cp.cosmo.critical_density(0).to("Mpc-3 M_sun").value
-    volume_total_m = mass * n_cond / mass_dens
-
-    crd_in = np.zeros(3 * n_cond).astype("i4")
-    # HALO MASS CONDITIONS WITH FIXED z-step
-    cond_in = np.full(n_cond, fill_value=mass).astype("f4")  # mass at z6
-
-    nhalo_out = np.zeros(1).astype("i4")
-    N_out = np.zeros(n_cond).astype("i4")
-    M_out = np.zeros(n_cond).astype("f8")
-    exp_M = np.zeros(n_cond).astype("f8")
-    exp_N = np.zeros(n_cond).astype("f8")
-    halomass_out = np.zeros(int(1e7)).astype("f4")
-    halocrd_out = np.zeros(int(3e7)).astype("i4")
-
-    lib.single_test_sample(
-        up.cstruct,
-        cp.cstruct,
-        ap.cstruct,
-        fo.cstruct,
-        12345,
-        n_cond,
-        ffi.cast("float *", cond_in.ctypes.data),
-        ffi.cast("int *", crd_in.ctypes.data),
-        z,
-        z_prev,
-        ffi.cast("int *", nhalo_out.ctypes.data),
-        ffi.cast("int *", N_out.ctypes.data),
-        ffi.cast("double *", exp_N.ctypes.data),
-        ffi.cast("double *", M_out.ctypes.data),
-        ffi.cast("double *", exp_M.ctypes.data),
-        ffi.cast("float *", halomass_out.ctypes.data),
-        ffi.cast("int *", halocrd_out.ctypes.data),
-    )
-
-    # since the tables are reallocated in the test sample function, we redo them here
-    lib.initialiseSigmaMInterpTable(edges[0] / 2, edges[-1])
+    dlnm = np.log(bin_maxima) - np.log(bin_minima)
 
     # get CMF integrals in the same bins
-    bin_minima = edges[:-1]
-    bin_maxima = edges[1:]
-    binned_cmf = np.vectorize(lib.Nhalo_Conditional)(
-        growthf,
-        np.log(bin_minima),
-        np.log(bin_maxima),
-        mass,
-        sigma_cond_m,
-        delta_cond_m,
-        0,
+    binned_cmf = cf.get_cmf_integral(
+        user_params=up,
+        cosmo_params=cp,
+        astro_params=ap,
+        flag_options=fo,
+        M_min=bin_minima,
+        M_max=bin_maxima,
+        M_cond=mass,
+        redshift=redshift,
+        delta=delta,
+        z_desc=z_desc,
     )
 
-    hist, _ = np.histogram(halomass_out, edges)
+    hist, _ = np.histogram(sample_dict["halo_masses"], edges)
+
+    mass_dens = cp.cosmo.Om0 * cp.cosmo.critical_density(0).to("Mpc-3 M_sun").value
+    volume_total_m = mass * n_cond / mass_dens
     mf_out = hist / volume_total_m / dlnm
     binned_cmf = binned_cmf * n_cond / volume_total_m / dlnm * mass
 
     if plt == mpl.pyplot:
         plot_sampler_comparison(
             edges,
-            exp_N,
-            exp_M,
-            N_out,
-            M_out,
+            sample_dict["expected_progenitors"],
+            sample_dict["expected_progenitor_mass"],
+            sample_dict["n_progenitors"],
+            sample_dict["progenitor_mass"],
             binned_cmf,
             mf_out,
-            f"mass = {mass:.2e}",
+            f"mass = {mass:.2e}" if from_cat else f"delta = {delta:.2e}",
             plt,
         )
 
-    np.testing.assert_allclose(N_out.mean(), exp_N[0], rtol=RELATIVE_TOLERANCE)
-    np.testing.assert_allclose(M_out.mean(), exp_M[0], rtol=RELATIVE_TOLERANCE)
-    np.testing.assert_allclose(mf_out, binned_cmf, rtol=RELATIVE_TOLERANCE)
-
-
-@pytest.mark.parametrize("name", options_hmf)
-@pytest.mark.parametrize("delta", options_delta)
-def test_sampler_from_grid(name, delta, plt):
-    redshift, kwargs = cint.OPTIONS_HMF[name]
-    opts = prd.get_all_options(redshift, **kwargs)
-
-    up = opts["user_params"]
-    cp = opts["cosmo_params"]
-    ap = opts["astro_params"]
-    fo = opts["flag_options"]
-    lib.Broadcast_struct_global_all(up.cstruct, cp.cstruct, ap.cstruct, fo.cstruct)
-
-    lib.init_ps()
-    lib.initialiseSigmaMInterpTable(
-        global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL
+    np.testing.assert_allclose(
+        sample_dict["n_progenitors"].mean(),
+        sample_dict["expected_progenitors"][0],
+        rtol=RELATIVE_TOLERANCE,
     )
-
-    n_cond = 5000
-
-    z = 6.0
-    growthf = lib.dicke(z)
-
-    mass_dens = cp.cosmo.Om0 * cp.cosmo.critical_density(0).to("Mpc-3 M_sun").value
-    cellvol = (up.BOX_LEN / up.HII_DIM) ** 3
-    cell_mass = cellvol * mass_dens
-
-    l10min = np.log10(up.SAMPLER_MIN_MASS)
-    l10max = np.log10(cell_mass)
-    edges = np.logspace(l10min, l10max, num=int(10 * (l10max - l10min)))
-    bin_minima = edges[:-1]
-    bin_maxima = edges[1:]
-    dlnm = np.log(edges[1:]) - np.log(edges[:-1])
-
-    sigma_cond = lib.sigma_z0(cell_mass)
-    volume_total = cellvol * n_cond
-
-    crd_in = np.zeros(3 * n_cond).astype("i4")
-
-    cond_in = np.full(n_cond, fill_value=delta).astype("f4")  # mass at z6
-
-    nhalo_out = np.zeros(1).astype("i4")
-    N_out = np.zeros(n_cond).astype("i4")
-    M_out = np.zeros(n_cond).astype("f8")
-    exp_M = np.zeros(n_cond).astype("f8")
-    exp_N = np.zeros(n_cond).astype("f8")
-    halomass_out = np.zeros(int(1e7)).astype("f4")
-    halocrd_out = np.zeros(int(3e7)).astype("i4")
-
-    lib.single_test_sample(
-        up.cstruct,
-        cp.cstruct,
-        ap.cstruct,
-        fo.cstruct,
-        12345,  # TODO: homogenize
-        n_cond,
-        ffi.cast("float *", cond_in.ctypes.data),
-        ffi.cast("int *", crd_in.ctypes.data),
-        z,
-        -1,
-        ffi.cast("int *", nhalo_out.ctypes.data),
-        ffi.cast("int *", N_out.ctypes.data),
-        ffi.cast("double *", exp_N.ctypes.data),
-        ffi.cast("double *", M_out.ctypes.data),
-        ffi.cast("double *", exp_M.ctypes.data),
-        ffi.cast("float *", halomass_out.ctypes.data),
-        ffi.cast("int *", halocrd_out.ctypes.data),
+    np.testing.assert_allclose(
+        sample_dict["progenitor_mass"].mean(),
+        sample_dict["expected_progenitor_mass"][0],
+        rtol=RELATIVE_TOLERANCE,
     )
-
-    # since the tables are reallocated in the test sample function, we redo them here
-    lib.initialiseSigmaMInterpTable(edges[0] / 2, edges[-1])
-
-    # get CMF integrals in the same bins
-    bin_minima = edges[:-1]
-    bin_maxima = edges[1:]
-    binned_cmf = np.vectorize(lib.Nhalo_Conditional)(
-        growthf,
-        np.log(bin_minima),
-        np.log(bin_maxima),
-        cell_mass,
-        sigma_cond,
-        delta,
-        0,
-    )
-
-    hist, _ = np.histogram(halomass_out, edges)
-    mf_out = hist / volume_total / dlnm
-    binned_cmf = binned_cmf * n_cond / volume_total / dlnm * cell_mass
-
-    if plt == mpl.pyplot:
-        plot_sampler_comparison(
-            edges,
-            exp_N,
-            exp_M,
-            N_out,
-            M_out,
-            binned_cmf,
-            mf_out,
-            f"delta = {delta:.2f}",
-            plt,
-        )
-
-    np.testing.assert_allclose(N_out.mean(), exp_N[0], rtol=RELATIVE_TOLERANCE)
-    np.testing.assert_allclose(M_out.mean(), exp_M[0], rtol=RELATIVE_TOLERANCE)
     np.testing.assert_allclose(mf_out, binned_cmf, rtol=RELATIVE_TOLERANCE)
 
 
@@ -250,16 +131,8 @@ def test_halo_scaling_relations(ic, default_input_struct):
     # specify parameters to use for this test
     redshift = 10.0
     opts = prd.get_all_options(redshift)
-
-    up = opts["user_params"]
-    cp = opts["cosmo_params"]
     ap = opts["astro_params"]
     fo = opts["flag_options"]
-    lib.Broadcast_struct_global_all(up.cstruct, cp.cstruct, ap.cstruct, fo.cstruct)
-
-    mturn_acg = np.maximum(lib.atomic_cooling_threshold(redshift), 10**ap.M_TURN)
-    # mturn_mcg = 10**ap.M_TURN
-    print(f"z={redshift} th = {1 / cp.cosmo.H(redshift).to('s-1').value}")
 
     # setup the halo masses to test
     halo_mass_vals = np.array([1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12])
@@ -270,58 +143,48 @@ def test_halo_scaling_relations(ic, default_input_struct):
     ).flatten()
     halo_rng = np.random.normal(size=n_halo_per_mass * n_masses)
 
-    # HACK: Make the fake halo list
-    fake_pthalos = PerturbHaloField(
-        inputs=default_input_struct,
-        buffer_size=halo_masses.size,
-    )
-    fake_pthalos()  # initialise memory
-    fake_pthalos.halo_masses = halo_masses.astype("f4")
-    fake_pthalos.halo_corods = np.zeros(halo_masses.size * 3).astype("i4")
-    fake_pthalos.star_rng = halo_rng.astype("f4")
-    fake_pthalos.sfr_rng = halo_rng.astype("f4")
-    fake_pthalos.xray_rng = halo_rng.astype("f4")
-    fake_pthalos.n_halos = halo_masses.size
-
-    # single element zero array to act as the grids (vcb, J_21_LW, z_reion, Gamma12)
-    zero_array = ffi.cast("float *", np.zeros(1).ctypes.data)
-
-    out_buffer = np.zeros(12 * halo_masses.size).astype("f4")
-    lib.test_halo_props(
-        redshift,
-        up.cstruct,
-        cp.cstruct,
-        ap.cstruct,
-        fo.cstruct,
-        zero_array,
-        zero_array,
-        zero_array,
-        zero_array,
-        fake_pthalos(),
-        ffi.cast("float *", out_buffer.ctypes.data),
-    )
-
     # (n_halo*n_mass*n_prop) --> (n_prop,n_mass,n_halo)
 
     # mass,star,sfr,xray,nion,wsfr,starmini,sfrmini,mturna,mturnm,mturnr,Z
-    out_buffer = out_buffer.reshape(n_masses, n_halo_per_mass, 12)
+    out_dict = cf.convert_halo_properties(
+        initial_conditions=ic,
+        redshift=redshift,
+        astro_params=ap,
+        flag_options=fo,
+        halo_masses=halo_masses,
+        halo_rng=halo_rng,
+    )
+
+    halo_mass_out = out_dict["halo_mass"].reshape(
+        (len(halo_mass_vals), n_halo_per_mass)
+    )
+    halo_stars_out = out_dict["halo_stars"].reshape(
+        (len(halo_mass_vals), n_halo_per_mass)
+    )
+    halo_sfr_out = out_dict["halo_sfr"].reshape((len(halo_mass_vals), n_halo_per_mass))
+    halo_xray_out = out_dict["halo_xray"].reshape(
+        (len(halo_mass_vals), n_halo_per_mass)
+    )
+
+    # assuming same value for all halos
+    mturn_acg = out_dict["mturn_a"][0]
 
     exp_SHMR = (
         (10**ap.F_STAR10) * n_masses**ap.ALPHA_STAR * np.exp(-mturn_acg / n_masses)
     )
-    sim_SHMR = out_buffer[:, :, 1] / out_buffer[:, :, 0]
+    sim_SHMR = halo_stars_out / halo_mass_out
     np.testing.assert_allclose(exp_SHMR, sim_SHMR.mean(axis=1), rtol=1e-1)
     np.testing.assert_allclose(ap.SIGMA_STAR, sim_SHMR.std(axis=1), rtol=1e-1)
 
-    exp_SSFR = cp.cosmo.H(redshift).to("s").value / (ap.t_STAR)
-    sim_SSFR = out_buffer[:, :, 2] / out_buffer[:, :, 1]
+    exp_SSFR = ic.cosmo_params.cosmo.H(redshift).to("s").value / (ap.t_STAR)
+    sim_SSFR = halo_sfr_out / halo_stars_out
     np.testing.assert_allclose(exp_SSFR, sim_SSFR.mean(axis=1), rtol=1e-1)
     np.testing.assert_allclose(
         ap.SIGMA_SFR_LIM, sim_SSFR.std(axis=1), rtol=1e-1
     )  # WRONG
 
     exp_LX = 10 ** (ap.L_X)  # low-z approx
-    sim_LX = out_buffer[:, :, 3] / out_buffer[:, :, 2]
+    sim_LX = halo_xray_out / halo_sfr_out
     np.testing.assert_allclose(exp_LX, sim_LX.mean(axis=1), rtol=1e-1)
     np.testing.assert_allclose(ap.SIGMA_LX, sim_LX.std(axis=1), rtol=1e-1)
 

--- a/tests/test_halo_sampler.py
+++ b/tests/test_halo_sampler.py
@@ -23,7 +23,7 @@ RELATIVE_TOLERANCE = 1e-1
 options_hmf = list(cint.OPTIONS_HMF.keys())
 
 options_delta = [-0.9, -0.5, 0, 1, 1.45]  # cell densities to draw samples from
-options_log10mass = [9, 10, 11, 12]  # halo masses to draw samples from
+options_log10mass = [9, 10, 11, 12, 13]  # halo masses to draw samples from
 
 
 @pytest.mark.parametrize("name", options_hmf)
@@ -136,18 +136,17 @@ def test_halo_scaling_relations(ic, default_input_struct):
 
     # setup the halo masses to test
     halo_mass_vals = np.array([1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12])
-    n_masses = halo_mass_vals.size
     n_halo_per_mass = 1000
-    halo_masses = np.array(
-        [n_halo_per_mass * [val] for val in halo_mass_vals]
+    halo_masses = np.broadcast_to(
+        halo_mass_vals[:, None], (halo_mass_vals.size, n_halo_per_mass)
     ).flatten()
-    halo_rng = np.random.normal(size=n_halo_per_mass * n_masses)
+    halo_rng = np.random.normal(size=n_halo_per_mass * halo_mass_vals.size)
 
     # (n_halo*n_mass*n_prop) --> (n_prop,n_mass,n_halo)
 
     # mass,star,sfr,xray,nion,wsfr,starmini,sfrmini,mturna,mturnm,mturnr,Z
     out_dict = cf.convert_halo_properties(
-        initial_conditions=ic,
+        ics=ic,
         redshift=redshift,
         astro_params=ap,
         flag_options=fo,
@@ -156,14 +155,14 @@ def test_halo_scaling_relations(ic, default_input_struct):
     )
 
     halo_mass_out = out_dict["halo_mass"].reshape(
-        (len(halo_mass_vals), n_halo_per_mass)
+        (halo_mass_vals.size, n_halo_per_mass)
     )
     halo_stars_out = out_dict["halo_stars"].reshape(
-        (len(halo_mass_vals), n_halo_per_mass)
+        (halo_mass_vals.size, n_halo_per_mass)
     )
-    halo_sfr_out = out_dict["halo_sfr"].reshape((len(halo_mass_vals), n_halo_per_mass))
+    halo_sfr_out = out_dict["halo_sfr"].reshape((halo_mass_vals.size, n_halo_per_mass))
     halo_xray_out = out_dict["halo_xray"].reshape(
-        (len(halo_mass_vals), n_halo_per_mass)
+        (halo_mass_vals.size, n_halo_per_mass)
     )
 
     # assuming same value for all halos

--- a/tests/test_singlefield.py
+++ b/tests/test_singlefield.py
@@ -126,7 +126,7 @@ def test_cache_exists(default_input_struct, perturbed_field, tmpdirec):
     assert pf.exists(tmpdirec)
 
     pf.read(tmpdirec)
-    assert np.all(pf.density == perturbed_field.density)
+    np.testing.assert_allclose(pf.density, perturbed_field.density)
     assert pf == perturbed_field
 
 


### PR DESCRIPTION
This PR will achieve two things:
- Moves most of the C backend access in the tests to wrapper/cfuncs.py to make them more intuitive
- changes the tolerances of tests to reflect what we actually expect from our functions. this mostly involves restricting the comparisons between interpolation tables and integrals to domains we actually care about, since most of these tests had <10^-3 errors in all bins except one near the critical collapse density, where it had 10^-1 error.

As such, tests (apart from integration tests of course) should all be passing.