### PR TITLE
lowres_vcb exists only if USE_MINI_HALOS=True and FIX_VCB_AVG=False

### DIFF
--- a/src/py21cmfast/src/InitialConditions.c
+++ b/src/py21cmfast/src/InitialConditions.c
@@ -78,7 +78,7 @@ void adj_complex_conj(fftwf_complex *HIRES_box, UserParams *user_params, CosmoPa
 
 int ComputeInitialConditions(
     unsigned long long random_seed, UserParams *user_params,
-    CosmoParams *cosmo_params, InitialConditions *boxes
+    CosmoParams *cosmo_params, FlagOptions *flag_options, InitialConditions *boxes
 ){
 
 //     Generates the initial conditions: gaussian random density field (user_params->DIM^3) as well as the equal or lower resolution velocity fields, and smoothed density field (user_params->HII_DIM^3).
@@ -237,7 +237,7 @@ int ComputeInitialConditions(
 
 
     // ******* Relative Velocity part ******* //
-    if(user_params->USE_RELATIVE_VELOCITIES){
+    if(user_params->USE_RELATIVE_VELOCITIES && flag_options->USE_MINI_HALOS && !flag_options->FIX_VCB_AVG){
     //JBM: We use the memory allocated to HIRES_box as it's free.
         for(ii=0;ii<3;ii++) {
             memcpy(HIRES_box, HIRES_box_saved, sizeof(fftwf_complex)*KSPACE_NUM_PIXELS);

--- a/src/py21cmfast/src/InitialConditions.h
+++ b/src/py21cmfast/src/InitialConditions.h
@@ -8,7 +8,7 @@
 
 int ComputeInitialConditions(
     unsigned long long random_seed, UserParams *user_params,
-    CosmoParams *cosmo_params, InitialConditions *boxes
+    CosmoParams *cosmo_params, FlagOptions *flag_options, InitialConditions *boxes
 );
 
 #endif

--- a/src/py21cmfast/src/_functionprototypes_wrapper.h
+++ b/src/py21cmfast/src/_functionprototypes_wrapper.h
@@ -3,7 +3,7 @@
     are visible to the python wrapper */
 
 /* OutputStruct COMPUTE FUNCTIONS */
-int ComputeInitialConditions(unsigned long long random_seed,  UserParams *user_params,  CosmoParams *cosmo_params,  InitialConditions *boxes);
+int ComputeInitialConditions(unsigned long long random_seed,  UserParams *user_params,  CosmoParams *cosmo_params, FlagOptions *flag_options, InitialConditions *boxes);
 
 int ComputePerturbField(float redshift,  UserParams *user_params,  CosmoParams *cosmo_params,  InitialConditions *boxes,  PerturbedField *perturbed_field);
 

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -533,7 +533,7 @@ class InitialConditions(OutputStruct):
                 "hires_vz_2LPT": Array(hires_shape, dtype=np.float32),
             }
 
-        if inputs.user_params.USE_RELATIVE_VELOCITIES:
+        if inputs.user_params.USE_RELATIVE_VELOCITIES and inputs.flag_options.USE_MINI_HALOS and not inputs.flag_options.FIX_VCB_AVG:
             out["lowres_vcb"] = Array(shape, dtype=np.float32)
 
         return cls(inputs=inputs, **out, **kw)
@@ -563,7 +563,7 @@ class InitialConditions(OutputStruct):
                 keep.append("hires_vy_2LPT")
                 keep.append("hires_vz_2LPT")
 
-        if self.user_params.USE_RELATIVE_VELOCITIES:
+        if self.user_params.USE_RELATIVE_VELOCITIES and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG:
             keep.append("lowres_vcb")
 
         self.prepare(keep=keep, force=force)
@@ -573,7 +573,7 @@ class InitialConditions(OutputStruct):
         keep = []
         if flag_options.USE_HALO_FIELD and self.user_params.AVG_BELOW_SAMPLER:
             keep.append("lowres_density")  # for the cmfs
-        if self.user_params.USE_RELATIVE_VELOCITIES:
+        if self.user_params.USE_RELATIVE_VELOCITIES and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG:
             keep.append("lowres_vcb")
         self.prepare(keep=keep, force=force)
 
@@ -588,6 +588,7 @@ class InitialConditions(OutputStruct):
             self.inputs.random_seed,
             self.inputs.user_params,
             self.inputs.cosmo_params,
+            self.inputs.flag_options,
         )
 
 
@@ -682,7 +683,7 @@ class PerturbedField(OutputStructZ):
                     "lowres_vz_2LPT",
                 ]
 
-        if self.user_params.USE_RELATIVE_VELOCITIES:
+        if self.user_params.USE_RELATIVE_VELOCITIES and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG:
             required.append("lowres_vcb")
 
         return required
@@ -945,7 +946,7 @@ class HaloBox(OutputStructZ):
                 and self.user_params.AVG_BELOW_SAMPLER
             ):
                 required += ["lowres_density"]
-            if self.user_params.USE_RELATIVE_VELOCITIES:
+            if self.user_params.USE_RELATIVE_VELOCITIES and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG:
                 required += ["lowres_vcb"]
         else:
             raise ValueError(f"{type(input_box)} is not an input required for HaloBox!")
@@ -1137,7 +1138,7 @@ class TsBox(OutputStructZ):
         if isinstance(input_box, InitialConditions):
             if (
                 self.user_params.USE_RELATIVE_VELOCITIES
-                and self.flag_options.USE_MINI_HALOS
+                and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG
             ):
                 required += ["lowres_vcb"]
         elif isinstance(input_box, PerturbedField):
@@ -1280,7 +1281,7 @@ class IonizedBox(OutputStructZ):
         if isinstance(input_box, InitialConditions):
             if (
                 self.user_params.USE_RELATIVE_VELOCITIES
-                and self.flag_options.USE_MASS_DEPENDENT_ZETA
+                and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG
             ):
                 required += ["lowres_vcb"]
         elif isinstance(input_box, PerturbedField):

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -533,7 +533,11 @@ class InitialConditions(OutputStruct):
                 "hires_vz_2LPT": Array(hires_shape, dtype=np.float32),
             }
 
-        if inputs.user_params.USE_RELATIVE_VELOCITIES and inputs.flag_options.USE_MINI_HALOS and not inputs.flag_options.FIX_VCB_AVG:
+        if (
+            inputs.user_params.USE_RELATIVE_VELOCITIES
+            and inputs.flag_options.USE_MINI_HALOS
+            and not inputs.flag_options.FIX_VCB_AVG
+        ):
             out["lowres_vcb"] = Array(shape, dtype=np.float32)
 
         return cls(inputs=inputs, **out, **kw)
@@ -563,7 +567,11 @@ class InitialConditions(OutputStruct):
                 keep.append("hires_vy_2LPT")
                 keep.append("hires_vz_2LPT")
 
-        if self.user_params.USE_RELATIVE_VELOCITIES and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG:
+        if (
+            self.user_params.USE_RELATIVE_VELOCITIES
+            and self.flag_options.USE_MINI_HALOS
+            and not self.flag_options.FIX_VCB_AVG
+        ):
             keep.append("lowres_vcb")
 
         self.prepare(keep=keep, force=force)
@@ -573,7 +581,11 @@ class InitialConditions(OutputStruct):
         keep = []
         if flag_options.USE_HALO_FIELD and self.user_params.AVG_BELOW_SAMPLER:
             keep.append("lowres_density")  # for the cmfs
-        if self.user_params.USE_RELATIVE_VELOCITIES and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG:
+        if (
+            self.user_params.USE_RELATIVE_VELOCITIES
+            and self.flag_options.USE_MINI_HALOS
+            and not self.flag_options.FIX_VCB_AVG
+        ):
             keep.append("lowres_vcb")
         self.prepare(keep=keep, force=force)
 
@@ -683,7 +695,11 @@ class PerturbedField(OutputStructZ):
                     "lowres_vz_2LPT",
                 ]
 
-        if self.user_params.USE_RELATIVE_VELOCITIES and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG:
+        if (
+            self.user_params.USE_RELATIVE_VELOCITIES
+            and self.flag_options.USE_MINI_HALOS
+            and not self.flag_options.FIX_VCB_AVG
+        ):
             required.append("lowres_vcb")
 
         return required
@@ -946,7 +962,11 @@ class HaloBox(OutputStructZ):
                 and self.user_params.AVG_BELOW_SAMPLER
             ):
                 required += ["lowres_density"]
-            if self.user_params.USE_RELATIVE_VELOCITIES and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG:
+            if (
+                self.user_params.USE_RELATIVE_VELOCITIES
+                and self.flag_options.USE_MINI_HALOS
+                and not self.flag_options.FIX_VCB_AVG
+            ):
                 required += ["lowres_vcb"]
         else:
             raise ValueError(f"{type(input_box)} is not an input required for HaloBox!")
@@ -1138,7 +1158,8 @@ class TsBox(OutputStructZ):
         if isinstance(input_box, InitialConditions):
             if (
                 self.user_params.USE_RELATIVE_VELOCITIES
-                and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG
+                and self.flag_options.USE_MINI_HALOS
+                and not self.flag_options.FIX_VCB_AVG
             ):
                 required += ["lowres_vcb"]
         elif isinstance(input_box, PerturbedField):
@@ -1281,7 +1302,8 @@ class IonizedBox(OutputStructZ):
         if isinstance(input_box, InitialConditions):
             if (
                 self.user_params.USE_RELATIVE_VELOCITIES
-                and self.flag_options.USE_MINI_HALOS and not self.flag_options.FIX_VCB_AVG
+                and self.flag_options.USE_MINI_HALOS
+                and not self.flag_options.FIX_VCB_AVG
             ):
                 required += ["lowres_vcb"]
         elif isinstance(input_box, PerturbedField):


### PR DESCRIPTION
This PR solves issue #484. It reduces the used memory and improves (slightly) runtime when either `USE_MINI_HALOS=False` or `FIX_VCB_AVG=True`.