### PR TITLE
Fcoll is 4D and Fcoll_MINI exists only if USE_HALO_FIELD=False

### DIFF
--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -649,7 +649,7 @@ void calculate_fcoll_grid(IonizedBox *box, IonizedBox *previous_ionize_box, stru
     struct ScalingConstants *sc_ptr = &(consts->scale_consts);
 
     int fc_r_idx;
-    fc_r_idx = flag_options_global->USE_MINI_HALOS ? rspec->R_index : 0;
+    fc_r_idx = (flag_options_global->USE_MINI_HALOS && !flag_options_global->USE_HALO_FIELD) ? rspec->R_index : 0;
     #pragma omp parallel num_threads(user_params_global->N_THREADS)
     {
         int x,y,z;
@@ -839,7 +839,7 @@ void find_ionised_regions(IonizedBox *box, IonizedBox *previous_ionize_box, Pert
     double mean_fix_term_acg = 1.;
     double mean_fix_term_mcg = 1.;
     int fc_r_idx;
-    fc_r_idx = flag_options_global->USE_MINI_HALOS ? rspec.R_index : 0;
+    fc_r_idx = (flag_options_global->USE_MINI_HALOS && !flag_options_global->USE_HALO_FIELD) ? rspec.R_index : 0;
 
     LOG_SUPER_DEBUG("global mean fcoll (mini) %.3e (%.3e) box mean fcoll %.3e (%.3e) ratio %.3e (%.3e)",
                     box->mean_f_coll,box->mean_f_coll_MINI,

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -1222,7 +1222,10 @@ class IonizedBox(OutputStructZ):
         All other parameters are passed through to the :class:`IonizedBox`
         constructor.
         """
-        if inputs.flag_options.USE_MINI_HALOS and not inputs.flag_options.USE_HALO_FIELD:
+        if (
+            inputs.flag_options.USE_MINI_HALOS
+            and not inputs.flag_options.USE_HALO_FIELD
+        ):
             n_filtering = (
                 int(
                     np.log(
@@ -1259,7 +1262,10 @@ class IonizedBox(OutputStructZ):
             "Fcoll": Array(filter_shape, dtype=np.float32),
         }
 
-        if inputs.flag_options.USE_MINI_HALOS and not inputs.flag_options.USE_HALO_FIELD:
+        if (
+            inputs.flag_options.USE_MINI_HALOS
+            and not inputs.flag_options.USE_HALO_FIELD
+        ):
             out["Fcoll_MINI"] = Array(filter_shape, dtype=np.float32)
 
         return cls(inputs=inputs, redshift=redshift, **out, **kw)
@@ -1297,9 +1303,13 @@ class IonizedBox(OutputStructZ):
                 self.inputs.flag_options.USE_MASS_DEPENDENT_ZETA
                 and self.inputs.flag_options.USE_MINI_HALOS
             ):
-                required += ["Fcoll",]
-                if (not self.inputs.flag_options.USE_HALO_FIELD):
-                    required += ["Fcoll_MINI",]
+                required += [
+                    "Fcoll",
+                ]
+                if not self.inputs.flag_options.USE_HALO_FIELD:
+                    required += [
+                        "Fcoll_MINI",
+                    ]
         elif isinstance(input_box, HaloBox):
             required += ["n_ion", "whalo_sfr"]
         else:

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -1222,7 +1222,7 @@ class IonizedBox(OutputStructZ):
         All other parameters are passed through to the :class:`IonizedBox`
         constructor.
         """
-        if inputs.flag_options.USE_MINI_HALOS:
+        if inputs.flag_options.USE_MINI_HALOS and not inputs.flag_options.USE_HALO_FIELD:
             n_filtering = (
                 int(
                     np.log(
@@ -1259,7 +1259,7 @@ class IonizedBox(OutputStructZ):
             "Fcoll": Array(filter_shape, dtype=np.float32),
         }
 
-        if inputs.flag_options.USE_MINI_HALOS:
+        if inputs.flag_options.USE_MINI_HALOS and not inputs.flag_options.USE_HALO_FIELD:
             out["Fcoll_MINI"] = Array(filter_shape, dtype=np.float32)
 
         return cls(inputs=inputs, redshift=redshift, **out, **kw)
@@ -1297,7 +1297,9 @@ class IonizedBox(OutputStructZ):
                 self.inputs.flag_options.USE_MASS_DEPENDENT_ZETA
                 and self.inputs.flag_options.USE_MINI_HALOS
             ):
-                required += ["Fcoll", "Fcoll_MINI"]
+                required += ["Fcoll",]
+                if (not self.inputs.flag_options.USE_HALO_FIELD):
+                    required += ["Fcoll_MINI",]
         elif isinstance(input_box, HaloBox):
             required += ["n_ion", "whalo_sfr"]
         else:


### PR DESCRIPTION
This change was made to reduce used memory when `USE_HALO_FIELD=True`.