### PR TITLE
reorganise cosmology functions, setup future speed tests

### DIFF
--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -1368,7 +1368,6 @@ void ts_main(float redshift, float prev_redshift, UserParams *user_params, Cosmo
             xray_R_factor = pow(1+zpp,-(astro_params->X_RAY_SPEC_INDEX));
 
             set_scaling_constants(zpp,astro_params,flag_options,&sc,false);
-            sc_sfrd = evolve_scaling_constants_sfr(&sc);
 
             //index for grids
             R_index = user_params->MINIMIZE_MEMORY ? 0 : R_ct;
@@ -1402,6 +1401,7 @@ void ts_main(float redshift, float prev_redshift, UserParams *user_params, Cosmo
                 if(flag_options->USE_MINI_HALOS) avg_fix_term_MINI = mean_sfr_zpp_mini[R_ct]/ave_fcoll_MINI;
 
 #if LOG_LEVEL > SUPER_DEBUG_LEVEL
+                sc_sfrd = evolve_scaling_constants_sfr(&sc);
                 LOG_SUPER_DEBUG("z %6.2f ave sfrd val %.3e global %.3e (int %.3e) Mmin %.3e ratio %.4e z_edge %.4e",
                                     zpp_for_evolve_list[R_ct],ave_fcoll,mean_sfr_zpp[R_ct],
                                     Nion_General(zpp_for_evolve_list[R_ct], log(M_min_R[R_ct]), log(M_MAX_INTEGRAL),

--- a/src/py21cmfast/src/cosmology.c
+++ b/src/py21cmfast/src/cosmology.c
@@ -124,7 +124,7 @@ double transfer_function_CLASS(double k, int flag_int, int flag_dv)
     int gsl_status;
     FILE *F;
 
-    static bool warning_printed = false;
+    static bool warning_printed;
 
     char filename[500];
     sprintf(filename,"%s/%s",config_settings.external_table_path,CLASS_FILENAME);
@@ -134,6 +134,7 @@ double transfer_function_CLASS(double k, int flag_int, int flag_dv)
             LOG_ERROR("Unable to open file: %s for reading.", filename);
             Throw(IOError);
         }
+        warning_printed = false;
 
         int nscans;
         for (i = 0; i < CLASS_LENGTH; i++) {

--- a/src/py21cmfast/src/filtering.h
+++ b/src/py21cmfast/src/filtering.h
@@ -6,5 +6,7 @@
 void filter_box(fftwf_complex *box, int RES, int filter_type, float R, float R_param);
 int test_filter(UserParams *user_params, CosmoParams *cosmo_params, AstroParams *astro_params, FlagOptions *flag_options
                     , float *input_box, double R, double R_param, int filter_flag, double *result);
+double filter_function(double k, int filter_type);
+double dwdm_filter(double k, double R, int filter_type);
 
 #endif

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -130,7 +130,7 @@ def test_bad_integral_inputs(default_input_struct):
 
 @pytest.mark.parametrize("hmf_model", ["PS", "ST"])
 @pytest.mark.parametrize("ps_model", ["EH", "BBKS"])
-@pytest.mark.xfail(reason="pending proper comparison between 21cmFAST and hmf")
+# @pytest.mark.xfail(reason="pending proper comparison between 21cmFAST and hmf")
 def test_matterfield_statistics(default_input_struct, hmf_model, ps_model, plt):
     redshift = 8.0
     hmf_map = {
@@ -217,12 +217,12 @@ def test_matterfield_statistics(default_input_struct, hmf_model, ps_model, plt):
         )
 
     # check matter power spectrum
-    np.testing.assert_allclose(power_vals, comparison_mf.power / (h**3), rtol=1e-3)
+    np.testing.assert_allclose(power_vals, comparison_mf._power0 / (h**3), rtol=1e-3)
     # check sigma(M)
-    np.testing.assert_allclose(sigma_vals, comparison_mf.sigma, rtol=1e-3)
+    np.testing.assert_allclose(sigma_vals, comparison_mf._sigma_0, rtol=1e-3)
     # check dSigma/dM
     np.testing.assert_allclose(
-        dsigmasq_vals / 2 * sigma_vals,
+        dsigmasq_vals / (2 * sigma_vals),
         comparison_mf._dlnsdlnm * comparison_mf._sigma_0 / comparison_mf.m * h,
         rtol=1e-3,
     )

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -130,7 +130,7 @@ def test_bad_integral_inputs(default_input_struct):
 
 @pytest.mark.parametrize("hmf_model", ["PS", "ST"])
 @pytest.mark.parametrize("ps_model", ["EH", "BBKS"])
-# @pytest.mark.xfail(reason="pending proper comparison between 21cmFAST and hmf")
+@pytest.mark.xfail(reason="pending proper comparison between 21cmFAST and hmf")
 def test_matterfield_statistics(default_input_struct, hmf_model, ps_model, plt):
     redshift = 8.0
     hmf_map = {
@@ -233,7 +233,9 @@ def test_matterfield_statistics(default_input_struct, hmf_model, ps_model, plt):
 
 
 @pytest.mark.parametrize("hmf_model", ["PS", "ST"])
-@pytest.mark.parametrize("ps_model", ["EH", "BBKS", "EFSTATHIOU"])
+@pytest.mark.parametrize(
+    "ps_model", ["EH", "BBKS", "EFSTATHIOU", "PEEBLES", "WHITE", "CLASS"]
+)
 def test_hmf_runs(default_input_struct, hmf_model, ps_model):
     mass_range = np.logspace(7, 12, num=64)
     redshift = 8.0
@@ -254,7 +256,9 @@ def test_hmf_runs(default_input_struct, hmf_model, ps_model):
 
 
 @pytest.mark.parametrize("hmf_model", ["PS", "ST"])
-@pytest.mark.parametrize("ps_model", ["EH", "BBKS", "EFSTATHIOU"])
+@pytest.mark.parametrize(
+    "ps_model", ["EH", "BBKS", "EFSTATHIOU", "PEEBLES", "WHITE", "CLASS"]
+)
 def test_chmf_runs(default_input_struct, hmf_model, ps_model):
     delta_range = np.linspace(-1.0, 1.7, num=32)
     condmass_range = np.logspace(8, 13, num=16)

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -135,7 +135,7 @@ def test_matterfield_statistics(default_input_struct, hmf_model, ps_model, plt):
     redshift = 8.0
     hmf_map = {
         "PS": "PS",
-        "ST": "Jenkins",
+        "ST": "SMT",
     }
     transfer_map = {
         "EH": "EH_NoBAO",
@@ -150,11 +150,17 @@ def test_matterfield_statistics(default_input_struct, hmf_model, ps_model, plt):
     else:
         t_params = {}
 
+    if hmf_model == "PS":
+        hmf_params = {}
+    elif hmf_model == "ST":
+        hmf_params = {"a": 0.73, "p": 0.175, "A": 0.353}
+
     comparison_mf = MassFunction(
         z=redshift,
         Mmin=7,
         Mmax=16,
         hmf_model=hmf_map[hmf_model],
+        hmf_params=hmf_params,
         transfer_model=transfer_map[ps_model],
         transfer_params=t_params,
         delta_c=1.68,

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -301,6 +301,7 @@ def make_matterfield_comparison_plot(
     axs[0, 0].loglog(x, test[0], linestyle=":", linewidth=3, label="Test", **kwargs)
     axs[1, 0].semilogx(x, (test[0] - true[0]) / true[0], **kwargs)
     axs[0, 0].legend()
+    axs[0, 0].set_ylim(1e-12, 1e2)
 
     axs[0, 1].loglog(x, true[1], linestyle="-", label="Truth", **kwargs)
     axs[0, 1].loglog(x, test[1], linestyle=":", linewidth=3, label="Test", **kwargs)

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -129,7 +129,7 @@ def test_bad_integral_inputs(default_input_struct):
 
 
 @pytest.mark.parametrize("hmf_model", ["PS", "ST"])
-@pytest.mark.parametrize("ps_model", ["EH", "BBKS", "EFSTATHIOU"])
+@pytest.mark.parametrize("ps_model", ["EH", "BBKS"])
 @pytest.mark.xfail(reason="pending proper comparison between 21cmFAST and hmf")
 def test_matterfield_statistics(default_input_struct, hmf_model, ps_model, plt):
     redshift = 8.0
@@ -140,13 +140,10 @@ def test_matterfield_statistics(default_input_struct, hmf_model, ps_model, plt):
     transfer_map = {
         "EH": "EH_NoBAO",
         "BBKS": "BBKS",
-        "EFSTATHIOU": "BondEfs",
     }
 
     if ps_model == "BBKS":
         t_params = {"use_sugiyama_baryons": True, "use_liddle_baryons": False}
-    elif ps_model == "EFSTATHIOU":
-        t_params = {"nu": 1.13}
     else:
         t_params = {}
 
@@ -163,7 +160,7 @@ def test_matterfield_statistics(default_input_struct, hmf_model, ps_model, plt):
         hmf_params=hmf_params,
         transfer_model=transfer_map[ps_model],
         transfer_params=t_params,
-        delta_c=1.68,
+        delta_c=1.68,  # hmf default is 1.686
     )
 
     inputs = default_input_struct.clone(


### PR DESCRIPTION
This is a cleanup of `cosmology.c` which had a lot of copy-pasted code and global parameter usage.

There are still some TODOs left involving double-checking all the transfer functions and removing a few old parts after I verify that they are no longer used/needed.

I've also added a speed criteria in `test_segfaults` to ensure that we aren't slowing the code down when making changes. First tests can be done using v3 values before perhaps moving to a different benchmarking method