### PR TITLE
Raise error for invalid keyword in evolve_input_structs

### DIFF
--- a/src/py21cmfast/wrapper/inputs.py
+++ b/src/py21cmfast/wrapper/inputs.py
@@ -1358,6 +1358,7 @@ class InputParameters:
         and only overwrites those sub-fields instead of the entire field
         """
         struct_args = {}
+        kwargs_copy = kwargs.copy()
         for inp_type in (
             "cosmo_params",
             "simulation_options",
@@ -1367,8 +1368,12 @@ class InputParameters:
         ):
             obj = getattr(self, inp_type)
             struct_args[inp_type] = obj.clone(
-                **{k: v for k, v in kwargs.items() if hasattr(obj, k)}
+                **{k: kwargs_copy.pop(k) for k in kwargs if hasattr(obj, k)}
             )
+
+        if len(kwargs_copy):
+            wrong_key = next(iter(kwargs_copy.keys()))
+            raise TypeError(f"{wrong_key} is not a valid keyword input.")
 
         return self.clone(**struct_args)
 

--- a/tests/test_input_structs.py
+++ b/tests/test_input_structs.py
@@ -354,6 +354,14 @@ def test_inputstruct_init(default_seed):
     assert altered_struct.simulation_options.BOX_LEN == 30
 
 
+def test_bad_input(default_seed):
+    with pytest.raises(
+        TypeError,
+        match="BAD_INPUT is not a valid keyword input.",
+    ):
+        InputParameters(random_seed=default_seed).evolve_input_structs(BAD_INPUT=True)
+
+
 def test_native_template_loading(default_seed):
     template_path = Path(__file__).parent.parent / "src/py21cmfast/templates/"
     with (template_path / "manifest.toml").open("rb") as f:


### PR DESCRIPTION
Introduced a new error (and a test) if evolve_input_structs receives an invalid keyword.