### PR TITLE
ci: fix deploy to install fftw and co

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: Publish Python distributions to PyPI
 
 on:
   release:
-    types: [published]
+    types: [published, edited]
 
 jobs:
   build-n-publish:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,6 +20,11 @@ jobs:
       - name: Install Build Tools
         run: pip install build
 
+      - name: Get C Libraries Linux
+        run: |
+          sudo apt-get install libfftw3-dev
+          sudo apt-get install libgsl0-dev
+
       - name: Build a binary wheel
         run: |
           python -m build .


### PR DESCRIPTION
This hopefully fixes the deployment to PyPI -- it installs fftw and gsl in the env before doing the build, and also makes it possible to run the deploy action when a release is _edited_, so we can just edit the already-existing release to re-trigger the deployment