### PR TITLE
Add pc and caching checks

### DIFF
--- a/src/py21cmfast/drivers/_param_config.py
+++ b/src/py21cmfast/drivers/_param_config.py
@@ -364,13 +364,15 @@ class _OutputStructComputationInspect:
         both needed and not initialised.
         In Future, may hold more backend state checks.
         """
+        # we need photon cons to be done before any non-IC box is computed
         if (
             inputs.flag_options.PHOTON_CONS_TYPE != "no-photoncons"
             and not lib.photon_cons_allocated
+            and issubclass(self._kls, OutputStructZ)
         ):
             raise ValueError(
                 "Photon conservation is needed but not initialised"
-                "Call `setup_photon_cons` or use the high-level functions."
+                " Call `setup_photon_cons` or use the high-level functions."
             )
 
     def _handle_read_from_cache(
@@ -389,7 +391,7 @@ class _OutputStructComputationInspect:
             return
 
         # First check whether the boxes already exist.
-        if issubclass(self._, OutputStructZ):
+        if issubclass(self._kls, OutputStructZ):
             obj = self._kls.new(inputs=inputs, redshift=current_redshfit)
         else:
             obj = self._kls.new(inputs=inputs)

--- a/src/py21cmfast/drivers/coeval.py
+++ b/src/py21cmfast/drivers/coeval.py
@@ -267,6 +267,12 @@ def evolve_perturb_halos(
     if not inputs.flag_options.USE_HALO_FIELD or inputs.flag_options.FIXED_HALO_GRIDS:
         return []
 
+    if not write.perturbed_halo_field and len(all_redshifts) > 1:
+        warnings.warn(
+            "You have turned off caching for the perturbed halo fields, but are"
+            "evolving them across multiple redshifts. This will result in very high memory usage"
+        )
+
     pt_halos = []
     kw = {
         "initial_conditions": initial_conditions,

--- a/src/py21cmfast/wrapper/photoncons.py
+++ b/src/py21cmfast/wrapper/photoncons.py
@@ -189,8 +189,8 @@ def _get_photon_nonconservation_data() -> dict:
 
 
 def setup_photon_cons(
+    initial_conditions: InitialConditions,
     inputs: InputParameters | None = None,
-    initial_conditions: InitialConditions | None = None,
     **kwargs,
 ):
     r"""
@@ -207,7 +207,7 @@ def setup_photon_cons(
     Parameters
     ----------
     inputs
-        An InputParameters instance.
+        An InputParameters instance. If not given will taken from initial_conditions.
     initial_conditions : :class:`~InitialConditions`, optional
         If given, the `inputs` will be set from this object, and it will not be
         re-calculated.
@@ -217,12 +217,7 @@ def setup_photon_cons(
     Any other parameters able to be passed to :func:`compute_initial_conditions`.
     """
     if inputs is None:
-        if initial_conditions is None:
-            raise ValueError(
-                "At least one of 'inputs' or 'initial_conditions' must be provided."
-            )
-        else:
-            inputs = initial_conditions.inputs
+        inputs = initial_conditions.inputs
 
     if inputs.flag_options.PHOTON_CONS_TYPE == "no-photoncons":
         return {}
@@ -261,7 +256,7 @@ def setup_photon_cons(
 
 def calibrate_photon_cons(
     inputs: InputParameters,
-    initial_conditions: InitialConditions | None,
+    initial_conditions: InitialConditions,
     **kwargs,
 ):
     r"""
@@ -269,9 +264,9 @@ def calibrate_photon_cons(
 
     Parameters
     ----------
-    inputs
-        An InputParameters instance.
-    initial_conditions : :class:`~InitialConditions`, optional
+    inputs: :class:`~InputParameters`
+        An InputParameters instance, must be compatible with the initial_conditions.
+    initial_conditions : :class:`~InitialConditions`
         If given, the `inputs` will be set from this object, and it will not be
         re-calculated.
 

--- a/tests/test_drivers_coev.py
+++ b/tests/test_drivers_coev.py
@@ -41,3 +41,26 @@ def test_coeval_lowerz_than_photon_cons(
             ),
             cache=cache,
         )
+
+
+def test_coeval_warnings(default_input_struct_lc):
+    # test for no caching with halo fields
+    with pytest.warns(UserWarning, match="You have turned off caching"):
+        inputs = default_input_struct_lc.evolve_input_structs(
+            USE_HALO_FIELD=True,
+        )
+        run_coeval(
+            out_redshifts=8.0,
+            inputs=inputs,
+            write=False,
+        )
+
+    # test for minimum node redshift > out_redshifts
+    with pytest.warns(UserWarning, match="minimum node redshift"):
+        inputs = default_input_struct_lc.evolve_input_structs(
+            USE_TS_FLUCT=True,
+        )
+        run_coeval(
+            inputs=inputs,
+            out_redshifts=8.0,
+        )


### PR DESCRIPTION
This PR adds two checks
- If the photon conservation hasn't been initialised and one of the models is being used, throw an error
- If you turn caching off and use the halo field, give a warning about the high memory usage

Tests have been added for the warnings