### PR TITLE
Existence of output initial velocities depend on PERTURB_ON_HIGH_RES

### DIFF
--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -485,13 +485,13 @@ class InitialConditions(OutputStruct):
     _compat_hash = _HashType.user_cosmo
 
     lowres_density = _arrayfield()
-    lowres_vx = _arrayfield()
-    lowres_vy = _arrayfield()
-    lowres_vz = _arrayfield()
+    lowres_vx = _arrayfield(optional=True)
+    lowres_vy = _arrayfield(optional=True)
+    lowres_vz = _arrayfield(optional=True)
     hires_density = _arrayfield()
-    hires_vx = _arrayfield()
-    hires_vy = _arrayfield()
-    hires_vz = _arrayfield()
+    hires_vx = _arrayfield(optional=True)
+    hires_vy = _arrayfield(optional=True)
+    hires_vz = _arrayfield(optional=True)
 
     lowres_vx_2LPT = _arrayfield(optional=True)
     lowres_vy_2LPT = _arrayfield(optional=True)
@@ -514,24 +514,33 @@ class InitialConditions(OutputStruct):
 
         out = {
             "lowres_density": Array(shape, dtype=np.float32),
-            "lowres_vx": Array(shape, dtype=np.float32),
-            "lowres_vy": Array(shape, dtype=np.float32),
-            "lowres_vz": Array(shape, dtype=np.float32),
             "hires_density": Array(hires_shape, dtype=np.float32),
-            "hires_vx": Array(hires_shape, dtype=np.float32),
-            "hires_vy": Array(hires_shape, dtype=np.float32),
-            "hires_vz": Array(hires_shape, dtype=np.float32),
         }
+        if inputs.user_params.PERTURB_ON_HIGH_RES:
+            out |= {
+                "hires_vx": Array(hires_shape, dtype=np.float32),
+                "hires_vy": Array(hires_shape, dtype=np.float32),
+                "hires_vz": Array(hires_shape, dtype=np.float32),
+            }
+        else:
+            out |= {
+                "lowres_vx": Array(shape, dtype=np.float32),
+                "lowres_vy": Array(shape, dtype=np.float32),
+                "lowres_vz": Array(shape, dtype=np.float32),
+            }
 
         if inputs.user_params.PERTURB_ALGORITHM == "2LPT":
             out |= {
-                "lowres_vx_2LPT": Array(shape, dtype=np.float32),
-                "lowres_vy_2LPT": Array(shape, dtype=np.float32),
-                "lowres_vz_2LPT": Array(shape, dtype=np.float32),
                 "hires_vx_2LPT": Array(hires_shape, dtype=np.float32),
                 "hires_vy_2LPT": Array(hires_shape, dtype=np.float32),
                 "hires_vz_2LPT": Array(hires_shape, dtype=np.float32),
             }
+            if not inputs.user_params.PERTURB_ON_HIGH_RES:
+                out |= {
+                    "lowres_vx_2LPT": Array(shape, dtype=np.float32),
+                    "lowres_vy_2LPT": Array(shape, dtype=np.float32),
+                    "lowres_vz_2LPT": Array(shape, dtype=np.float32),
+                }
 
         if inputs.user_params.USE_RELATIVE_VELOCITIES:
             out["lowres_vcb"] = Array(shape, dtype=np.float32)


### PR DESCRIPTION
This change was made to reduce used memory.
If `PERTURB_ON_HIGH_RES = True`, then only hires initial velocities exist.
If `PERTURB_ON_HIGH_RES = False`, then only lowres initial velocities exist. However, note that if `PERTURB_ALGORITHM == "2LPT"`, we must also have 2LPT hires initial velocities (even if we don't use them as an output), as these boxes are always used as an intermediate storage place for the 2LPT calculation, regardless the value of `PERTURB_ON_HIGH_RES`.

NOTE: In the future, we may come up with a similar logic when `PERTURB_ALGORITHM=LINEAR`, in this case the initial velocities are not used at all for the perturbed density and velocity fields. However, these initial velocities can be used in `PerturbHaloField` so they should still exist and be computed if `USE_HALO_FIELD=True` (and `FIXED_HALO_GRIDS=False`). So a future PR should be something like if `PERTURB_ALGORITHM=LINEAR` and (`USE_HALO_FIELD=False` or `FIXED_HALO_GRIDS=True`)->don't bother calculating and saving initial velocities.