### PR TITLE
Fixed Template Filepath Reading

### DIFF
--- a/src/py21cmfast/run_templates.py
+++ b/src/py21cmfast/run_templates.py
@@ -75,7 +75,8 @@ def create_params_from_template(template_name: str, **kwargs):
     # First check if the provided name is a path to an existsing TOML file
     template = None
     if Path(template_name).is_file():
-        template = tomllib.load(template_name)
+        with open(template_name, "rb") as template_file:
+            template = tomllib.load(template_file)
 
     # Next, check if the string matches one of our template aliases
     with open(TEMPLATE_PATH / "manifest.toml", "rb") as f:


### PR DESCRIPTION
`InputParameters.from_template()` failed when supplied a filepath rather than template name due to the `create_params_from_template()` callable passing a string to `tomllib.load()` rather than a stream object. This has been fixed so that custom templates can now be supplied via their filepath.