### PR TITLE
Fixing Some Issues with New Mturn Paramterisation

### DIFF
--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -126,7 +126,7 @@ int get_box_averages(double M_min, double M_max, double M_turn_a, double M_turn_
                                             1., consts->Mlim_Fstar_mini, 0.);
     }
     if(flag_options_global->USE_TS_FLUCT){
-        integral_xray = Xray_General(consts->redshift, lnMmin, lnMmax, M_turn_m, M_turn_a,
+        integral_xray = Xray_General(consts->redshift, lnMmin, lnMmax, M_turn_a, M_turn_m,
                                             consts->alpha_star, consts->alpha_star_mini, consts->fstar_10,
                                             consts->fstar_7, consts->l_x, consts->l_x_mini, consts->t_h, consts->t_star,
                                             consts->Mlim_Fstar, consts->Mlim_Fstar_mini);
@@ -250,7 +250,7 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes,
             if(min_log10_mturn_a > mturn_a_grid[i]) min_log10_mturn_a = mturn_a_grid[i];
             if(min_log10_mturn_m > mturn_m_grid[i]) min_log10_mturn_m = mturn_m_grid[i];
             if(max_log10_mturn_a < mturn_a_grid[i]) max_log10_mturn_a = mturn_a_grid[i];
-            if(max_log10_mturn_m < mturn_m_grid[i]) max_log10_mturn_m = mturn_a_grid[i];
+            if(max_log10_mturn_m < mturn_m_grid[i]) max_log10_mturn_m = mturn_m_grid[i];
 
             l10_mlim_a_sum += mturn_a_grid[i];
             l10_mlim_m_sum += mturn_m_grid[i];
@@ -275,34 +275,25 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes,
         }
 
         //This table assumes no reionisation feedback
-        initialise_SFRD_Conditional_table(min_density,max_density,growth_z,consts->mturn_a_nofb,M_min,M_max,M_cell,
-                                                consts->alpha_star, consts->alpha_star_mini, consts->fstar_10,
-                                                consts->fstar_7, user_params_global->INTEGRATION_METHOD_ATOMIC,
-                                                user_params_global->INTEGRATION_METHOD_MINI,
-                                                flag_options_global->USE_MINI_HALOS);
+        initialise_SFRD_Conditional_table(consts->redshift,min_density,max_density,M_min,M_max,M_cell,
+                                            consts->alpha_star, consts->alpha_star_mini, consts->fstar_10,
+                                            consts->fstar_7);
 
         //This table includes reionisation feedback, but takes the atomic turnover anyway for the upper turnover
-        initialise_Nion_Conditional_spline(consts->redshift,consts->mturn_a_nofb,min_density,max_density,M_min,M_max,M_cell,
+        initialise_Nion_Conditional_spline(consts->redshift,min_density,max_density,M_min,M_max,M_cell,
                                 min_log10_mturn_a,max_log10_mturn_a,min_log10_mturn_m,max_log10_mturn_m,
                                 consts->alpha_star, consts->alpha_star_mini,
                                 consts->alpha_esc, consts->fstar_10,
-                                consts->fesc_10,consts->Mlim_Fstar,consts->Mlim_Fesc,consts->fstar_7,
-                                consts->fesc_7,consts->Mlim_Fstar_mini, consts->Mlim_Fesc_mini,
-                                user_params_global->INTEGRATION_METHOD_ATOMIC,
-                                user_params_global->INTEGRATION_METHOD_MINI,
-                                flag_options_global->USE_MINI_HALOS, false);
+                                consts->fesc_10,consts->fstar_7,
+                                consts->fesc_7, false);
 
         initialise_dNdM_tables(min_density, max_density, lnMmin, lnMmax, growth_z, lnMcell, false);
         if(flag_options_global->USE_TS_FLUCT){
             initialise_Xray_Conditional_table(
-                min_density, max_density, consts->redshift, growth_z, consts->mturn_a_nofb, M_min, M_max, M_cell,
+                min_density, max_density, consts->redshift, M_min, M_max, M_cell,
                 consts->alpha_star, consts->alpha_star_mini,
                 consts->fstar_10, consts->fstar_7, consts->l_x, consts->l_x_mini, consts->t_h,
-                consts->t_star,
-                user_params_global->INTEGRATION_METHOD_ATOMIC,
-                user_params_global->INTEGRATION_METHOD_MINI,
-                flag_options_global->USE_MINI_HALOS
-            );
+                consts->t_star);
         }
     }
 
@@ -334,19 +325,19 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes,
             intgrl_fesc_weighted = EvaluateNion_Conditional(dens,l10_mturn_a,growth_z,M_min,M_max,M_cell,sigma_cell,
                                             consts->Mlim_Fstar,consts->Mlim_Fesc,false);
             intgrl_stars_only = EvaluateSFRD_Conditional(dens,growth_z,M_min,M_max,M_cell,sigma_cell,
-                                            l10_mturn_a,consts->Mlim_Fstar);
+                                            pow(10.,l10_mturn_a),consts->Mlim_Fstar);
             if(flag_options_global->USE_MINI_HALOS){
                 intgrl_stars_only_mini = EvaluateSFRD_Conditional_MINI(dens,l10_mturn_m,growth_z,M_min,M_max,M_cell,sigma_cell,
-                                                            l10_mturn_a,consts->Mlim_Fstar);
+                                                            pow(10.,l10_mturn_a),consts->Mlim_Fstar);
                 intgrl_fesc_weighted_mini = EvaluateNion_Conditional_MINI(dens,l10_mturn_m,growth_z,M_min,M_max,M_cell,sigma_cell,
-                                                            l10_mturn_a,consts->Mlim_Fstar,consts->Mlim_Fesc,false);
+                                                            pow(10.,l10_mturn_a),consts->Mlim_Fstar,consts->Mlim_Fesc,false);
             }
 
             if(flag_options_global->USE_TS_FLUCT){
                 //MAKE A NEW TABLEdouble delta, double log10Mturn_m, double growthf, double M_min, double M_max, double M_cond, double sigma_max,
                                   //   double Mturn_a, double Mlim_Fstar, double Mlim_Fstar_MINI
                 integral_xray = EvaluateXray_Conditional(dens,l10_mturn_m,consts->redshift,growth_z,M_min,M_max,M_cell,sigma_cell,
-                                                            l10_mturn_a,consts->t_h,consts->Mlim_Fstar,consts->Mlim_Fstar_mini);
+                                                            pow(10.,l10_mturn_a),consts->t_h,consts->Mlim_Fstar,consts->Mlim_Fstar_mini);
             }
 
             grids->count[i] = (int)(h_count * M_cell * dens_fac); //NOTE: truncated

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -677,26 +677,24 @@ void setup_integration_tables(struct FilteredGrids *fg_struct, struct IonBoxCons
             log10Mturn_max_MINI = log10Mturn_max_MINI * 1.01;
 
             //current redshift tables (automatically handles minihalo case)
-            initialise_Nion_Conditional_spline(consts->redshift,consts->mturn_a_nofb,min_density,max_density,consts->M_min,rspec.M_max_R,rspec.M_max_R,
+            initialise_Nion_Conditional_spline(consts->redshift,min_density,max_density,
+                                    consts->M_min,rspec.M_max_R,rspec.M_max_R,
                                     log10Mturn_min,log10Mturn_max,log10Mturn_min_MINI,log10Mturn_max_MINI,
                                     consts->alpha_star, consts->alpha_star_mini,
                                     consts->alpha_esc,consts->fstar_10,
-                                    consts->fesc_10,consts->Mlim_Fstar,consts->Mlim_Fesc,consts->fstar_7,
-                                    consts->fesc_7,consts->Mlim_Fstar_mini,consts->Mlim_Fesc_mini,
-                                    user_params_global->INTEGRATION_METHOD_ATOMIC, user_params_global->INTEGRATION_METHOD_MINI,
-                                    flag_options_global->USE_MINI_HALOS,false);
+                                    consts->fesc_10,consts->fstar_7,
+                                    consts->fesc_7,false);
 
             //previous redshift tables if needed
             if(need_prev && flag_options_global->USE_MINI_HALOS){
                 //NOTE: we intentionally use the lower turnovers at this redshift, but should we be doing the same for the upper turnover?
-                initialise_Nion_Conditional_spline(consts->prev_redshift,consts->mturn_a_nofb,prev_min_density,prev_max_density,consts->M_min,rspec.M_max_R,rspec.M_max_R,
+                initialise_Nion_Conditional_spline(consts->prev_redshift,prev_min_density,prev_max_density,
+                                        consts->M_min,rspec.M_max_R,rspec.M_max_R,
                                         log10Mturn_min,log10Mturn_max,log10Mturn_min_MINI,log10Mturn_max_MINI,
                                         consts->alpha_star, consts->alpha_star_mini,
                                         consts->alpha_esc,consts->fstar_10,
-                                        consts->fesc_10,consts->Mlim_Fstar,consts->Mlim_Fesc,consts->fstar_7,
-                                        consts->fstar_7,consts->Mlim_Fstar_mini,consts->Mlim_Fesc_mini,
-                                        user_params_global->INTEGRATION_METHOD_ATOMIC, user_params_global->INTEGRATION_METHOD_MINI,
-                                        flag_options_global->USE_MINI_HALOS,true);
+                                        consts->fesc_10,consts->fstar_7,
+                                        consts->fstar_7,true);
             }
         }
     }

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -851,13 +851,11 @@ int global_reion_properties(double zp, double x_e_ave, double *log10_Mcrit_LW_av
             /* initialise interpolation of the mean collapse fraction for global reionization.*/
             initialise_Nion_Ts_spline(zpp_interp_points_SFR, determine_zpp_min, determine_zpp_max,
                                         astro_params_global->ALPHA_STAR, astro_params_global->ALPHA_STAR_MINI, astro_params_global->ALPHA_ESC,
-                                        astro_params_global->F_STAR10, astro_params_global->F_ESC10, astro_params_global->F_STAR7_MINI, astro_params_global->F_ESC7_MINI,
-                                        astro_params_global->M_TURN, flag_options_global->USE_MINI_HALOS);
+                                        astro_params_global->F_STAR10, astro_params_global->F_ESC10, astro_params_global->F_STAR7_MINI, astro_params_global->F_ESC7_MINI);
 
             initialise_SFRD_spline(zpp_interp_points_SFR, determine_zpp_min, determine_zpp_max,
                                     astro_params_global->ALPHA_STAR, astro_params_global->ALPHA_STAR_MINI,
-                                    astro_params_global->F_STAR10, astro_params_global->F_STAR7_MINI,astro_params_global->M_TURN,
-                                    flag_options_global->USE_MINI_HALOS);
+                                    astro_params_global->F_STAR10, astro_params_global->F_STAR7_MINI);
         }
         else{
             init_FcollTable(determine_zpp_min,determine_zpp_max,true);
@@ -906,12 +904,11 @@ void calculate_sfrd_from_grid(int R_ct, float *dens_R_grid, float *Mcrit_R_grid,
 
     if(user_params_global->USE_INTERPOLATION_TABLES){
         if(flag_options_global->USE_MASS_DEPENDENT_ZETA){
-            initialise_SFRD_Conditional_table(min_densities[R_ct]*zpp_growth[R_ct],
-                                                    max_densities[R_ct]*zpp_growth[R_ct]*1.001,zpp_growth[R_ct],Mcrit_atom_interp_table[R_ct],
-                                                    M_min_R[R_ct],M_max_R[R_ct],M_max_R[R_ct],
-                                                    astro_params_global->ALPHA_STAR, astro_params_global->ALPHA_STAR_MINI, astro_params_global->F_STAR10,
-                                                    astro_params_global->F_STAR7_MINI, user_params_global->INTEGRATION_METHOD_ATOMIC, user_params_global->INTEGRATION_METHOD_MINI,
-                                                    flag_options_global->USE_MINI_HALOS);
+            initialise_SFRD_Conditional_table(zpp_for_evolve_list[R_ct],
+                min_densities[R_ct]*zpp_growth[R_ct],max_densities[R_ct]*zpp_growth[R_ct]*1.001,
+                M_min_R[R_ct],M_max_R[R_ct],M_max_R[R_ct],
+                astro_params_global->ALPHA_STAR, astro_params_global->ALPHA_STAR_MINI,
+                astro_params_global->F_STAR10, astro_params_global->F_STAR7_MINI);
         }
         else{
             initialise_FgtrM_delta_table(min_densities[R_ct]*zpp_growth[R_ct], max_densities[R_ct]*zpp_growth[R_ct], zpp_for_evolve_list[R_ct],

--- a/src/py21cmfast/src/_functionprototypes_wrapper.h
+++ b/src/py21cmfast/src/_functionprototypes_wrapper.h
@@ -83,26 +83,22 @@ void Broadcast_struct_global_all( UserParams *user_params,  CosmoParams *cosmo_p
 /* Interpolation Table Functions */
 //Initialisation
 void initialiseSigmaMInterpTable(float M_Min, float M_Max);
-void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_star_mini, float Fstar10, float Fstar7_MINI,
-                             float mturn_a_const, bool minihalos);
+void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_star_mini, float Fstar10, float Fstar7_MINI);
 void initialise_Nion_Ts_spline(int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_star_mini, float Alpha_esc, float Fstar10,
-                                float Fesc10, float Fstar7_MINI, float Fesc7_MINI, float mturn_a_const, bool minihalos);
+                                float Fesc10, float Fstar7_MINI, float Fesc7_MINI);
 void initialise_FgtrM_delta_table(double min_dens, double max_dens, double zpp, double growth_zpp, double smin_zpp, double smax_zpp);
 void init_FcollTable(double zmin, double zmax, bool x_ray);
-void initialise_Nion_Conditional_spline(double z, double Mcrit_atom, double min_density, double max_density,
+void initialise_Nion_Conditional_spline(double z, double min_density, double max_density,
                                      double Mmin, double Mmax, double Mcond, double log10Mturn_min, double log10Mturn_max,
                                      double log10Mturn_min_MINI, double log10Mturn_max_MINI, float Alpha_star,
                                      float Alpha_star_mini, float Alpha_esc, float Fstar10, float Fesc10,
-                                     float Mlim_Fstar, float Mlim_Fesc, float Fstar7_MINI, float Fesc7_MINI,
-                                     float Mlim_Fstar_MINI, float Mlim_Fesc_MINI, int method, int method_mini,
-                                     bool minihalos, bool prev);
-void initialise_SFRD_Conditional_table(double min_density, double max_density, double growthf,
-                                    float Mcrit_atom, double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
-                                    float Fstar10, float Fstar7_MINI, int method, int method_mini, bool minihalos);
-void initialise_Xray_Conditional_table(double min_density, double max_density, double redshift, double growthf,
-                                    float Mcrit_atom, double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
-                                    float Fstar10, float Fstar7_MINI, double l_x, double l_x_mini, double t_h, double t_star,
-                                    int method, int method_mini, bool minihalos);
+                                     float Fstar7_MINI, float Fesc7_MINI, bool prev);
+void initialise_SFRD_Conditional_table(double z, double min_density, double max_density,
+                                    double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
+                                    float Fstar10, float Fstar7_MINI);
+void initialise_Xray_Conditional_table(double min_density, double max_density, double redshift,
+                                    double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
+                                    float Fstar10, float Fstar7_MINI, double l_x, double l_x_mini, double t_h, double t_star);
 
 void initialise_dNdM_tables(double xmin, double xmax, double ymin, double ymax, double growth1, double param, bool from_catalog);
 void initialise_dNdM_inverse_table(double xmin, double xmax, double lnM_min, double growth1, double param, bool from_catalog);
@@ -141,14 +137,14 @@ double Nion_ConditionalM_MINI(double growthf, double lnM1, double lnM2, double M
                             double MassTurnover_upper, double Alpha_star, double Alpha_esc, double Fstar7,
                             double Fesc7, double Mlim_Fstar, double Mlim_Fesc, int method);
 double Xray_ConditionalM(double redshift, double growthf, double lnM1, double lnM2, double lnM_cond, double sigma2, double delta2,
-                         double MassTurnover, double MassTurnover_upper,
+                         double mturn_acg, double mturn_mcg,
                         double Alpha_star, double Alpha_star_mini, double Fstar10, double Fstar7, double Mlim_Fstar,
                         double Mlim_Fstar_mini, double l_x, double l_x_mini, double t_h, double t_star, int method);
 double Nion_General(double z, double lnM_Min, double lnM_Max, double MassTurnover, double Alpha_star, double Alpha_esc, double Fstar10,
                      double Fesc10, double Mlim_Fstar, double Mlim_Fesc);
 double Nion_General_MINI(double z, double lnM_Min, double lnM_Max, double MassTurnover, double MassTurnover_upper, double Alpha_star,
                          double Alpha_esc, double Fstar7_MINI, double Fesc7_MINI, double Mlim_Fstar, double Mlim_Fesc);
-double Xray_General(double z, double lnM_Min, double lnM_Max, double MassTurnover, double MassTurnover_upper, double Alpha_star,
+double Xray_General(double z, double lnM_Min, double lnM_Max, double mturn_acg, double mturn_mcg, double Alpha_star,
                      double Alpha_star_mini, double Fstar10, double Fstar7, double l_x, double l_x_mini, double t_h,
                      double t_star, double Mlim_Fstar, double Mlim_Fstar_mini);
 double Fcoll_General(double z, double lnM_min, double lnM_max);

--- a/src/py21cmfast/src/hmf.c
+++ b/src/py21cmfast/src/hmf.c
@@ -58,7 +58,7 @@ struct parameters_gsl_MF_integrals{
     double delta;
 
     //SFR additions
-    double Mturn;
+    double Mturn_acg;
     double f_star_norm;
     double alpha_star;
     double Mlim_star;
@@ -69,6 +69,7 @@ struct parameters_gsl_MF_integrals{
     double Mlim_esc;
 
     //Minihalo additions
+    double Mturn_mcg;
     double Mturn_upper;
 
     //X-ray additions
@@ -340,7 +341,7 @@ double nion_fraction(double lnM, void *param_struct){
     double Fstar = log_scaling_PL_limit(lnM,p.f_star_norm,p.alpha_star,10*LN10,p.Mlim_star);
     double Fesc = log_scaling_PL_limit(lnM,p.f_esc_norm,p.alpha_esc,10*LN10,p.Mlim_esc);
 
-    return exp(Fstar + Fesc - p.Mturn/exp(lnM) + lnM);
+    return exp(Fstar + Fesc - p.Mturn_acg/exp(lnM) + lnM);
 }
 
 double nion_fraction_mini(double lnM, void *param_struct){
@@ -349,7 +350,7 @@ double nion_fraction_mini(double lnM, void *param_struct){
     double Fesc = log_scaling_PL_limit(lnM,p.f_esc_norm,p.alpha_esc,7*LN10,p.Mlim_esc);
     double M = exp(lnM);
 
-    return exp(Fstar + Fesc - M/p.Mturn_upper - p.Mturn/M + lnM);
+    return exp(Fstar + Fesc - M/p.Mturn_upper - p.Mturn_mcg/M + lnM);
 }
 
 //Due to the log(1+Mstar) in the metallicity, this is hard to simplify into log-space
@@ -358,12 +359,12 @@ double nion_fraction_mini(double lnM, void *param_struct){
 double xray_fraction_doublePL(double lnM, void *param_struct){
     struct parameters_gsl_MF_integrals p = *(struct parameters_gsl_MF_integrals *)param_struct;
     double M = exp(lnM);
-    double Fstar = exp(log_scaling_PL_limit(lnM,p.f_star_norm,p.alpha_star,10*LN10,p.Mlim_star) - p.Mturn_upper/M + p.f_star_norm);
+    double Fstar = exp(log_scaling_PL_limit(lnM,p.f_star_norm,p.alpha_star,10*LN10,p.Mlim_star) - p.Mturn_acg/M + p.f_star_norm);
 
     //using the escape fraction variables for minihalos
     double Fstar_mini = 0.;
     if(flag_options_global->USE_MINI_HALOS)
-        Fstar_mini = exp(log_scaling_PL_limit(lnM,p.f_esc_norm,p.alpha_esc,7*LN10,p.Mlim_esc) - p.Mturn/M - M/p.Mturn_upper + p.f_esc_norm);
+        Fstar_mini = exp(log_scaling_PL_limit(lnM,p.f_esc_norm,p.alpha_esc,7*LN10,p.Mlim_esc) - p.Mturn_mcg/M - M/p.Mturn_upper + p.f_esc_norm);
 
     double stars = M*Fstar*cosmo_params_global->OMb/cosmo_params_global->OMm;
     double stars_mini = M*Fstar_mini*cosmo_params_global->OMb/cosmo_params_global->OMm;
@@ -501,10 +502,10 @@ double IntegratedNdM_QAG(double lnM_lo, double lnM_hi, struct parameters_gsl_MF_
                     lower_limit,exp(lower_limit),upper_limit,exp(upper_limit),rel_tol,result,error);
         LOG_ERROR("data: z=%.3e growthf=%.3e  HMF=%d ",params.redshift,params.growthf,params.HMF);
         LOG_ERROR("sigma=%.3e delta=%.3e",params.sigma_cond,params.delta);
-        LOG_ERROR("Mturn_lo=%.3e f*=%.3e a*=%.3e Mlim*=%.3e",params.Mturn,params.f_star_norm,params.alpha_star,params.Mlim_star);
+        LOG_ERROR("Mturn_acg=%.3e f*=%.3e a*=%.3e Mlim*=%.3e",params.Mturn_acg,params.f_star_norm,params.alpha_star,params.Mlim_star);
         LOG_ERROR("f_escn=%.3e a_esc=%.3e Mlim_esc=%.3e",params.f_esc_norm,params.alpha_esc,params.Mlim_esc);
         LOG_ERROR("t_*=%.3e t_h=%.3e lx=%.3e lxmini %.3e",params.t_star,params.t_h,params.l_x_norm,params.l_x_norm_mini);
-        LOG_ERROR("Mturn_hi %.3e gamma_type %d",params.Mturn_upper,params.gamma_type);
+        LOG_ERROR("Mturn_mcg %.3e Mturn_up %.3e gamma_type %d",params.Mturn_mcg,params.Mturn_upper,params.gamma_type);
         CATCH_GSL_ERROR(status);
     }
 
@@ -637,7 +638,7 @@ double MFIntegral_Approx(double lnM_lo, double lnM_hi, struct parameters_gsl_MF_
     double lnM_lo_limit = lnM_lo;
     double lnM_hi_limit = lnM_hi;
     //(Speed): by passing in log(M_turnover) i can avoid these 2 log calls
-    double lnMturn_l = log(params.Mturn);
+    double lnMturn_l = abs(params.gamma_type < 4) ? log(params.Mturn_acg) : log(params.Mturn_mcg);
     double lnMturn_u = log(params.Mturn_upper);
     //(Speed): LOG(MPIVOTn) can be pre-defined via macro
     double lnMp1 = log(MPIVOT1);
@@ -810,7 +811,7 @@ double Nion_General(double z, double lnM_Min, double lnM_Max, double MassTurnove
     struct parameters_gsl_MF_integrals params = {
         .redshift = z,
         .growthf = dicke(z),
-        .Mturn = MassTurnover,
+        .Mturn_acg = MassTurnover,
         .alpha_star = Alpha_star,
         .alpha_esc = Alpha_esc,
         .f_star_norm = log(Fstar10),
@@ -828,7 +829,7 @@ double Nion_General_MINI(double z, double lnM_Min, double lnM_Max, double MassTu
     struct parameters_gsl_MF_integrals params = {
         .redshift = z,
         .growthf = dicke(z),
-        .Mturn = MassTurnover,
+        .Mturn_mcg = MassTurnover,
         .Mturn_upper = MassTurnover_upper,
         .alpha_star = Alpha_star,
         .alpha_esc = Alpha_esc,
@@ -842,14 +843,15 @@ double Nion_General_MINI(double z, double lnM_Min, double lnM_Max, double MassTu
     return IntegratedNdM(lnM_Min,lnM_Max,params,&u_nion_integrand_mini,0);
 }
 
-double Xray_General(double z, double lnM_Min, double lnM_Max, double MassTurnover, double MassTurnover_upper, double Alpha_star,
+double Xray_General(double z, double lnM_Min, double lnM_Max, double mturn_acg, double mturn_mcg, double Alpha_star,
                      double Alpha_star_mini, double Fstar10, double Fstar7, double l_x, double l_x_mini, double t_h,
                      double t_star, double Mlim_Fstar, double Mlim_Fstar_mini){
     struct parameters_gsl_MF_integrals params = {
         .redshift = z,
         .growthf = dicke(z),
-        .Mturn = MassTurnover,
-        .Mturn_upper = MassTurnover_upper,
+        .Mturn_acg = mturn_acg,
+        .Mturn_mcg = mturn_mcg,
+        .Mturn_upper = atomic_cooling_threshold(z),
         .alpha_star = Alpha_star,
         .alpha_esc = Alpha_star_mini,
         .f_star_norm = log(Fstar10),
@@ -914,7 +916,7 @@ double Nion_ConditionalM_MINI(double growthf, double lnM1, double lnM2, double l
                             double Fesc7, double Mlim_Fstar, double Mlim_Fesc, int method){
     struct parameters_gsl_MF_integrals params = {
         .growthf = growthf,
-        .Mturn = MassTurnover,
+        .Mturn_mcg = MassTurnover,
         .Mturn_upper = MassTurnover_upper,
         .alpha_star = Alpha_star,
         .alpha_esc = Alpha_esc,
@@ -953,7 +955,7 @@ double Nion_ConditionalM(double growthf, double lnM1, double lnM2, double lnM_co
                         double Mlim_Fesc, int method){
     struct parameters_gsl_MF_integrals params = {
         .growthf = growthf,
-        .Mturn = MassTurnover,
+        .Mturn_acg = MassTurnover,
         .alpha_star = Alpha_star,
         .alpha_esc = Alpha_esc,
         .f_star_norm = log(Fstar10),
@@ -984,15 +986,16 @@ double Nion_ConditionalM(double growthf, double lnM1, double lnM2, double lnM_co
 }
 
 double Xray_ConditionalM(double redshift, double growthf, double lnM1, double lnM2, double lnM_cond, double sigma2, double delta2,
-                         double MassTurnover, double MassTurnover_upper,
+                         double mturn_acg, double mturn_mcg,
                         double Alpha_star, double Alpha_star_mini, double Fstar10, double Fstar7, double Mlim_Fstar,
                         double Mlim_Fstar_mini, double l_x, double l_x_mini, double t_h, double t_star, int method){
     //re-using escape fraction for minihalo parameters
     struct parameters_gsl_MF_integrals params = {
         .redshift = redshift,
         .growthf = growthf,
-        .Mturn = MassTurnover,
-        .Mturn_upper = MassTurnover_upper,
+        .Mturn_acg = mturn_acg,
+        .Mturn_mcg = mturn_mcg,
+        .Mturn_upper = atomic_cooling_threshold(redshift),
         .alpha_star = Alpha_star,
         .alpha_esc = Alpha_star_mini,
         .f_star_norm = log(Fstar10),

--- a/src/py21cmfast/src/hmf.h
+++ b/src/py21cmfast/src/hmf.h
@@ -20,14 +20,14 @@ double Nion_ConditionalM_MINI(double growthf, double lnM1, double lnM2, double l
                             double MassTurnover_upper, double Alpha_star, double Alpha_esc, double Fstar7,
                             double Fesc7, double Mlim_Fstar, double Mlim_Fesc, int method);
 double Xray_ConditionalM(double redshift, double growthf, double lnM1, double lnM2, double lnM_cond, double sigma2, double delta2,
-                         double MassTurnover, double MassTurnover_upper,
+                         double mturn_acg, double mturn_mcg,
                         double Alpha_star, double Alpha_star_mini, double Fstar10, double Fstar7, double Mlim_Fstar,
                         double Mlim_Fstar_mini, double l_x, double l_x_mini, double t_h, double t_star, int method);
 double Nion_General(double z, double lnM_Min, double lnM_Max, double MassTurnover, double Alpha_star, double Alpha_esc, double Fstar10,
                      double Fesc10, double Mlim_Fstar, double Mlim_Fesc);
 double Nion_General_MINI(double z, double lnM_Min, double lnM_Max, double MassTurnover, double MassTurnover_upper, double Alpha_star,
                          double Alpha_esc, double Fstar7_MINI, double Fesc7_MINI, double Mlim_Fstar, double Mlim_Fesc);
-double Xray_General(double z, double lnM_Min, double lnM_Max, double MassTurnover, double MassTurnover_upper, double Alpha_star,
+double Xray_General(double z, double lnM_Min, double lnM_Max, double mturn_acg, double mturn_mcg, double Alpha_star,
                      double Alpha_star_mini, double Fstar10, double Fstar7, double l_x, double l_x_mini, double t_h,
                      double t_star, double Mlim_Fstar, double Mlim_Fstar_mini);
 double Nhalo_General(double z, double lnM_min, double lnM_max);

--- a/src/py21cmfast/src/interp_tables.c
+++ b/src/py21cmfast/src/interp_tables.c
@@ -77,8 +77,7 @@ static RGTable1D_f dSigmasqdm_InterpTable = {.allocated = false,};
 
 //NOTE: this table is initialised for up to N_redshift x N_Mturn, but only called N_filter times to assign ST_over_PS in Spintemp.
 //  It may be better to just do the integrals at each R
-void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_star_mini, float Fstar10, float Fstar7_MINI,
-                             float mturn_a_const, bool minihalos){
+void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_star_mini, float Fstar10, float Fstar7_MINI){
     int i,j;
     float Mlim_Fstar;
     float Mlim_Fstar_MINI=0.;
@@ -91,7 +90,7 @@ void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, 
     if (!SFRD_z_table.allocated){
         allocate_RGTable1D(Nbin,&SFRD_z_table);
     }
-    if(minihalos && !SFRD_z_table_MINI.allocated){
+    if(flag_options_global->USE_MINI_HALOS && !SFRD_z_table_MINI.allocated){
         allocate_RGTable2D(Nbin,NMTURN,&SFRD_z_table_MINI);
     }
 
@@ -99,7 +98,7 @@ void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, 
     SFRD_z_table.x_width = (zmax - zmin)/((double)Nbin-1.);
 
     Mlim_Fstar = Mass_limit_bisection(Mmin, Mmax, Alpha_star, Fstar10);
-    if(minihalos){
+    if(flag_options_global->USE_MINI_HALOS){
         SFRD_z_table_MINI.x_min = zmin;
         SFRD_z_table_MINI.x_width = (zmax - zmin)/((double)Nbin-1.);
         SFRD_z_table_MINI.y_min = LOG10_MTURN_MIN;
@@ -109,7 +108,8 @@ void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, 
 
     #pragma omp parallel private(i,j) num_threads(user_params_global->N_THREADS)
     {
-        double Mcrit_atom_val = mturn_a_const;
+        double Mturn_acg = astro_params_global->M_TURN;
+        double acg_thresh;
         double mturn_val;
         double lnMmin;
         double z_val;
@@ -117,16 +117,17 @@ void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, 
         for (i=0; i<Nbin; i++){
             z_val = SFRD_z_table.x_min + i*SFRD_z_table.x_width; //both tables will have the same values here
             lnMmin = log(minimum_source_mass(z_val,true,astro_params_global,flag_options_global));
-            if(minihalos) Mcrit_atom_val = atomic_cooling_threshold(z_val);
 
-            SFRD_z_table.y_arr[i] = Nion_General(z_val, lnMmin, lnMmax, Mcrit_atom_val, Alpha_star, 0., Fstar10, 1.,Mlim_Fstar,0.);
-            if(minihalos){
+            if(flag_options_global->USE_MINI_HALOS){
+                acg_thresh = atomic_cooling_threshold(z_val);
+                Mturn_acg = fmax(astro_params_global->M_TURN,acg_thresh);
                 for (j=0; j<NMTURN; j++){
                     mturn_val = pow(10,SFRD_z_table_MINI.y_min + j*SFRD_z_table_MINI.y_width);
-                    SFRD_z_table_MINI.z_arr[i][j] = Nion_General_MINI(z_val, lnMmin, lnMmax, mturn_val, Mcrit_atom_val, Alpha_star_mini,
+                    SFRD_z_table_MINI.z_arr[i][j] = Nion_General_MINI(z_val, lnMmin, lnMmax, mturn_val, acg_thresh, Alpha_star_mini,
                                                                  0., Fstar7_MINI, 1.,Mlim_Fstar_MINI,0.);
                 }
             }
+            SFRD_z_table.y_arr[i] = Nion_General(z_val, lnMmin, lnMmax, Mturn_acg, Alpha_star, 0., Fstar10, 1.,Mlim_Fstar,0.);
         }
     }
 
@@ -135,7 +136,7 @@ void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, 
             LOG_ERROR("Detected either an infinite or NaN value in SFRD table");
             Throw(TableGenerationError);
         }
-        if(minihalos){
+        if(flag_options_global->USE_MINI_HALOS){
             for (j=0; j<NMTURN; j++){
                 if(isfinite(SFRD_z_table_MINI.z_arr[i][j])==0) {
                     LOG_ERROR("Detected either an infinite or NaN value in SFRD_MINI table");
@@ -148,7 +149,7 @@ void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, 
 
 //Unlike the SFRD spline, this one is used more due to the nu_tau_one() rootfind
 void initialise_Nion_Ts_spline(int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_star_mini, float Alpha_esc, float Fstar10,
-                                float Fesc10, float Fstar7_MINI, float Fesc7_MINI, float mturn_a_const, bool minihalos){
+                                float Fesc10, float Fstar7_MINI, float Fesc7_MINI){
     int i,j;
     float Mlim_Fstar, Mlim_Fesc;
     float Mlim_Fstar_MINI=0., Mlim_Fesc_MINI=0.;
@@ -160,7 +161,7 @@ void initialise_Nion_Ts_spline(int Nbin, float zmin, float zmax, float Alpha_sta
     if (!Nion_z_table.allocated){
         allocate_RGTable1D(Nbin,&Nion_z_table);
     }
-    if(minihalos && !Nion_z_table_MINI.allocated){
+    if(flag_options_global->USE_MINI_HALOS && !Nion_z_table_MINI.allocated){
         allocate_RGTable2D(Nbin,NMTURN,&Nion_z_table_MINI);
     }
     Nion_z_table.x_min = zmin;
@@ -168,7 +169,7 @@ void initialise_Nion_Ts_spline(int Nbin, float zmin, float zmax, float Alpha_sta
 
     Mlim_Fstar = Mass_limit_bisection(Mmin, Mmax, Alpha_star, Fstar10);
     Mlim_Fesc = Mass_limit_bisection(Mmin, Mmax, Alpha_esc, Fesc10);
-    if(minihalos){
+    if(flag_options_global->USE_MINI_HALOS){
         Nion_z_table_MINI.x_min = zmin;
         Nion_z_table_MINI.x_width = (zmax - zmin)/((double)Nbin-1.);
         Nion_z_table_MINI.y_min = LOG10_MTURN_MIN;
@@ -179,7 +180,8 @@ void initialise_Nion_Ts_spline(int Nbin, float zmin, float zmax, float Alpha_sta
 
 #pragma omp parallel private(i,j) num_threads(user_params_global->N_THREADS)
     {
-        double Mcrit_atom_val = mturn_a_const;
+        double Mturn_acg = astro_params_global->M_TURN;
+        double acg_thresh;
         double mturn_val;
         double z_val;
         double lnMmin;
@@ -188,18 +190,17 @@ void initialise_Nion_Ts_spline(int Nbin, float zmin, float zmax, float Alpha_sta
             z_val = Nion_z_table.x_min + i*Nion_z_table.x_width; //both tables will have the same values here
             //Minor note: while this is called in xray, we use it to estimate ionised fraction, do we use ION_Tvir_MIN if applicable?
             lnMmin = log(minimum_source_mass(z_val,true,astro_params_global,flag_options_global));
-            if(minihalos) Mcrit_atom_val = atomic_cooling_threshold(z_val);
-
-            Nion_z_table.y_arr[i] = Nion_General(z_val, lnMmin, lnMmax, Mcrit_atom_val, Alpha_star, Alpha_esc, Fstar10, Fesc10,
-                                             Mlim_Fstar, Mlim_Fesc);
-
-            if(minihalos){
+            if(flag_options_global->USE_MINI_HALOS){
+                acg_thresh = atomic_cooling_threshold(z_val);
+                Mturn_acg = fmax(astro_params_global->M_TURN,acg_thresh);
                 for (j=0; j<NMTURN; j++){
                     mturn_val = pow(10,Nion_z_table_MINI.y_min + j*Nion_z_table_MINI.y_width);
-                    Nion_z_table_MINI.z_arr[i][j] = Nion_General_MINI(z_val, lnMmin, lnMmax, mturn_val, Mcrit_atom_val, Alpha_star_mini, Alpha_esc,
+                    Nion_z_table_MINI.z_arr[i][j] = Nion_General_MINI(z_val, lnMmin, lnMmax, mturn_val, acg_thresh, Alpha_star_mini, Alpha_esc,
                                                      Fstar7_MINI, Fesc7_MINI, Mlim_Fstar_MINI, Mlim_Fesc_MINI);
                 }
             }
+            Nion_z_table.y_arr[i] = Nion_General(z_val, lnMmin, lnMmax, Mturn_acg, Alpha_star, Alpha_esc, Fstar10, Fesc10,
+                                             Mlim_Fstar, Mlim_Fesc);
         }
     }
 
@@ -208,7 +209,7 @@ void initialise_Nion_Ts_spline(int Nbin, float zmin, float zmax, float Alpha_sta
             LOG_ERROR("Detected either an infinite or NaN value in Nion_z_val");
             Throw(TableGenerationError);
         }
-        if(minihalos){
+        if(flag_options_global->USE_MINI_HALOS){
             for (j=0; j<NMTURN; j++){
                 if(isfinite(Nion_z_table_MINI.z_arr[i][j])==0){
                     LOG_ERROR("Detected either an infinite or NaN value in Nion_z_val_MINI");
@@ -279,15 +280,14 @@ void init_FcollTable(double zmin, double zmax, bool x_ray){
 //NOTE: SFRD tables have fixed Mturn range, Nion tables vary
 //NOTE: it would be slightly less accurate but maybe faster to tabulate in linear delta, linear Fcoll
 //  rather than linear-log, check the profiles
-void initialise_Nion_Conditional_spline(double z, double Mcrit_atom, double min_density, double max_density,
+void initialise_Nion_Conditional_spline(double z, double min_density, double max_density,
                                      double Mmin, double Mmax, double Mcond, double log10Mturn_min, double log10Mturn_max,
                                      double log10Mturn_min_MINI, double log10Mturn_max_MINI, float Alpha_star,
                                      float Alpha_star_mini, float Alpha_esc, float Fstar10, float Fesc10,
-                                     float Mlim_Fstar, float Mlim_Fesc, float Fstar7_MINI, float Fesc7_MINI,
-                                     float Mlim_Fstar_MINI, float Mlim_Fesc_MINI, int method, int method_mini,
-                                     bool minihalos, bool prev){
-    double growthf, sigma2;
+                                     float Fstar7_MINI, float Fesc7_MINI, bool prev){
     int i,j;
+    double Mlim_Fstar, Mlim_Fesc;
+    double Mlim_Fstar_MINI=0., Mlim_Fesc_MINI=0.;
     double overdense_table[NDELTA];
     double mturns[NMTURN], mturns_MINI[NMTURN];
     RGTable2D_f *table_2d, *table_mini;
@@ -295,15 +295,21 @@ void initialise_Nion_Conditional_spline(double z, double Mcrit_atom, double min_
     LOG_SUPER_DEBUG("Initialising Nion conditional table at mass %.2e from delta %.2e to %.2e",Mcond,min_density,max_density);
     LOG_SUPER_DEBUG("l10Mturns ACG %.2e %.2e MCG %.2e %.2e",log10Mturn_min,log10Mturn_max,log10Mturn_min_MINI,log10Mturn_max_MINI);
 
-    growthf = dicke(z);
+    double growthf = dicke(z);
     double lnMmin = log(Mmin);
     double lnMmax = log(Mmax);
+    double acg_thresh = atomic_cooling_threshold(z);
+    double mturn_acg = astro_params_global->M_TURN;
+    if(flag_options_global->USE_MINI_HALOS) mturn_acg = fmax(acg_thresh,mturn_acg);
 
-    sigma2 = EvaluateSigma(log(Mcond));
+    double sigma2 = EvaluateSigma(log(Mcond));
+
+    Mlim_Fstar = Mass_limit_bisection(M_MIN_INTEGRAL, M_MAX_INTEGRAL, Alpha_star, Fstar10);
+    Mlim_Fesc = Mass_limit_bisection(M_MIN_INTEGRAL, M_MAX_INTEGRAL, Alpha_esc, Fesc10);
 
     //If we use minihalos, both tables are 2D (delta,mturn) due to reionisaiton feedback
     //otherwise, the Nion table is 1D, since reionsaiton feedback is only active with minihalos
-    if (minihalos){
+    if (flag_options_global->USE_MINI_HALOS){
         if(prev){
             table_2d = &Nion_conditional_table_prev;
             table_mini = &Nion_conditional_table_MINI_prev;
@@ -327,6 +333,8 @@ void initialise_Nion_Conditional_spline(double z, double Mcrit_atom, double min_
         table_mini->x_width = (max_density - min_density)/(NDELTA-1.);
         table_mini->y_min = log10Mturn_min_MINI;
         table_mini->y_width = (log10Mturn_max_MINI - log10Mturn_min_MINI)/(NMTURN-1.);
+        Mlim_Fstar_MINI = Mass_limit_bisection(M_MIN_INTEGRAL, M_MAX_INTEGRAL, Alpha_star_mini, Fstar7_MINI * pow(1e3, Alpha_star_mini));
+        Mlim_Fesc_MINI = Mass_limit_bisection(M_MIN_INTEGRAL, M_MAX_INTEGRAL, Alpha_esc, Fesc7_MINI * pow(1e3, Alpha_esc));
     }
     else{
         if(!Nion_conditional_table1D.allocated) {
@@ -339,7 +347,7 @@ void initialise_Nion_Conditional_spline(double z, double Mcrit_atom, double min_
     for (i=0;i<NDELTA;i++) {
         overdense_table[i] = min_density + (float)i/((float)NDELTA-1.)*(max_density - min_density);
     }
-    if(minihalos){
+    if(flag_options_global->USE_MINI_HALOS){
         for (i=0;i<NMTURN;i++){
             mturns[i] = pow(10., log10Mturn_min + (float)i/((float)NMTURN-1.)*(log10Mturn_max-log10Mturn_min));
             mturns_MINI[i] = pow(10., log10Mturn_min_MINI + (float)i/((float)NMTURN-1.)*(log10Mturn_max_MINI-log10Mturn_min_MINI));
@@ -350,10 +358,10 @@ void initialise_Nion_Conditional_spline(double z, double Mcrit_atom, double min_
     {
 #pragma omp for
         for(i=0;i<NDELTA;i++){
-            if(!minihalos){
+            if(!flag_options_global->USE_MINI_HALOS){
                 //pass constant M_turn as minimum
                 Nion_conditional_table1D.y_arr[i] = log(Nion_ConditionalM(growthf,lnMmin,lnMmax,log(Mcond),sigma2,
-                                                overdense_table[i],Mcrit_atom,Alpha_star,Alpha_esc,
+                                                overdense_table[i],mturn_acg,Alpha_star,Alpha_esc,
                                                 Fstar10,Fesc10,Mlim_Fstar,Mlim_Fesc,user_params_global->INTEGRATION_METHOD_ATOMIC));
                 if(Nion_conditional_table1D.y_arr[i] < -40.)
                     Nion_conditional_table1D.y_arr[i] = -40.;
@@ -369,7 +377,7 @@ void initialise_Nion_Conditional_spline(double z, double Mcrit_atom, double min_
                     table_2d->z_arr[i][j] = -40.;
 
                 table_mini->z_arr[i][j] = log(Nion_ConditionalM_MINI(growthf,lnMmin,lnMmax,log(Mcond),sigma2,overdense_table[i],
-                                                    mturns_MINI[j],Mcrit_atom,Alpha_star_mini,Alpha_esc,Fstar7_MINI,Fesc7_MINI,
+                                                    mturns_MINI[j],acg_thresh,Alpha_star_mini,Alpha_esc,Fstar7_MINI,Fesc7_MINI,
                                                     Mlim_Fstar_MINI,Mlim_Fesc_MINI,user_params_global->INTEGRATION_METHOD_MINI));
 
                 if(table_mini->z_arr[i][j] < -40.)
@@ -379,7 +387,7 @@ void initialise_Nion_Conditional_spline(double z, double Mcrit_atom, double min_
     }
 
     for(i=0;i<NDELTA;i++) {
-        if(!minihalos){
+        if(!flag_options_global->USE_MINI_HALOS){
             if(isfinite(Nion_conditional_table1D.y_arr[i])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in Nion_spline_1D");
                 Throw(TableGenerationError);
@@ -404,9 +412,9 @@ void initialise_Nion_Conditional_spline(double z, double Mcrit_atom, double min_
 //    The non-minihalo table is always Rx1D and the minihalo table is always Rx2D
 
 //This function initialises one table, for table Rx arrays I will call this function in a loop
-void initialise_SFRD_Conditional_table(double min_density, double max_density, double growthf,
-                                    float Mcrit_atom, double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
-                                    float Fstar10, float Fstar7_MINI, int method, int method_mini, bool minihalos){
+void initialise_SFRD_Conditional_table(double z, double min_density, double max_density,
+                                    double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
+                                    float Fstar10, float Fstar7_MINI){
     float Mlim_Fstar,sigma2;
     float Mlim_Fstar_MINI=0.;
     int i,k;
@@ -419,6 +427,10 @@ void initialise_SFRD_Conditional_table(double min_density, double max_density, d
     for(i=0;i<NMTURN;i++){
         MassTurnover[i] = pow(10., LOG10_MTURN_MIN + (float)i/((float)NMTURN-1.)*(LOG10_MTURN_MAX-LOG10_MTURN_MIN));
     }
+    double growthf = dicke(z);
+    double acg_thresh = atomic_cooling_threshold(z);
+    double mturn_acg = astro_params_global->M_TURN;
+    if(flag_options_global->USE_MINI_HALOS) mturn_acg = fmax(acg_thresh,mturn_acg);
 
     //NOTE: Here we use the constant Mturn limits instead of variables like in the Nion tables
     if(!SFRD_conditional_table.allocated){
@@ -428,7 +440,7 @@ void initialise_SFRD_Conditional_table(double min_density, double max_density, d
     SFRD_conditional_table.x_width = (max_density - min_density)/(NDELTA-1.);
     Mlim_Fstar = Mass_limit_bisection(M_MIN_INTEGRAL, M_MAX_INTEGRAL, Alpha_star, Fstar10);
 
-    if(minihalos){
+    if(flag_options_global->USE_MINI_HALOS){
         if(!SFRD_conditional_table_MINI.allocated){
             allocate_RGTable2D_f(NDELTA,NMTURN,&SFRD_conditional_table_MINI);
         }
@@ -449,18 +461,18 @@ void initialise_SFRD_Conditional_table(double min_density, double max_density, d
 #pragma omp for
         for (i=0; i<NDELTA; i++){
             curr_dens = min_density + (float)i/((float)NDELTA-1.)*(max_density - min_density);
-            SFRD_conditional_table.y_arr[i] = log(Nion_ConditionalM(growthf,lnMmin,lnMmax,lnM_condition,sigma2,curr_dens,\
-                                            Mcrit_atom,Alpha_star,0.,Fstar10,1.,Mlim_Fstar,0., user_params_global->INTEGRATION_METHOD_ATOMIC));
+            SFRD_conditional_table.y_arr[i] = log(Nion_ConditionalM(growthf,lnMmin,lnMmax,lnM_condition,sigma2,curr_dens,
+                                            mturn_acg,Alpha_star,0.,Fstar10,1.,Mlim_Fstar,0., user_params_global->INTEGRATION_METHOD_ATOMIC));
 
             if(SFRD_conditional_table.y_arr[i] < -50.)
                 SFRD_conditional_table.y_arr[i] = -50.;
 
-            if(!minihalos) continue;
+            if(!flag_options_global->USE_MINI_HALOS) continue;
 
             for (k=0; k<NMTURN; k++){
-                SFRD_conditional_table_MINI.z_arr[i][k] = log(Nion_ConditionalM_MINI(growthf,lnMmin,lnMmax,lnM_condition,sigma2,\
-                                            curr_dens,MassTurnover[k],Mcrit_atom,\
-                                            Alpha_star_mini,0.,Fstar7_MINI,1.,Mlim_Fstar_MINI, 0., user_params_global->INTEGRATION_METHOD_MINI));
+                SFRD_conditional_table_MINI.z_arr[i][k] = log(Nion_ConditionalM_MINI(growthf,lnMmin,lnMmax,lnM_condition,sigma2,
+                                            curr_dens,MassTurnover[k],acg_thresh,Alpha_star_mini,0.,Fstar7_MINI,1.,Mlim_Fstar_MINI,
+                                            0.,user_params_global->INTEGRATION_METHOD_MINI));
 
                 if(SFRD_conditional_table_MINI.z_arr[i][k] < -50.)
                     SFRD_conditional_table_MINI.z_arr[i][k] = -50.;
@@ -472,7 +484,7 @@ void initialise_SFRD_Conditional_table(double min_density, double max_density, d
             LOG_ERROR("Detected either an infinite or NaN value in ACG SFRD conditional table");
             Throw(TableGenerationError);
         }
-        if(!minihalos) continue;
+        if(!flag_options_global->USE_MINI_HALOS) continue;
 
         for (k=0; k<NMTURN; k++){
             if(isfinite(SFRD_conditional_table_MINI.z_arr[i][k])==0) {
@@ -484,12 +496,10 @@ void initialise_SFRD_Conditional_table(double min_density, double max_density, d
 }
 
 //This function initialises one table, for table Rx arrays I will call this function in a loop
-void initialise_Xray_Conditional_table(double min_density, double max_density, double redshift, double growthf,
-                                    float Mcrit_atom, double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
-                                    float Fstar10, float Fstar7_MINI, double l_x, double l_x_mini, double t_h, double t_star,
-                                    int method, int method_mini, bool minihalos){
-    float Mlim_Fstar,sigma2;
-    float Mlim_Fstar_MINI=0.;
+void initialise_Xray_Conditional_table(double min_density, double max_density, double redshift,
+                                    double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
+                                    float Fstar10, float Fstar7_MINI, double l_x, double l_x_mini, double t_h, double t_star){
+    float Mlim_Fstar, Mlim_Fstar_MINI=0.;
     int i,k;
 
     LOG_SUPER_DEBUG("Initialising Xray conditional table at mass %.2e from delta %.2e to %.2e",Mcond,min_density,max_density);
@@ -500,9 +510,10 @@ void initialise_Xray_Conditional_table(double min_density, double max_density, d
     for(i=0;i<NMTURN;i++){
         MassTurnover[i] = pow(10., LOG10_MTURN_MIN + (float)i/((float)NMTURN-1.)*(LOG10_MTURN_MAX-LOG10_MTURN_MIN));
     }
+    double growthf = dicke(redshift);
 
     //NOTE: Here we use the constant Mturn_acg limits instead of variables like in the Nion tables
-    if(minihalos){
+    if(flag_options_global->USE_MINI_HALOS){
         if(!Xray_conditional_table_2D.allocated){
             allocate_RGTable2D_f(NDELTA,NMTURN,&Xray_conditional_table_2D);
         }
@@ -523,10 +534,11 @@ void initialise_Xray_Conditional_table(double min_density, double max_density, d
 
     double lnMmin = log(Mmin);
     double lnMmax = log(Mmax);
-    sigma2 = EvaluateSigma(lnM_condition); //sigma is always the condition, whereas lnMmax is just the integral limit
-    // double growthf, double lnM1, double lnM2, double M_cond, double sigma2, double delta2, double MassTurnover,
-    //                     double Alpha_star, double Alpha_star_mini, double Fstar10, double Fstar7, double Mlim_Fstar,
-    //                     double Mlim_Fstar_mini, double l_x, double l_x_mini, double t_h, double t_star, int method
+    double sigma2 = EvaluateSigma(lnM_condition); //sigma is always the condition, whereas lnMmax is just the integral limit
+
+    double acg_thresh = atomic_cooling_threshold(redshift);
+    double mturn_acg = astro_params_global->M_TURN;
+    if(flag_options_global->USE_MINI_HALOS) mturn_acg = fmax(acg_thresh,mturn_acg);
 
 #pragma omp parallel private(i,k) num_threads(user_params_global->N_THREADS)
     {
@@ -534,10 +546,9 @@ void initialise_Xray_Conditional_table(double min_density, double max_density, d
 #pragma omp for
         for (i=0; i<NDELTA; i++){
             curr_dens = min_density + (float)i/((float)NDELTA-1.)*(max_density - min_density);
-            if(!minihalos){
+            if(!flag_options_global->USE_MINI_HALOS){
                 Xray_conditional_table_1D.y_arr[i] = log(Xray_ConditionalM(redshift,growthf,lnMmin,lnMmax,lnM_condition,sigma2,curr_dens,
-                                            0.,Mcrit_atom,Alpha_star,0.,Fstar10,0.,Mlim_Fstar,0.,
-                                            l_x, 0., t_h, t_star,
+                                            mturn_acg,0.,Alpha_star,0.,Fstar10,0.,Mlim_Fstar,0.,l_x,0.,t_h,t_star,
                                             user_params_global->INTEGRATION_METHOD_ATOMIC));
 
                 if(Xray_conditional_table_1D.y_arr[i] < -50.)
@@ -547,7 +558,7 @@ void initialise_Xray_Conditional_table(double min_density, double max_density, d
 
             for (k=0; k<NMTURN; k++){
                 Xray_conditional_table_2D.z_arr[i][k] = log(Xray_ConditionalM(redshift,growthf,lnMmin,lnMmax,lnM_condition,sigma2,
-                                            curr_dens,MassTurnover[k],Mcrit_atom,
+                                            curr_dens,mturn_acg,MassTurnover[k],
                                             Alpha_star,Alpha_star_mini,Fstar10,Fstar7_MINI,Mlim_Fstar,Mlim_Fstar_MINI,
                                             l_x, l_x_mini, t_h, t_star,
                                             user_params_global->INTEGRATION_METHOD_MINI)); //Using mini integration method for both
@@ -558,7 +569,7 @@ void initialise_Xray_Conditional_table(double min_density, double max_density, d
         }
     }
     for (i=0; i<NDELTA; i++){
-        if(!minihalos){
+        if(!flag_options_global->USE_MINI_HALOS){
             if(isfinite(Xray_conditional_table_1D.y_arr[i])==0) {
                 LOG_ERROR("Detected either an infinite or NaN value in 1D Xray conditional table");
                 Throw(TableGenerationError);
@@ -876,6 +887,9 @@ void free_global_tables(){
 
 //JD: moving the interp table evaluations here since some of them are needed in nu_tau_one
 //NOTE: with !USE_MASS_DEPENDENT_ZETA both EvaluateNionTs and EvaluateSFRD return Fcoll
+//TODO:These evaluation functions require computation of a bunch of arguments that aren't required when
+// USE_INTERPOLATION_TABLES is True, I would like to create a way to keep the flexibility obtained by them
+// WITHOUT computing all the additional arguments if we don't need them
 double EvaluateNionTs(double redshift, double Mlim_Fstar, double Mlim_Fesc){
     //differences in turnover are handled by table setup
     if(user_params_global->USE_INTERPOLATION_TABLES){
@@ -889,12 +903,13 @@ double EvaluateNionTs(double redshift, double Mlim_Fstar, double Mlim_Fesc){
     double lnMmin = log(minimum_source_mass(redshift,true,astro_params_global,flag_options_global));
     double lnMmax = log(M_MAX_INTEGRAL);
 
+    double mturn = astro_params_global->M_TURN;
+    if(flag_options_global->USE_MINI_HALOS && mturn < atomic_cooling_threshold(redshift))
+        mturn = atomic_cooling_threshold(redshift);
+
     //minihalos uses a different turnover mass
-    if(flag_options_global->USE_MINI_HALOS)
-        return Nion_General(redshift, lnMmin, lnMmax, atomic_cooling_threshold(redshift), astro_params_global->ALPHA_STAR, astro_params_global->ALPHA_ESC,
-                            astro_params_global->F_STAR10, astro_params_global->F_ESC10, Mlim_Fstar, Mlim_Fesc);
     if(flag_options_global->USE_MASS_DEPENDENT_ZETA)
-        return Nion_General(redshift, lnMmin, lnMmax, astro_params_global->M_TURN, astro_params_global->ALPHA_STAR, astro_params_global->ALPHA_ESC,
+        return Nion_General(redshift, lnMmin, lnMmax, mturn, astro_params_global->ALPHA_STAR, astro_params_global->ALPHA_ESC,
                             astro_params_global->F_STAR10, astro_params_global->F_ESC10, Mlim_Fstar, Mlim_Fesc);
 
     return Fcoll_General(redshift, lnMmin, lnMmax);
@@ -1005,9 +1020,9 @@ double EvaluateXray_Conditional(double delta, double log10Mturn_m, double redshi
         return exp(EvaluateRGTable1D_f(delta,&Xray_conditional_table_1D));
     }
 
-    return Xray_ConditionalM(redshift, growthf, log(M_min), log(M_max), log(M_cond), sigma_max, delta, pow(10,log10Mturn_m),
-                                Mturn_a, astro_params_global->ALPHA_STAR, astro_params_global->ALPHA_STAR_MINI,
-                                astro_params_global->F_STAR10, astro_params_global->F_STAR7_MINI,
+    return Xray_ConditionalM(redshift, growthf, log(M_min), log(M_max), log(M_cond), sigma_max, delta,
+                                Mturn_a, pow(10,log10Mturn_m), astro_params_global->ALPHA_STAR,
+                                astro_params_global->ALPHA_STAR_MINI, astro_params_global->F_STAR10, astro_params_global->F_STAR7_MINI,
                                 Mlim_Fstar, Mlim_Fstar_MINI, astro_params_global->L_X, astro_params_global->L_X_MINI,t_h,
                                 astro_params_global->t_STAR, user_params_global->INTEGRATION_METHOD_MINI);
 }

--- a/src/py21cmfast/src/interp_tables.h
+++ b/src/py21cmfast/src/interp_tables.h
@@ -6,13 +6,12 @@
 //Functions within interp_tables.c need the parameter structures, but we don't want to pass them all down the chain, so we broadcast them
 //TODO: in future it would be better to use a context struct. See `HaloBox.c`
 
-void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_star_mini, float Fstar10, float Fstar7_MINI,
-                             float mturn_a_const, bool minihalos);
+void initialise_SFRD_spline(int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_star_mini, float Fstar10, float Fstar7_MINI);
 double EvaluateSFRD(double redshift, double Mlim_Fstar);
 double EvaluateSFRD_MINI(double redshift, double log10_Mturn_LW_ave, double Mlim_Fstar_MINI);
 
 void initialise_Nion_Ts_spline(int Nbin, float zmin, float zmax, float Alpha_star, float Alpha_star_mini, float Alpha_esc, float Fstar10,
-                                float Fesc10, float Fstar7_MINI, float Fesc7_MINI, float mturn_a_const, bool minihalos);
+                                float Fesc10, float Fstar7_MINI, float Fesc7_MINI);
 double EvaluateNionTs(double redshift, double Mlim_Fstar, double Mlim_Fesc);
 double EvaluateNionTs_MINI(double redshift, double log10_Mturn_LW_ave, double Mlim_Fstar_MINI, double Mlim_Fesc_MINI);
 
@@ -22,26 +21,23 @@ double EvaluateFcoll_delta(double delta, double growthf, double sigma_min, doubl
 void init_FcollTable(double zmin, double zmax, bool x_ray);
 double EvaluatedFcolldz(double delta, double redshift, double sigma_min, double sigma_max);
 
-void initialise_Nion_Conditional_spline(double z, double Mcrit_atom, double min_density, double max_density,
+void initialise_Nion_Conditional_spline(double z, double min_density, double max_density,
                                      double Mmin, double Mmax, double Mcond, double log10Mturn_min, double log10Mturn_max,
                                      double log10Mturn_min_MINI, double log10Mturn_max_MINI, float Alpha_star,
                                      float Alpha_star_mini, float Alpha_esc, float Fstar10, float Fesc10,
-                                     float Mlim_Fstar, float Mlim_Fesc, float Fstar7_MINI, float Fesc7_MINI,
-                                     float Mlim_Fstar_MINI, float Mlim_Fesc_MINI, int method, int method_mini,
-                                     bool minihalos, bool prev);
+                                     float Fstar7_MINI, float Fesc7_MINI, bool prev);
 double EvaluateNion_Conditional(double delta, double log10Mturn, double growthf, double M_min, double M_max, double M_cond, double sigma_max,
                                 double Mlim_Fstar, double Mlim_Fesc, bool prev);
 double EvaluateNion_Conditional_MINI(double delta, double log10Mturn_m, double growthf, double M_min, double M_max, double M_cond, double sigma_max,
                                     double Mturn_a, double Mlim_Fstar, double Mlim_Fesc, bool prev);
-void initialise_Xray_Conditional_table(double min_density, double max_density, double redshift, double growthf,
-                                    float Mcrit_atom, double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
-                                    float Fstar10, float Fstar7_MINI, double l_x, double l_x_mini, double t_h, double t_star,
-                                    int method, int method_mini, bool minihalos);
+void initialise_Xray_Conditional_table(double min_density, double max_density, double redshift,
+                                    double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
+                                    float Fstar10, float Fstar7_MINI, double l_x, double l_x_mini, double t_h, double t_star);
 double EvaluateXray_Conditional(double delta, double log10Mturn_m, double redshift, double growthf, double M_min, double M_max, double M_cond, double sigma_max,
                                      double Mturn_a, double t_h, double Mlim_Fstar, double Mlim_Fstar_MINI);
-void initialise_SFRD_Conditional_table(double min_density, double max_density, double growthf,
-                                    float Mcrit_atom, double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
-                                    float Fstar10, float Fstar7_MINI, int method, int method_mini, bool minihalos);
+void initialise_SFRD_Conditional_table(double z, double min_density, double max_density,
+                                    double Mmin, double Mmax, double Mcond, float Alpha_star, float Alpha_star_mini,
+                                    float Fstar10, float Fstar7_MINI);
 double EvaluateSFRD_Conditional(double delta, double growthf, double M_min, double M_max, double M_cond, double sigma_max, double Mturn_a, double Mlim_Fstar);
 double EvaluateSFRD_Conditional_MINI(double delta, double log10Mturn_m, double growthf, double M_min, double M_max, double M_cond, double sigma_max, double Mturn_a, double Mlim_Fstar);
 

--- a/tests/test_c_interpolation_tables.py
+++ b/tests/test_c_interpolation_tables.py
@@ -251,9 +251,9 @@ def test_inverse_cmf_tables(name, from_cat, delta_range, mass_range, plt):
     )
 
 
-# NOTE: This test currently fails (~10% differences in mass in <1% of bins)
-#   I don't want to relax the tolerance yet since it can be improved, but
-#   for now this is acceptable
+# NOTE: This test is currently very slow since USE_INTERPOLATION_TABLES turns on
+#   both the mass function tables and the signa tables, so it does double-integrals.
+#   We could implement a ternary table flag OR implement a return_integral like the N_ion tests
 @pytest.mark.parametrize("name", options_hmf)
 @pytest.mark.parametrize("from_cat", ["cat", "grid"])
 def test_massfunc_conditional_tables(name, from_cat, mass_range, delta_range, plt):


### PR DESCRIPTION
Recently, we allowed the free parameter M_TURN to function in the minihalo model, as a lower limit set by supernovae feedback. Previously, the atomic cooling threshold was used both as the lower turnover for ACGs and the upper turnover for MCGs.

The correct behaviour would have been to separate these two turnovers entirely, where the upper turnover for MCGs is *always* the atomic cooling threshold, and the lower turnover for ACGs is set by the maximum of M_TURN and the cooling threshold. When implementing this new lower limit, I did not do this, meaning that the maximum of the cooling and M_TURN was used for both turnovers.

This PR fixes this issue by separating the two turnovers properly, as well as trying to clean up the table/integral functions a little to make them less confusing. The latter involves doing some repeated computation once per snapshot (`atomic_cooling_threshold`,`dicke`,`Mass_limit_bisection` etc) but this should be insignificant, and worth the readibility.

Missing this bug in the first place exposes some gaps in our tests. Where we do have internal consistency checks for whether the tables match the integrals, but we cannot catch:
- when the integral functions are called incorrectly in computation functions
- when the integral functions themselves have errors

Both of these tests would require comparing some known cases of an output function or integral, which can be difficult to construct, but maybe we can store values for a couple of known integrals, maybe we can some numbers for specific cases `delta=0`, `mturn=1e8` etc. However this could have some issues similar to the integration tests, where changes to the code require updates to the comparison data.