### PR TITLE
fix array shape bug, make Mcrit array optional

### DIFF
--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -724,13 +724,13 @@ int UpdateXraySourceBox(HaloBox *halobox, double R_inner, double R_outer, int R_
 
         if (R_ct == astro_params_global->N_STEP_TS - 1) LOG_DEBUG("finished XraySourceBox");
 
-        LOG_SUPER_DEBUG(
-            "R_inner = %8.3f | mean filtered sfr  = %10.3e (%10.3e MINI) unfiltered %10.3e (%10.3e "
-            "MINI) mean log10McritLW %.4e",
-            R_inner, fsfr_avg, fsfr_avg_mini, sfr_avg, sfr_avg_mini,
-            source_box->mean_log10_Mcrit_LW[R_ct]);
-        LOG_SUPER_DEBUG("R_outer = %8.3f | mean filtered xray = %10.3e unfiltered %10.3e", R_outer,
-                        fxray_avg, xray_avg);
+        LOG_SUPER_DEBUG("R = [%8.3f - %8.3f] | mean filtered sfr  = %10.3e unfiltered %10.3e",
+                        R_inner, R_outer, fsfr_avg, sfr_avg);
+        LOG_ULTRA_DEBUG("mean filtered xray = %10.3e unfiltered %10.3e", fxray_avg, xray_avg);
+        if (astro_options_global->USE_MINI_HALOS) {
+            LOG_SUPER_DEBUG("MINI: filtered sfr %10.3e unfiltered %10.3e log10_Mcrit_LW = %10.3e",
+                            fsfr_avg_mini, sfr_avg_mini, source_box->mean_log10_Mcrit_LW[R_ct]);
+        }
 
         fftwf_forget_wisdom();
         fftwf_cleanup_threads();

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -713,13 +713,13 @@ int UpdateXraySourceBox(HaloBox *halobox, double R_inner, double R_outer, int R_
                            R_outer, &xray_avg, &fxray_avg);
 
         source_box->mean_sfr[R_ct] = fsfr_avg;
-        source_box->mean_log10_Mcrit_LW[R_ct] = halobox->log10_Mcrit_MCG_ave;
         if (astro_options_global->USE_MINI_HALOS) {
             one_annular_filter(halobox->halo_sfr_mini,
                                &(source_box->filtered_sfr_mini[R_ct * HII_TOT_NUM_PIXELS]), R_inner,
                                R_outer, &sfr_avg_mini, &fsfr_avg_mini);
 
             source_box->mean_sfr_mini[R_ct] = fsfr_avg_mini;
+            source_box->mean_log10_Mcrit_LW[R_ct] = halobox->log10_Mcrit_MCG_ave;
         }
 
         if (R_ct == astro_params_global->N_STEP_TS - 1) LOG_DEBUG("finished XraySourceBox");
@@ -1382,7 +1382,7 @@ void ts_main(float redshift, float prev_redshift, float perturbed_field_redshift
             }
         }
         LOG_DEBUG("Constructed filtered boxes.");
-    } else {
+    } else if (astro_options_global->USE_MINI_HALOS) {
         for (R_ct = 0; R_ct < astro_params_global->N_STEP_TS; R_ct++) {
             ave_log10_MturnLW[R_ct] = source_box->mean_log10_Mcrit_LW[R_ct];
         }

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -1041,7 +1041,7 @@ class XraySourceBox(OutputStructZ):
     filtered_xray = _arrayfield()
     mean_sfr = _arrayfield()
     mean_sfr_mini = _arrayfield(optional=True)
-    mean_log10_Mcrit_LW = _arrayfield()
+    mean_log10_Mcrit_LW = _arrayfield(optional=True)
 
     @classmethod
     def new(cls, inputs: InputParameters, redshift: float, **kw) -> Self:
@@ -1073,14 +1073,14 @@ class XraySourceBox(OutputStructZ):
         out = {
             "filtered_sfr": Array(shape, dtype=np.float32),
             "filtered_xray": Array(shape, dtype=np.float32),
-            "mean_sfr": Array(shape, dtype=np.float64),
-            "mean_log10_Mcrit_LW": Array(
-                (inputs.astro_params.N_STEP_TS,), dtype=np.float64
-            ),
+            "mean_sfr": Array((inputs.astro_params.N_STEP_TS,), dtype=np.float64),
         }
         if inputs.astro_options.USE_MINI_HALOS:
             out["filtered_sfr_mini"] = Array(shape, dtype=np.float32)
             out["mean_sfr_mini"] = Array(
+                (inputs.astro_params.N_STEP_TS,), dtype=np.float64
+            )
+            out["mean_log10_Mcrit_LW"] = Array(
                 (inputs.astro_params.N_STEP_TS,), dtype=np.float64
             )
 


### PR DESCRIPTION
Thanks @jordanflitter for finding this. The mean sfr array has had the wrong (very large) shape for a while.

This PR also sets the MCG critical mass array to optional.