### PR TITLE
copy the test workflow installation to the benchmarks

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -20,17 +20,13 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-            # auto-update-conda: true
             channels: conda-forge,defaults
             python-version: 3.11
-            environment-file: ci/ubuntu-latest-env.yml
-            activate-environment: tests
             channel-priority: true
 
-      - name: Get C Libraries
+      - name: Install Non-Python Dependencies
         run: |
-          sudo apt-get install libfftw3-dev
-          sudo apt-get install libgsl0-dev
+          conda install fftw gsl
 
       - name: Install 21cmFAST
         run: |


### PR DESCRIPTION
PR #487 changed the installation strategy in our test workflows be much simpler, however they did not update the benchmark workflow, which now fails due to the missing environment file. This updates the installation in the bencher workflow to mimic the others.