### PR TITLE
make r_bubble_max error clearer and add notes to the small template

### DIFF
--- a/src/py21cmfast/templates/latest-small.toml
+++ b/src/py21cmfast/templates/latest-small.toml
@@ -1,4 +1,6 @@
-# Run template for a small run
+# Run template for a small test run
+#NOTE: To use this one should disable the default R_BUBBLE_MAX errors
+#   by setting py21cmfast.config["ignore_R_BUBBLE_MAX_error"] = True
 
 [CosmoParams]
 

--- a/src/py21cmfast/wrapper/inputs.py
+++ b/src/py21cmfast/wrapper/inputs.py
@@ -1345,6 +1345,8 @@ class InputParameters:
                 msg = (
                     "Your R_BUBBLE_MAX is > BOX_LEN/3 "
                     f"({val.R_BUBBLE_MAX} > {self.simulation_options.BOX_LEN / 3})."
+                    f" This can produce strange reionisation topologies"
+                    f" To ignore this error, set `py21cmfast.config['ignore_R_BUBBLE_MAX_error'] = True`"
                 )
 
                 if config["ignore_R_BUBBLE_MAX_error"]:


### PR DESCRIPTION
@DanielaBreitman pointed out that the small template causes an error due to the R_BUBBLE_MAX size.

In future, it would be cleaner to perhaps set config from the template file, but for now we can make the error message clearer