### PR TITLE
Minor fixes to plotting scripts, adding turnover masses to global variables

### DIFF
--- a/src/py21cmfast/drivers/lightcone.py
+++ b/src/py21cmfast/drivers/lightcone.py
@@ -459,14 +459,14 @@ def _run_lightcone_from_perturbed_fields(
     ):
         # Save mean/global quantities
         for quantity in global_quantities:
-            if "log10_mturn_acg" == quantity:
-                lightcone.global_quantities[quantity][
-                    iz
-                ] = coeval.ionized_box.log10_Mturnover_ave
-            elif "log10_mturn_mcg" == quantity:
-                lightcone.global_quantities[quantity][
-                    iz
-                ] = coeval.ionized_box.log10_Mturnover_MINI_ave
+            if quantity == "log10_mturn_acg":
+                lightcone.global_quantities[quantity][iz] = (
+                    coeval.ionized_box.log10_Mturnover_ave
+                )
+            elif quantity == "log10_mturn_mcg":
+                lightcone.global_quantities[quantity][iz] = (
+                    coeval.ionized_box.log10_Mturnover_MINI_ave
+                )
             else:
                 lightcone.global_quantities[quantity][iz] = np.mean(
                     getattr(coeval, quantity)

--- a/src/py21cmfast/drivers/lightcone.py
+++ b/src/py21cmfast/drivers/lightcone.py
@@ -459,9 +459,18 @@ def _run_lightcone_from_perturbed_fields(
     ):
         # Save mean/global quantities
         for quantity in global_quantities:
-            lightcone.global_quantities[quantity][iz] = np.mean(
-                getattr(coeval, quantity)
-            )
+            if "log10_mturn_acg" == quantity:
+                lightcone.global_quantities[quantity][
+                    iz
+                ] = coeval.ionized_box.log10_Mturnover_ave
+            elif "log10_mturn_mcg" == quantity:
+                lightcone.global_quantities[quantity][
+                    iz
+                ] = coeval.ionized_box.log10_Mturnover_MINI_ave
+            else:
+                lightcone.global_quantities[quantity][iz] = np.mean(
+                    getattr(coeval, quantity)
+                )
 
         # Update photon conservation data in-place
         lightcone.photon_nonconservation_data |= coeval.photon_nonconservation_data

--- a/src/py21cmfast/plotting.py
+++ b/src/py21cmfast/plotting.py
@@ -494,9 +494,13 @@ def plot_global_history(
     else:
         value = getattr(lightcone, "global_" + kind)
 
-    sel = np.array(lightcone.node_redshifts) < zmax if zmax is not None else Ellipsis
+    sel = (
+        np.array(lightcone.inputs.node_redshifts) < zmax
+        if zmax is not None
+        else Ellipsis
+    )
 
-    ax.plot(np.array(lightcone.node_redshifts)[sel], value[sel], **kwargs)
+    ax.plot(np.array(lightcone.inputs.node_redshifts)[sel], value[sel], **kwargs)
     ax.set_xlabel("Redshift")
     if ylabel is None:
         ylabel = kind

--- a/src/py21cmfast/wrapper/inputs.py
+++ b/src/py21cmfast/wrapper/inputs.py
@@ -562,7 +562,7 @@ class UserParams(InputStruct):
     )
     AVG_BELOW_SAMPLER = field(default=True, converter=bool)
     HALOMASS_CORRECTION = field(
-        default=0.9, converter=float, validator=validators.gt(0)
+        default=0.89, converter=float, validator=validators.gt(0)
     )
     PARKINSON_G0 = field(default=1.0, converter=float, validator=validators.gt(0))
     PARKINSON_y1 = field(default=0.0, converter=float)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -81,3 +81,9 @@ def test_lc_sliceplot_sliceax(lc: p21c.LightCone):
 
     assert ax.yaxis.get_label().get_text() == "y-axis [Mpc]"
     assert ax.xaxis.get_label().get_text() == "x-axis [Mpc]"
+
+
+def test_global_plot(lc: p21c.LightCone):
+    fig, ax = plotting.plot_global_history(lc)
+
+    assert ax.xaxis.get_label().get_text() == "Redshift"


### PR DESCRIPTION
- Updated global plotting script for the new output structures, which were still using lightcone.node_redshifts, And added a test to check for it.
- Added the turnover masses back into the possible lightcone global quantities
- Changed the default HALOMASS_CORRECTION variable to produce slightly better results with the default timestep