### PR TITLE
fix: small bug in caching

### DIFF
--- a/src/py21cmfast/io/caching.py
+++ b/src/py21cmfast/io/caching.py
@@ -435,7 +435,7 @@ class RunCache:
             closest = np.argmin(np.abs(zs_of_kind - z))
             if abs(zs_of_kind[closest] - z) > match_z_within:
                 raise ValueError(
-                    f"No output struct found for kind '{kind}' at redshift {z} (closest available: {zs_of_kind[closest]} at z={closest})"
+                    f"No output struct found for kind '{kind}' at redshift {z} (closest available: {zs_of_kind[closest]} at z idx = {closest})"
                 )
             z = zs_of_kind[closest]
 

--- a/src/py21cmfast/io/caching.py
+++ b/src/py21cmfast/io/caching.py
@@ -433,11 +433,11 @@ class RunCache:
         zs_of_kind = np.array(list(getattr(self, kind).keys()))
         if z not in zs_of_kind:
             closest = np.argmin(np.abs(zs_of_kind - z))
-            if abs(closest - z) > match_z_within:
+            if abs(zs_of_kind[closest] - z) > match_z_within:
                 raise ValueError(
                     f"No output struct found for kind '{kind}' at redshift {z} (closest available: {zs_of_kind[closest]} at z={closest})"
                 )
-            z = closest
+            z = zs_of_kind[closest]
 
         fl = getattr(self, kind)[z]
         return read_output_struct(fl)

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -129,6 +129,10 @@ class TestRunCache:
                 assert isinstance(output, getattr(outputs, name))
                 assert output.redshift == z
 
+                output = cache.get_output_struct_at_z(kind=name, z=z)
+                assert isinstance(output, getattr(outputs, name))
+                assert output.redshift == z
+
                 output = cache.get_output_struct_at_z(kind=name, index=idx)
                 assert isinstance(output, getattr(outputs, name))
                 assert output.redshift == z

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -125,7 +125,7 @@ class TestRunCache:
                 continue
 
             for idx, z in enumerate(cache.inputs.node_redshifts):
-                output = cache.get_output_struct_at_z(kind=name, z=z)
+                output = cache.get_output_struct_at_z(kind=name, z=z+1e-3)
                 assert isinstance(output, getattr(outputs, name))
                 assert output.redshift == z
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -125,7 +125,7 @@ class TestRunCache:
                 continue
 
             for idx, z in enumerate(cache.inputs.node_redshifts):
-                output = cache.get_output_struct_at_z(kind=name, z=z+1e-3)
+                output = cache.get_output_struct_at_z(kind=name, z=z + 1e-3)
                 assert isinstance(output, getattr(outputs, name))
                 assert output.redshift == z
 


### PR DESCRIPTION
`get_output_struct_at_z` currently uses the index `closest` instead of the actual redshift value `zs_of_kind[closest]`.
This leads to incorrect behaviour when the user passes a given `z` to this method.