### PR TITLE
Log the compiler choice during installation

### DIFF
--- a/build_cffi.py
+++ b/build_cffi.py
@@ -6,7 +6,10 @@ import sysconfig
 from cffi import FFI
 
 # Get the compiler. We support gcc and clang.
+# The compiler is determnined from the environment and uses sysconfig as a fallback.
+source = "environment variable 'CC'" if "CC" in os.environ else "sysconfig"
 _compiler = os.environ.get("CC", sysconfig.get_config_var("CC"))
+print(f"Using compiler from {source}: {_compiler}")
 
 if "gcc" in _compiler:
     compiler = "gcc"


### PR DESCRIPTION
This is a follow up to #480. This PR adds a log entry documenting why the value of `_compiler` was set, either because of an ENV var or because of the fallback specified by `sysconfig`.

Running `pip install -v ...` now produces output along the lines of:
```
...
DEBUG         See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
DEBUG         ********************************************************************************
DEBUG
DEBUG !!
DEBUG   self._finalize_license_expression()
DEBUG Using compiler from environment variable 'CC': gcc
DEBUG running dist_info
DEBUG creating /home/remy/.cache/uv/builds-v0/.tmpSbFtEc/metadata_directory/21cmFAST.egg-info
DEBUG writing /home/remy/.cache/uv/builds-v0/.tmpSbFtEc/metadata_directory/21cmFAST.egg-info/PKG-INFO
DEBUG writing dependency_links to /home/remy/.cache/uv/builds-v0/.tmpSbFtEc/metadata_directory/21cmFAST.egg-info/dependency_links.txt
DEBUG writing entry points to /home/remy/.cache/uv/builds-v0/.tmpSbFtEc/metadata_directory/21cmFAST.egg-info/entry_points.txt
DEBUG writing requirements to /home/remy/.cache/uv/builds-v0/.tmpSbFtEc/metadata_directory/21cmFAST.egg-info/requires.txt
DEBUG writing top-level names to /home/remy/.cache/uv/builds-v0/.tmpSbFtEc/metadata_directory/21cmFAST.egg-info/top_level.txt
DEBUG writing manifest file '/home/remy/.cache/uv/builds-v0/.tmpSbFtEc/metadata_directory/21cmFAST.egg-info/SOURCES.txt'
DEBUG adding license file 'LICENSE'
...
```
This output is also shown if the install fails (in particular when the `ValueError` is raised: `ValueError(f"Compiler {_compiler} not supported for 21cmFAST")`