### PR TITLE
Detect c compiler more interactively

### DIFF
--- a/build_cffi.py
+++ b/build_cffi.py
@@ -6,7 +6,13 @@ import sysconfig
 from cffi import FFI
 
 # Get the compiler. We support gcc and clang.
-_compiler = sysconfig.get_config_var("CC")
+_compiler = os.environ.get("CC", None)
+if _compiler is None:
+    # If CC is not set, use the default compiler from sysconfig - the one used to build Python
+    _compiler = sysconfig.get_config_var("CC")
+    print(f"No environment variable CC set, trying to use compiler from sysconfig: {_compiler}")
+else:
+    print(f"Compiler specified as environment variable CC: {_compiler}")
 
 if "gcc" in _compiler:
     compiler = "gcc"

--- a/build_cffi.py
+++ b/build_cffi.py
@@ -6,15 +6,7 @@ import sysconfig
 from cffi import FFI
 
 # Get the compiler. We support gcc and clang.
-_compiler = os.environ.get("CC", None)
-if _compiler is None:
-    # If CC is not set, use the default compiler from sysconfig - the one used to build Python
-    _compiler = sysconfig.get_config_var("CC")
-    print(
-        f"No environment variable CC set, trying to use compiler from sysconfig: {_compiler}"
-    )
-else:
-    print(f"Compiler specified as environment variable CC: {_compiler}")
+_compiler = os.environ.get("CC", sysconfig.get_config_var("CC"))
 
 if "gcc" in _compiler:
     compiler = "gcc"

--- a/build_cffi.py
+++ b/build_cffi.py
@@ -10,7 +10,9 @@ _compiler = os.environ.get("CC", None)
 if _compiler is None:
     # If CC is not set, use the default compiler from sysconfig - the one used to build Python
     _compiler = sysconfig.get_config_var("CC")
-    print(f"No environment variable CC set, trying to use compiler from sysconfig: {_compiler}")
+    print(
+        f"No environment variable CC set, trying to use compiler from sysconfig: {_compiler}"
+    )
 else:
     print(f"Compiler specified as environment variable CC: {_compiler}")
 


### PR DESCRIPTION
Hello, this is a tentative PR to fix an installation issue when simply using pip to install the package.

During the installation this version tries to infer the compiler from the environment variable `CC` and only then falls back onto the compiler returned by `sysconfig.get_config_var("CC")`.

Since binary distributions of programs are so common, it is often the case that the compiler used to build python is not present on the system. But `sysconfig.get_config_var("CC")` returns just that - the compiler that was used to build this particular distribution. Using environment variables instead is a more flexible approach in my opinion.

Let me know if you are interested in integrating this PR and whether you require changes/tests/documentation.