### PR TITLE
fixed some bugs when PERTURB_ON_HIGH_RES=True

### DIFF
--- a/src/py21cmfast/src/PerturbField.c
+++ b/src/py21cmfast/src/PerturbField.c
@@ -763,7 +763,9 @@ int ComputePerturbField(float redshift, InitialConditions *boxes, PerturbedField
                                               (unsigned long long)(k * f_pixel_factor + 0.5))) /
                                 (float)TOT_NUM_PIXELS;
 
-                            *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i, j, k)) -= 1.;
+                            if (matter_options_global->PERTURB_ALGORITHM > 0) {
+                                *((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i, j, k)) -= 1.;
+                            }
 
                             if (*((float *)LOWRES_density_perturb + HII_R_FFT_INDEX(i, j, k)) <
                                 -1) {

--- a/src/py21cmfast/wrapper/inputs.py
+++ b/src/py21cmfast/wrapper/inputs.py
@@ -537,14 +537,6 @@ class MatterOptions(InputStruct):
         if val and not self.USE_HALO_FIELD:
             raise ValueError("HALO_STOCHASTICITY is True but USE_HALO_FIELD is False")
 
-        if val and self.PERTURB_ON_HIGH_RES:
-            msg = (
-                "Since the lowres density fields are required for the halo sampler"
-                "We are currently unable to use PERTURB_ON_HIGH_RES and HALO_STOCHASTICITY"
-                "Simultaneously."
-            )
-            raise NotImplementedError(msg)
-
         if val and self.USE_INTERPOLATION_TABLES != "hmf-interpolation":
             msg = (
                 "The halo sampler enabled with HALO_STOCHASTICITY requires the use of HMF interpolation tables."

--- a/tests/test_input_structs.py
+++ b/tests/test_input_structs.py
@@ -273,12 +273,6 @@ def test_simulation_options():
 
 
 def test_matter_options():
-    msg = r"Since the lowres density fields are required for the halo sampler"
-    with pytest.raises(NotImplementedError, match=msg):
-        MatterOptions(
-            PERTURB_ON_HIGH_RES=True, USE_HALO_FIELD=True, HALO_STOCHASTICITY=True
-        )
-
     msg = r"The halo sampler enabled with HALO_STOCHASTICITY requires the use of HMF interpolation tables."
     with pytest.raises(ValueError, match=msg):
         MatterOptions(


### PR DESCRIPTION
This PR solves two bugs when `PERTURB_ON_HIGH_RES=True`:

1. In **InitialConditions.c**: if `PERTURB_ON_HIGH_RES=True` then `lowres_density` was not filled, thereby it was an array of all zeros. Now, `lowres_density` is always filled, regardless the value of `PERTURB_ON_HIGH_RES`. This change prevents a segmentation fault error when `HALO_STOCHASTICITY=False`, and there is a need to integrate over the conditional mass function where `lowres_density` serves as the conditional density (I am not sure why this segfault error happened in first place). NOTE: There is already an automatic error message that is thrown if `PERTURB_ON_HIGH_RES=True` and `HALO_STOCHASTICITY=True`, so this fix only handles the scenario where the latter is False.
2. In **PerturbField**: if `PERTURB_ALGORITHM='LINEAR'`, the code still subtracted -1 from all the cells of the perturbed density field, causing the output overdensity field to have an unphysical non-zero mean. Now, the subtraction by -1 is done only if `PERTURB_ALGORITHM!='LINEAR'`, so in the linear case we get a zero mean overdensity box, as required.