### PR TITLE
run lc tests with correct params, stop purging ics for halos

### DIFF
--- a/src/py21cmfast/drivers/coeval.py
+++ b/src/py21cmfast/drivers/coeval.py
@@ -689,11 +689,6 @@ def run_coeval(
 
     perturbed_field = perturb_
 
-    # Now we can purge initial_conditions further.
-    with contextlib.suppress(OSError):
-        initial_conditions.prepare_for_halos(
-            flag_options=flag_options, force=always_purge
-        )
     # get the halos (reverse redshift order)
     pt_halos = []
     if flag_options.USE_HALO_FIELD and not flag_options.FIXED_HALO_GRIDS:

--- a/src/py21cmfast/drivers/lightcone.py
+++ b/src/py21cmfast/drivers/lightcone.py
@@ -581,11 +581,6 @@ def _run_lightcone_from_perturbed_fields(
                 "run with write=True to continue from a checkpoint."
             )
 
-    # Now we can purge initial_conditions further.
-    with contextlib.suppress(OSError):
-        initial_conditions.prepare_for_halos(
-            flag_options=inputs.flag_options, force=always_purge
-        )
     # we explicitly pass the descendant halos here since we have a redshift list prior
     #   this will generate the extra fields if STOC_MINIMUM_Z is given
     pt_halos = []

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -142,15 +142,6 @@ class InitialConditions(_OutputStruct):
 
         self.prepare(keep=keep, force=force)
 
-    def prepare_for_halos(self, flag_options: FlagOptions, force: bool = False):
-        """Ensure ICs have all boxes required for the halos, and no more."""
-        keep = ["hires_density"]  # for dexm
-        if flag_options.HALO_STOCHASTICITY:
-            keep.append("lowres_density")  # for the sampler
-        if self.user_params.USE_RELATIVE_VELOCITIES:
-            keep.append("lowres_vcb")
-        self.prepare(keep=keep, force=force)
-
     def prepare_for_spin_temp(self, flag_options: FlagOptions, force: bool = False):
         """Ensure ICs have all boxes required for spin_temp, and no more."""
         keep = []

--- a/tests/test_drivers_lc.py
+++ b/tests/test_drivers_lc.py
@@ -171,10 +171,16 @@ def test_run_lc_bad_inputs(ic):
         )
 
 
-def test_lc_with_lightcone_filename(ic, rectlcn, perturbed_field, tmpdirec):
+def test_lc_with_lightcone_filename(
+    ic, rectlcn, default_astro_params, default_flag_options, tmpdirec
+):
     fname = tmpdirec / "lightcone.h5"
     _, _, _, lc = p21c.exhaust_lightcone(
-        lightconer=rectlcn, initial_conditions=ic, lightcone_filename=fname
+        lightconer=rectlcn,
+        initial_conditions=ic,
+        astro_params=default_astro_params,
+        flag_options=default_flag_options,
+        lightcone_filename=fname,
     )
     assert fname.exists()
 
@@ -186,6 +192,8 @@ def test_lc_with_lightcone_filename(ic, rectlcn, perturbed_field, tmpdirec):
     _, _, _, lc2 = p21c.exhaust_lightcone(
         lightconer=rectlcn,
         initial_conditions=ic,
+        astro_params=default_astro_params,
+        flag_options=default_flag_options,
         lightcone_filename=fname,
     )
 


### PR DESCRIPTION
I had previously included a third purging method of the ICs, `prepare_for_halos`. However since I needed the perturbing fields for the halos anyway, this was over-purging the arrays, resulting in unnecessary i/o.

This also includes a small fix to one of the tests which was taking longer than it should by using the wrong flag options.