### PR TITLE
maint: changed halo field buffer

### DIFF
--- a/src/py21cmfast/src/Stochasticity.c
+++ b/src/py21cmfast/src/Stochasticity.c
@@ -859,7 +859,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field,
                         // we do not want to save these
                         if (hm_buf[i] < simulation_options_global->SAMPLER_MIN_MASS) continue;
 
-                        if (count >= arraysize_local) {
+                        if (count >= 1e6 && count >= arraysize_local) {
                             LOG_ERROR(
                                 "More than %llu halos (expected %.1e) with buffer size factor %.1f",
                                 arraysize_local,


### PR DESCRIPTION
Do not raise an error if we have less than 1e6 halos. Use the 1.2 buffer factor only above 1e6 halos.
This is because the simulation keeps crashing with e.g. `More than 111505 halos (expected 9.3e+04) with buffer size factor 1.2` where the number of halos is pretty close to the expected number with the buffer size. 