### PR TITLE
Fixing photoncons

### DIFF
--- a/src/py21cmfast/drivers/coeval.py
+++ b/src/py21cmfast/drivers/coeval.py
@@ -89,7 +89,7 @@ class _HighLevelOutput:
         kinds = {
             "init": InitialConditions,
             "perturb_field": PerturbedField,
-            "halobox": HaloBox,
+            "halo_box": HaloBox,
             "ionized_box": IonizedBox,
             "spin_temp": TsBox,
             "brightness_temp": BrightnessTemp,
@@ -109,7 +109,7 @@ class _HighLevelOutput:
         kinds = kinds or [
             "init",
             "perturb_field",
-            "halobox",
+            "halo_box",
             "ionized_box",
             "spin_temp",
             "brightness_temp",
@@ -360,7 +360,7 @@ class Coeval(_HighLevelOutput):
         ionized_box: IonizedBox,
         brightness_temp: BrightnessTemp,
         ts_box: TsBox | None = None,
-        halobox: HaloBox | None = None,
+        halo_box: HaloBox | None = None,
         cache_files: dict | None = None,
         photon_nonconservation_data=None,
         _globals=None,
@@ -371,7 +371,7 @@ class Coeval(_HighLevelOutput):
             redshift,
             (
                 perturbed_field,
-                halobox,
+                halo_box,
                 ionized_box,
                 brightness_temp,
                 ts_box,
@@ -383,7 +383,7 @@ class Coeval(_HighLevelOutput):
         self.perturb_struct = perturbed_field
         self.ionization_struct = ionized_box
         self.brightness_temp_struct = brightness_temp
-        self.halobox_struct = halobox
+        self.halo_box_struct = halo_box
         self.spin_temp_struct = ts_box
 
         self.cache_files = cache_files
@@ -396,7 +396,7 @@ class Coeval(_HighLevelOutput):
         for box in [
             initial_conditions,
             perturbed_field,
-            halobox,
+            halo_box,
             ionized_box,
             brightness_temp,
             ts_box,
@@ -461,7 +461,14 @@ class Coeval(_HighLevelOutput):
         return ""
 
     def _write_particulars(self, fname):
-        for name in ["init", "perturb", "ionization", "brightness_temp", "spin_temp"]:
+        for name in [
+            "init",
+            "perturb",
+            "halo_box",
+            "ionization",
+            "brightness_temp",
+            "spin_temp",
+        ]:
             struct = getattr(self, f"{name}_struct")
             if struct is not None:
                 struct.write(fname=fname, write_inputs=False)
@@ -818,7 +825,7 @@ def run_coeval(
             ionized_box=ib,
             brightness_temp=_bt,
             ts_box=st,
-            halobox=hb,
+            halo_box=hb,
             photon_nonconservation_data=photon_nonconservation_data,
             cache_files={
                 "init": [(0, os.path.join(direc, initial_conditions.filename))],

--- a/src/py21cmfast/drivers/lightcone.py
+++ b/src/py21cmfast/drivers/lightcone.py
@@ -522,7 +522,7 @@ def _run_lightcone_from_perturbed_fields(
 
     photon_nonconservation_data = None
     if inputs.flag_options.PHOTON_CONS_TYPE != "no-photoncons":
-        setup_photon_cons(**kw)
+        photon_nonconservation_data = setup_photon_cons(**kw)
 
     # At first we don't have any "previous" fields.
     st, ib, pf, hbox = None, None, None, None
@@ -672,7 +672,7 @@ def _run_lightcone_from_perturbed_fields(
             ionized_box=ib2,
             brightness_temp=bt2,
             ts_box=st2,
-            halobox=hbox2,
+            halo_box=hbox2,
             photon_nonconservation_data=photon_nonconservation_data,
             _globals=None,
         )
@@ -757,7 +757,7 @@ def _run_lightcone_from_perturbed_fields(
             "ionized_box": ionize_files,
             "brightness_temp": brightness_files,
             "spin_temp": spin_temp_files,
-            "halobox": hbox_files,
+            "halo_box": hbox_files,
             "pt_halos": phf_files,
         }
 

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -189,7 +189,10 @@ void set_ionbox_constants(double redshift, double prev_redshift, CosmoParams *co
     if(consts->mturn_m_nofb < astro_params->M_TURN)consts->mturn_m_nofb = astro_params->M_TURN;
     if(consts->mturn_a_nofb < astro_params->M_TURN)consts->mturn_a_nofb = astro_params->M_TURN;
 
-    if(flag_options->FIXED_HALO_GRIDS || user_params_global->AVG_BELOW_SAMPLER){
+    if(!flag_options_global->USE_HALO_FIELD || \
+        flag_options->FIXED_HALO_GRIDS || \
+        user_params_global->AVG_BELOW_SAMPLER)
+    {
         consts->Mlim_Fstar = Mass_limit_bisection(global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL, consts->alpha_star, consts->fstar_10);
         consts->Mlim_Fesc = Mass_limit_bisection(global_params.M_MIN_INTEGRAL, global_params.M_MAX_INTEGRAL, consts->alpha_esc, consts->fesc_10);
 

--- a/src/py21cmfast/src/photoncons.c
+++ b/src/py21cmfast/src/photoncons.c
@@ -1008,7 +1008,7 @@ double get_fesc_fit(double redshift){
     Q_at_z(redshift,&Q);
     if(Q > 1.) Q = 1.;
     fesc_fit = fesc_photoncons_yint + Q*fesc_photoncons_slope;
-    LOG_DEBUG("Alpha photon cons fit activated z = %.2e, fit yint,slope = %.2e, %.2e, alpha = %.2e", redshift,
+    LOG_DEBUG("photon cons fit activated z = %.2e, fit (yint, slope) = (%.2e, %.2e), val = %.2e", redshift,
                 fesc_photoncons_yint,fesc_photoncons_slope,fesc_fit);
     return fesc_fit;
 }

--- a/src/py21cmfast/src/photoncons.c
+++ b/src/py21cmfast/src/photoncons.c
@@ -1008,7 +1008,7 @@ double get_fesc_fit(double redshift){
     Q_at_z(redshift,&Q);
     if(Q > 1.) Q = 1.;
     fesc_fit = fesc_photoncons_yint + Q*fesc_photoncons_slope;
-    LOG_DEBUG("photon cons fit activated z = %.2e, fit (yint, slope) = (%.2e, %.2e), val = %.2e", redshift,
+    LOG_DEBUG("photon cons fit activated z = %.2f Q = %.2f, fit (yint, slope) = (%.2f, %.2f), val = %.2f", redshift, Q,
                 fesc_photoncons_yint,fesc_photoncons_slope,fesc_fit);
     return fesc_fit;
 }

--- a/src/py21cmfast/templates/fixed-halos.toml
+++ b/src/py21cmfast/templates/fixed-halos.toml
@@ -1,0 +1,17 @@
+# Run template for latest fiducial grid-based 21cmfast runs
+
+[CosmoParams]
+
+[UserParams]
+
+[AstroParams]
+R_BUBBLE_MAX = 50.0
+
+[FlagOptions]
+USE_HALO_FIELD = true
+USE_EXP_FILTER = true
+CELL_RECOMB = true
+USE_MINI_HALOS = false
+USE_TS_FLUCT = true
+INHOMO_RECO = true
+FIXED_HALO_GRID = true

--- a/src/py21cmfast/templates/manifest.toml
+++ b/src/py21cmfast/templates/manifest.toml
@@ -59,3 +59,9 @@ name = "latest-small"
 file = "latest-small.toml"
 aliases = ["latest-small"]
 description = "Small version of latest.toml"
+
+[[templates]]
+name = "fixed-halos"
+file = "fixed-halos.toml"
+aliases = ["fixed-halos"]
+description = "integrals of the CHMF on the Eulerian (evolved) density grid, FFRT-P in Davies+22 or ESF-E in Trac+22"

--- a/src/py21cmfast/wrapper/photoncons.py
+++ b/src/py21cmfast/wrapper/photoncons.py
@@ -644,12 +644,6 @@ def photoncons_fesc(cosmo_params, user_params, astro_params, flag_options):
     fit_fesc = ratio_ref * 10**astro_params.F_ESC10
     sel = np.isfinite(fit_fesc) & (ref_interp < max_q_fit) & (ref_interp > min_q_fit)
 
-    logger.info("PHOTONCONS DEBUG")
-    logger.info(f"z Calibration {ref_pc_data['z_calibration']}")
-    logger.info(f"Q Analytic    {ref_interp}")
-    logger.info(f"Q Calibration {1 - ref_pc_data['nf_calibration']}")
-    logger.info(f"Fesc {fit_fesc}")
-    logger.info(f"Mask {sel}")
     popt, pcov = curve_fit(alpha_func, ref_interp[sel], fit_fesc[sel])
     # pass to C
     logger.info(f"F_ESC10 Original = {10**astro_params.F_ESC10:.3f}")

--- a/src/py21cmfast/wrapper/photoncons.py
+++ b/src/py21cmfast/wrapper/photoncons.py
@@ -317,6 +317,7 @@ def calibrate_photon_cons(
             INHOMO_RECO=False,
             USE_MINI_HALOS=False,
             USE_HALO_FIELD=False,
+            HALO_STOCHASTICITY=False,
             PHOTON_CONS_TYPE="no-photoncons",
         )
         ib = None
@@ -631,6 +632,12 @@ def photoncons_fesc(cosmo_params, user_params, astro_params, flag_options):
     fit_fesc = ratio_ref * 10**astro_params.F_ESC10
     sel = np.isfinite(fit_fesc) & (ref_interp < max_q_fit) & (ref_interp > min_q_fit)
 
+    logger.info("PHOTONCONS DEBUG")
+    logger.info(f"z Calibration {ref_pc_data['z_calibration']}")
+    logger.info(f"Q Analytic    {ref_interp}")
+    logger.info(f"Q Calibration {1 - ref_pc_data['nf_calibration']}")
+    logger.info(f"Fesc {fit_fesc}")
+    logger.info(f"Mask {sel}")
     popt, pcov = curve_fit(alpha_func, ref_interp[sel], fit_fesc[sel])
     # pass to C
     logger.info(f"F_ESC10 Original = {10**astro_params.F_ESC10:.3f}")


### PR DESCRIPTION
Some of the InputParamteters changes were breaking the photon conservation models. The biggest issue was that in v3, the conditional defaults set `R_BUBBLE_MAX` to 15 on the calibration simulation if `INHOMO_RECO` was True. When the conditional defaults were changed and the parameter structs were frozen the calibrations were done with `R_BUBBLE_MAX=50` which messed with the photon conservation. This has been set back to the original behaviour, however we may want to think about this model a bit more in the future, each of the photon nonconservation corrections are unstable in certain areas of parameter space.

I've also snuck in a fix to the HaloBox caching, since the objects were not being saved correctly. I'm guessing the pending output PR fixes this anyway but I needed it for testing. 

Todos:
- figure out why the tests in `test_segfaults.py` didn't catch these errors and update the tests