### PR TITLE
Fix double regen pop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ test_req = [
     "pytest-benchmark",
     "questionary",
     "pytest-xdist",
+    "pytest-mock",
 ]
 
 doc_req = ["nbsphinx", "numpydoc", "sphinx >= 1.3", "sphinx-rtd-theme"]

--- a/src/py21cmfast/drivers/_param_config.py
+++ b/src/py21cmfast/drivers/_param_config.py
@@ -389,7 +389,6 @@ class _OutputStructComputationInspect:
         Checks the given input parameters for cache-related keywords and manages reading
         an OutputStruct from cache if possible and desired.
         """
-
         if cache is None or regen:
             return
 

--- a/src/py21cmfast/drivers/_param_config.py
+++ b/src/py21cmfast/drivers/_param_config.py
@@ -380,21 +380,22 @@ class _OutputStructComputationInspect:
     def _handle_read_from_cache(
         self,
         inputs: InputParameters,
-        current_redshfit: float | None,
+        current_redshift: float | None,
         cache: OutputCache | None,
-        kwargs: dict[str, Any],
+        regen: bool = True,
     ) -> OutputStruct | None:
         """Handle potential reading from cache.
 
         Checks the given input parameters for cache-related keywords and manages reading
         an OutputStruct from cache if possible and desired.
         """
-        if kwargs.pop("regenerate", True):
+
+        if cache is None or regen:
             return
 
         # First check whether the boxes already exist.
         if issubclass(self._kls, OutputStructZ):
-            obj = self._kls.new(inputs=inputs, redshift=current_redshfit)
+            obj = self._kls.new(inputs=inputs, redshift=current_redshift)
         else:
             obj = self._kls.new(inputs=inputs)
 
@@ -404,11 +405,11 @@ class _OutputStructComputationInspect:
                 this = h5.read_output_struct(path)
                 if hasattr(this, "redshift"):
                     logger.info(
-                        f"Existing {obj.__name__} found at z={this.redshift} and read in (seed={this.random_seed})."
+                        f"Existing {obj._name} found at z={this.redshift} and read in (seed={this.random_seed})."
                     )
                 else:
                     logger.info(
-                        f"Existing {obj.__name__} found and read in (seed={this.random_seed})."
+                        f"Existing {obj._name} found and read in (seed={this.random_seed})."
                     )
                 return this
 
@@ -450,7 +451,7 @@ class single_field_func(_OutputStructComputationInspect):  # noqa: N801
         write = kwargs.pop("write", False)
         out = None
         if cache is not None and not regen:
-            out = self._handle_read_from_cache(inputs, current_redshift, cache, kwargs)
+            out = self._handle_read_from_cache(inputs, current_redshift, cache, regen)
 
         if "inputs" in self._signature.parameters:
             # Here we set the inputs (if accepted by the function signature)

--- a/src/py21cmfast/drivers/_param_config.py
+++ b/src/py21cmfast/drivers/_param_config.py
@@ -390,7 +390,7 @@ class _OutputStructComputationInspect:
         an OutputStruct from cache if possible and desired.
         """
         if cache is None or regen:
-            return
+            return None
 
         # First check whether the boxes already exist.
         if issubclass(self._kls, OutputStructZ):
@@ -448,9 +448,8 @@ class single_field_func(_OutputStructComputationInspect):  # noqa: N801
         cache = kwargs.pop("cache", None)
         regen = kwargs.pop("regenerate", True)
         write = kwargs.pop("write", False)
-        out = None
-        if cache is not None and not regen:
-            out = self._handle_read_from_cache(inputs, current_redshift, cache, regen)
+
+        out = self._handle_read_from_cache(inputs, current_redshift, cache, regen)
 
         if "inputs" in self._signature.parameters:
             # Here we set the inputs (if accepted by the function signature)

--- a/src/py21cmfast/drivers/coeval.py
+++ b/src/py21cmfast/drivers/coeval.py
@@ -594,6 +594,7 @@ def _redshift_loop_generator(
             hbox_arr += [this_halobox]
             if inputs.matter_options.USE_HALO_FIELD:
                 xrs = sf.compute_xray_source_field(
+                    redshift=z,
                     hboxes=hbox_arr,
                     write=write.xray_source_box,
                     **kw,

--- a/src/py21cmfast/drivers/single_field.py
+++ b/src/py21cmfast/drivers/single_field.py
@@ -398,6 +398,7 @@ def compute_xray_source_field(
     *,
     initial_conditions: InitialConditions,
     hboxes: list[HaloBox],
+    redshift: float,
 ) -> XraySourceBox:
     r"""
     Compute filtered grid of SFR for use in spin temperature calculation.
@@ -427,7 +428,6 @@ def compute_xray_source_field(
     """
     z_halos = [hb.redshift for hb in hboxes]
     inputs = hboxes[0].inputs
-    redshift = z_halos[-1]
 
     # Initialize halo list boxes.
     box = XraySourceBox.new(redshift=redshift, inputs=inputs)

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -12,6 +12,8 @@ from py21cmfast import (
     InputParameters,
     IonizedBox,
     PerturbedField,
+    compute_initial_conditions,
+    perturb_field,
 )
 from py21cmfast.io import caching, h5
 from py21cmfast.wrapper import outputs
@@ -265,3 +267,28 @@ class TestOutputCache:
             assert f is not f2
 
         assert not cache.find_existing(ib2)
+
+    def test_regeneration(
+        self,
+        default_input_struct,
+        ic,
+        cache,
+        mocker,
+    ):
+        """Test that the rengerate keyword works as intended, skipping calculation and loading from cache."""
+        reader_spy = mocker.spy(h5, "read_output_struct")
+        compute_spy = mocker.spy(InitialConditions, "compute")
+
+        ics_noregen = compute_initial_conditions(
+            inputs=default_input_struct, regenerate=False, cache=cache
+        )
+        assert reader_spy.call_count == 1
+        assert compute_spy.call_count == 0
+        assert ics_noregen == ic
+
+        ics_regen = compute_initial_conditions(
+            inputs=default_input_struct, regenerate=True, cache=cache
+        )
+        assert reader_spy.call_count == 1
+        assert compute_spy.call_count == 1
+        assert ics_regen == ic

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -286,9 +286,12 @@ class TestOutputCache:
         assert compute_spy.call_count == 0
         assert ics_noregen == ic
 
+        reader_spy.reset_mock()
+        compute_spy.reset_mock()
+
         ics_regen = compute_initial_conditions(
             inputs=default_input_struct, regenerate=True, cache=cache
         )
-        assert reader_spy.call_count == 1
+        assert reader_spy.call_count == 0
         assert compute_spy.call_count == 1
         assert ics_regen == ic


### PR DESCRIPTION
the `regenerate` keyword was double-popped in the `single_field_func` wrapper. This fixes the bug and adds a test using `pytest-mock` that the regeneration works as intended for single fields.