### PR TITLE
Fix checkpointing

### DIFF
--- a/src/py21cmfast/drivers/coeval.py
+++ b/src/py21cmfast/drivers/coeval.py
@@ -32,7 +32,7 @@ from ..wrapper.outputs import (
 )
 from ..wrapper.photoncons import _get_photon_nonconservation_data, setup_photon_cons
 from . import single_field as sf
-from ._param_config import check_consistency_of_outputs_with_inputs, high_level_func
+from ._param_config import high_level_func
 
 logger = logging.getLogger(__name__)
 
@@ -304,6 +304,7 @@ def evolve_perturb_halos(
     ):
         halos = sf.determine_halo_list(
             redshift=z,
+            inputs=inputs,
             descendant_halos=halos_desc,
             write=write.halo_field,
             **kw,
@@ -592,6 +593,7 @@ def _redshift_loop_generator(
                 this_pthalo = pt_halos[iz]
 
             this_halobox = sf.compute_halo_grid(
+                inputs=inputs,
                 perturbed_halo_list=this_pthalo,
                 perturbed_field=this_perturbed_field,
                 previous_ionize_box=getattr(prev_coeval, "ionized_box", None),
@@ -614,6 +616,7 @@ def _redshift_loop_generator(
                 xrs = None
 
             this_spin_temp = sf.compute_spin_temperature(
+                inputs=inputs,
                 previous_spin_temp=getattr(prev_coeval, "ts_box", None),
                 perturbed_field=this_perturbed_field,
                 xray_source_box=xrs,
@@ -623,6 +626,7 @@ def _redshift_loop_generator(
             )
 
         this_ionized_box = sf.compute_ionization_field(
+            inputs=inputs,
             previous_ionized_box=getattr(prev_coeval, "ionized_box", None),
             perturbed_field=this_perturbed_field,
             # perturb field *not* interpolated here.
@@ -698,13 +702,6 @@ def _setup_ics_and_pfs_for_scrolling(
         initial_conditions = sf.compute_initial_conditions(
             inputs=inputs, write=write.initial_conditions, **iokw
         )
-
-    # We want to be able to pass in initial conditions with
-    # compatible, but not identical inputs. In which case we take
-    # all the zgrid/astro parameters from the input structure
-    if inputs is not None:
-        check_consistency_of_outputs_with_inputs(inputs, [initial_conditions])
-        initial_conditions.inputs = inputs
 
     # We can go ahead and purge some of the stuff in the initial_conditions, but only if
     # it is cached -- otherwise we could be losing information.

--- a/src/py21cmfast/drivers/coeval.py
+++ b/src/py21cmfast/drivers/coeval.py
@@ -513,7 +513,6 @@ def _obtain_starting_point_for_scrolling(
     logger.info(f"Determining pre-cached boxes for the run in {cache}")
     rc = RunCache.from_inputs(inputs, cache)
 
-    print(f"datasets in cache {cache.list_datasets()}", flush=True)
     for idx in range(minimum_node, -1, -1):
         if not rc.is_complete_at(index=idx):
             continue
@@ -521,7 +520,6 @@ def _obtain_starting_point_for_scrolling(
         _z = inputs.node_redshifts[idx]
         outputs = rc.get_all_boxes_at_z(z=_z)
         break
-    print(f"using {outputs.keys()} at {idx}")
 
     # Create a Coeval from the outputs
     if outputs is not None:

--- a/src/py21cmfast/drivers/coeval.py
+++ b/src/py21cmfast/drivers/coeval.py
@@ -740,7 +740,12 @@ def _setup_ics_and_pfs_for_scrolling(
         disable=not progressbar,
         total=len(all_redshifts),
     ):
-        p = sf.perturb_field(redshift=z, write=write.perturbed_field, **kw)
+        p = sf.perturb_field(
+            redshift=z,
+            inputs=inputs,
+            write=write.perturbed_field,
+            **kw,
+        )
 
         if inputs.matter_options.MINIMIZE_MEMORY:
             with contextlib.suppress(OSError):

--- a/src/py21cmfast/drivers/lightcone.py
+++ b/src/py21cmfast/drivers/lightcone.py
@@ -383,6 +383,7 @@ def setup_lightcone_instance(
             },
             photon_nonconservation_data=photon_nonconservation_data,
         )
+        print(f'lc has last {lightcone._last_completed_lcidx} {lightcone._last_completed_node}')
     return lightcone
 
 
@@ -447,12 +448,9 @@ def _run_lightcone_from_perturbed_fields(
             f"redshift of the lightcone. Repeating the higher-z calculations...",
             stacklevel=2,
         )
-
-    lightcone._last_completed_node = idx
-    lightcone._last_completed_lcidx = (
-        np.sum(lightcone.lightcone_redshifts >= scrollz[lightcone._last_completed_node])
-        - 1
-    )
+    
+    print(f'after start lc has last {lightcone._last_completed_lcidx} {lightcone._last_completed_node}')
+    print(f'prev is None: {prev_coeval is None}')
 
     if lightcone_filename and not Path(lightcone_filename).exists():
         lightcone.save(lightcone_filename)
@@ -502,7 +500,8 @@ def _run_lightcone_from_perturbed_fields(
 
             # only checkpoint if we have slices
             if lightcone_filename and lc_index is not None:
-                lightcone.make_checkpoint(lightcone_filename, lcidx=idx, node_index=iz)
+                print(f"making checkpoint to {lc_index}")
+                lightcone.make_checkpoint(lightcone_filename, lcidx=lc_index, node_index=iz)
 
         prev_coeval = coeval
 

--- a/src/py21cmfast/drivers/single_field.py
+++ b/src/py21cmfast/drivers/single_field.py
@@ -186,7 +186,7 @@ def perturb_halo_list(
     Fill this in once finalised
 
     """
-    inputs = initial_conditions.inputs
+    inputs = halo_field.inputs
     hbuffer_size = halo_field.n_halos
     redshift = halo_field.redshift
 

--- a/src/py21cmfast/io/caching.py
+++ b/src/py21cmfast/io/caching.py
@@ -394,7 +394,9 @@ class RunCache:
         for kind in attrs.asdict(self, recurse=False).values():
             if not isinstance(kind, dict):
                 continue
+            print(f"looking for {kind[z]}", flush=True)
             if not kind[z].exists():
+                print("not found")
                 return False
         return True
 

--- a/src/py21cmfast/io/caching.py
+++ b/src/py21cmfast/io/caching.py
@@ -394,9 +394,7 @@ class RunCache:
         for kind in attrs.asdict(self, recurse=False).values():
             if not isinstance(kind, dict):
                 continue
-            print(f"looking for {kind[z]}", flush=True)
             if not kind[z].exists():
-                print("not found")
                 return False
         return True
 

--- a/src/py21cmfast/lightcones.py
+++ b/src/py21cmfast/lightcones.py
@@ -193,7 +193,7 @@ class Lightconer(ABC):
         # last slice (lowest redshift) may correspond *exactly* to the lowest coeval
         # box, and due to rounding error in the `z_at_value` call, they might be
         # slightly off.
-        lcidx = np.nonzero((pixlcdist >= dcmin * 0.9999) & (pixlcdist < dcmax))[0]
+        lcidx = np.nonzero((pixlcdist >= dcmin * (1 - 1e-6)) & (pixlcdist < dcmax))[0]
 
         # Return early if no lightcone indices are between the coeval distances.
         if len(lcidx) == 0:

--- a/tests/test_drivers_coev.py
+++ b/tests/test_drivers_coev.py
@@ -53,7 +53,7 @@ def test_coeval_warnings(default_input_struct_lc, cache):
             USE_HALO_FIELD=True,
         )
         run_coeval(
-            out_redshifts=8.0,
+            out_redshifts=16.0,
             inputs=inputs,
             write=False,
             cache=cache,

--- a/tests/test_drivers_coev.py
+++ b/tests/test_drivers_coev.py
@@ -5,10 +5,13 @@ They do not test for correctness of simulations, but whether different parameter
 work/don't work as intended.
 """
 
+import attrs
 import pytest
 
 import py21cmfast as p21c
-from py21cmfast import run_coeval
+from py21cmfast import Coeval, run_coeval
+from py21cmfast.wrapper.arrays import Array
+from py21cmfast.wrapper.outputs import OutputStruct
 
 
 def test_coeval_st(ic, default_input_struct_ts, cache):
@@ -67,3 +70,12 @@ def test_coeval_warnings(default_input_struct_lc, cache):
             write=False,
             cache=cache,
         )
+
+
+def test_coeval_fields():
+    """Test that every array ends up in the coeval object."""
+    fields = Coeval.get_fields()
+    for kls in OutputStruct.__subclasses__():
+        for field in attrs.fields(kls):
+            if isinstance(field, Array):
+                assert field.name in fields

--- a/tests/test_drivers_lc.py
+++ b/tests/test_drivers_lc.py
@@ -184,7 +184,7 @@ def test_lc_partial_eval(rectlcn, default_input_struct_lc, tmpdirec, lc, cache):
         write=False,
         regenerate=False,
     )
-    for iz_2, z, _, finished in lc_gen_cont:
+    for iz_2, z, _, finished in lc_gen_cont:  # noqa: B007
         assert z <= 20.0
         assert iz_2 > iz_1
 

--- a/tests/test_drivers_lc.py
+++ b/tests/test_drivers_lc.py
@@ -194,6 +194,7 @@ def test_lc_partial_eval(rectlcn, default_input_struct_lc, tmpdirec, lc, cache):
     np.testing.assert_allclose(
         finished.global_quantities["brightness_temp"],
         lc.global_quantities["brightness_temp"],
+        rtol=1e-6,
     )
     np.testing.assert_allclose(
         finished.lightcones["brightness_temp"],

--- a/tests/test_drivers_lc.py
+++ b/tests/test_drivers_lc.py
@@ -176,6 +176,19 @@ def test_lc_partial_eval(rectlcn, default_input_struct_lc, tmpdirec, lc, cache):
 
     assert 0 < partial._last_completed_node < len(rectlcn.lc_redshifts) - 1
 
+    np.testing.assert_allclose(
+        partial.global_quantities["brightness_temp"][
+            : partial._last_completed_node + 1
+        ],
+        lc.global_quantities["brightness_temp"][: partial._last_completed_node + 1],
+        rtol=1e-6,
+    )
+    np.testing.assert_allclose(
+        partial.lightcones["brightness_temp"][partial._last_completed_lcidx :],
+        lc.lightcones["brightness_temp"][partial._last_completed_lcidx :],
+        rtol=1e-4,
+    )
+
     lc_gen_cont = p21c.generate_lightcone(
         lightconer=rectlcn,
         inputs=default_input_struct_lc,

--- a/tests/test_drivers_lc.py
+++ b/tests/test_drivers_lc.py
@@ -196,8 +196,9 @@ def test_lc_partial_eval(rectlcn, default_input_struct_lc, tmpdirec, lc, cache):
         lc.global_quantities["brightness_temp"],
     )
     np.testing.assert_allclose(
-        finished.lightcones["brightness_temp"][0, 0, :],
-        lc.lightcones["brightness_temp"][0, 0, :],
+        finished.lightcones["brightness_temp"],
+        lc.lightcones["brightness_temp"],
+        rtol=1e-4,
     )
 
 

--- a/tests/test_drivers_lc.py
+++ b/tests/test_drivers_lc.py
@@ -195,11 +195,6 @@ def test_lc_partial_eval(rectlcn, default_input_struct_lc, tmpdirec, lc, cache):
         finished.global_quantities["brightness_temp"],
         lc.global_quantities["brightness_temp"],
     )
-    for i in range(finished.lightcones["brightness_temp"].shape[2]):
-        print(
-            f"{i} | {finished.lightcones['brightness_temp'][0, 0, i]} || {lc.lightcones['brightness_temp'][0, 0, i]}",
-            flush=True,
-        )
     np.testing.assert_allclose(
         finished.lightcones["brightness_temp"][0, 0, :],
         lc.lightcones["brightness_temp"][0, 0, :],

--- a/tests/test_drivers_lc.py
+++ b/tests/test_drivers_lc.py
@@ -161,32 +161,50 @@ def test_lc_with_lightcone_filename(
     fname.unlink()
 
 
-def test_lc_partial_eval(rectlcn, ic, default_input_struct_lc, tmpdirec, lc, cache):
+def test_lc_partial_eval(rectlcn, default_input_struct_lc, tmpdirec, lc, cache):
     fname = tmpdirec / "lightcone_partial.h5"
 
     z = rectlcn.lc_redshifts.max()
     lc_gen = p21c.generate_lightcone(
         lightconer=rectlcn,
-        initial_conditions=ic,
         inputs=default_input_struct_lc,
         lightcone_filename=fname,
         write=True,
         cache=cache,
     )
     while z > 20.0:
-        iz, z, _, partial = next(lc_gen)
+        iz_1, z, _, partial = next(lc_gen)
 
     assert 0 < partial._last_completed_node < len(rectlcn.lc_redshifts) - 1
 
-    _, _, _, finished = p21c.run_lightcone(
+    lc_gen_cont = p21c.generate_lightcone(
         lightconer=rectlcn,
-        initial_conditions=ic,
         inputs=default_input_struct_lc,
         lightcone_filename=fname,
         cache=cache,
+        write=False,
+        regenerate=False,
     )
+    for iz_2, z, _, finished in lc_gen_cont:
+        assert z <= 20.0
+        assert iz_2 > iz_1
 
+    # this only checks the lightcone object, not the array fields
     assert finished == lc
+    # make sure we wrote to the correct indices
+    np.testing.assert_allclose(
+        finished.global_quantities["brightness_temp"],
+        lc.global_quantities["brightness_temp"],
+    )
+    for i in range(finished.lightcones["brightness_temp"].shape[2]):
+        print(
+            f"{i} | {finished.lightcones['brightness_temp'][0, 0, i]} || {lc.lightcones['brightness_temp'][0, 0, i]}",
+            flush=True,
+        )
+    np.testing.assert_allclose(
+        finished.lightcones["brightness_temp"][0, 0, :],
+        lc.lightcones["brightness_temp"][0, 0, :],
+    )
 
 
 def test_lc_lowerz_than_photon_cons(

--- a/tests/test_singlefield.py
+++ b/tests/test_singlefield.py
@@ -87,11 +87,14 @@ def test_pf_unnamed_param():
 
 
 def test_perturb_field_ic(perturbed_field, default_input_struct, ic, cache):
-    # this will run perturb_field again, since by default regenerate=True for tests.
-    # BUT it should produce exactly the same as the default perturb_field since it has
+    # this will run perturb_field again,
+    # it should produce exactly the same as the default perturb_field since it has
     # the same seed.
     pf = p21c.perturb_field(
-        redshift=perturbed_field.redshift, initial_conditions=ic, cache=cache
+        redshift=perturbed_field.redshift,
+        initial_conditions=ic,
+        cache=cache,
+        regenerate=True,
     )
 
     assert pf.density.shape == ic.lowres_density.shape


### PR DESCRIPTION
There were a few issues with the checkpointing system. Which was split into three levels:
1. Checking if an object existed already in the cache via the `single_field_func` wrapper
2. Determining the starting point of the run *from* the cache in `_obtain_starting_point_for_scrolling`
3. Checkpointing a lightcone object with `make_lightcone_checkpoint`

These changes fix the following issues with the checkpoints to make them more consistent:
- if `regenerate=True`, none of the checkpointing should run, this is now achieved by a check in (2) which sets the start to the first node
- (2) now checks if coeval `out_redshifts` or `lightcone._last_completed_node` is above the redshift of the cache completion.
- (3) now reads and writes to the correct lightcone indices, and tests have been made to check this