### PR TITLE
Onthefly haloperturb

### DIFF
--- a/src/py21cmfast/drivers/lightcone.py
+++ b/src/py21cmfast/drivers/lightcone.py
@@ -25,10 +25,10 @@ from ..wrapper.inputs import InputParameters
 from ..wrapper.outputs import (
     BrightnessTemp,
     HaloBox,
+    HaloField,
     InitialConditions,
     IonizedBox,
     PerturbedField,
-    PerturbHaloField,
     TsBox,
 )
 from ._param_config import high_level_func
@@ -402,7 +402,7 @@ def _run_lightcone_from_perturbed_fields(
     include_dvdr_in_tau21: bool,
     apply_rsds: bool,
     n_rsd_subcells: int,
-    pt_halos: list[PerturbHaloField],
+    halofield_list: list[HaloField],
     regenerate: bool | None = None,
     cache: OutputCache = _ocache,
     cleanup: bool = True,
@@ -463,7 +463,7 @@ def _run_lightcone_from_perturbed_fields(
         initial_conditions=initial_conditions,
         all_redshifts=scrollz,
         perturbed_field=perturbed_fields,
-        pt_halos=pt_halos,
+        halofield_list=halofield_list,
         write=write,
         cleanup=cleanup,
         progressbar=progressbar,
@@ -644,7 +644,7 @@ def generate_lightcone(
     (
         initial_conditions,
         perturbed_fields,
-        pt_halos,
+        halofield_list,
         photon_nonconservation_data,
     ) = _setup_ics_and_pfs_for_scrolling(
         all_redshifts=inputs.node_redshifts,
@@ -662,7 +662,7 @@ def generate_lightcone(
         inputs=inputs,
         lc_distances=lc_distances,
         regenerate=regenerate,
-        pt_halos=pt_halos,
+        halofield_list=halofield_list,
         photon_nonconservation_data=photon_nonconservation_data,
         include_dvdr_in_tau21=include_dvdr_in_tau21,
         apply_rsds=apply_rsds,

--- a/src/py21cmfast/drivers/single_field.py
+++ b/src/py21cmfast/drivers/single_field.py
@@ -206,7 +206,7 @@ def compute_halo_grid(
     redshift: float,
     initial_conditions: InitialConditions,
     inputs: InputParameters | None = None,
-    halo_list: HaloField | None = None,
+    halo_field: HaloField | None = None,
     previous_spin_temp: TsBox | None = None,
     previous_ionize_box: IonizedBox | None = None,
 ) -> HaloBox:
@@ -245,11 +245,11 @@ def compute_halo_grid(
     """
     box = HaloBox.new(redshift=redshift, inputs=inputs)
 
-    if halo_list is None:
+    if halo_field is None:
         if not inputs.matter_options.FIXED_HALO_GRIDS:
-            raise ValueError("You must provide halo_list if FIXED_HALO_GRIDS is False")
+            raise ValueError("You must provide halo_field if FIXED_HALO_GRIDS is False")
         else:
-            halo_list = HaloField.dummy()
+            halo_field = HaloField.dummy()
 
     # NOTE: due to the order, we use the previous spin temp here, like spin_temperature,
     #       but UNLIKE ionize_box, which uses the current box
@@ -279,7 +279,7 @@ def compute_halo_grid(
 
     return box.compute(
         initial_conditions=initial_conditions,
-        halo_field=halo_list,
+        halo_field=halo_field,
         previous_ionize_box=previous_ionize_box,
         previous_spin_temp=previous_spin_temp,
     )

--- a/src/py21cmfast/drivers/single_field.py
+++ b/src/py21cmfast/drivers/single_field.py
@@ -206,7 +206,7 @@ def compute_halo_grid(
     redshift: float,
     initial_conditions: InitialConditions,
     inputs: InputParameters | None = None,
-    perturbed_halo_list: PerturbHaloField | None = None,
+    halo_list: HaloField | None = None,
     previous_spin_temp: TsBox | None = None,
     previous_ionize_box: IonizedBox | None = None,
 ) -> HaloBox:
@@ -245,13 +245,11 @@ def compute_halo_grid(
     """
     box = HaloBox.new(redshift=redshift, inputs=inputs)
 
-    if perturbed_halo_list is None:
+    if halo_list is None:
         if not inputs.matter_options.FIXED_HALO_GRIDS:
-            raise ValueError(
-                "You must provide the perturbed halo list if FIXED_HALO_GRIDS is False"
-            )
+            raise ValueError("You must provide halo_list if FIXED_HALO_GRIDS is False")
         else:
-            perturbed_halo_list = PerturbHaloField.dummy()
+            halo_list = HaloField.dummy()
 
     # NOTE: due to the order, we use the previous spin temp here, like spin_temperature,
     #       but UNLIKE ionize_box, which uses the current box
@@ -281,7 +279,7 @@ def compute_halo_grid(
 
     return box.compute(
         initial_conditions=initial_conditions,
-        pt_halos=perturbed_halo_list,
+        halo_field=halo_list,
         previous_ionize_box=previous_ionize_box,
         previous_spin_temp=previous_spin_temp,
     )

--- a/src/py21cmfast/io/caching.py
+++ b/src/py21cmfast/io/caching.py
@@ -17,7 +17,11 @@ import numpy as np
 from .._cfg import config
 from ..wrapper import outputs as op
 from ..wrapper.inputs import InputParameters
-from ..wrapper.outputs import OutputStruct, OutputStructZ, _HashType
+from ..wrapper.outputs import (
+    _ALL_OUTPUT_STRUCTS,
+    OutputStruct,
+    _HashType,
+)
 from .h5 import read_inputs, read_output_struct, write_output_to_hdf5
 
 logger = logging.getLogger(__name__)
@@ -43,7 +47,7 @@ class OutputCache:
 
     _output_to_cache_map: ClassVar = {
         kls.__name__: kls._compat_hash
-        for kls in OutputStruct.__subclasses__() + OutputStructZ.__subclasses__()
+        for name, kls in _ALL_OUTPUT_STRUCTS.items()
         if not kls._meta
     }
     _path_structures: ClassVar = {
@@ -291,7 +295,7 @@ class RunCache:
     IonizedBox: dict[float, Path] = _dict_of_paths_field()
     BrightnessTemp: dict[float, Path] = _dict_of_paths_field()
     HaloBox: dict[float, Path] | None = _dict_of_paths_field()
-    PerturbHaloField: dict[float, Path] | None = _dict_of_paths_field()
+    HaloField: dict[float, Path] | None = _dict_of_paths_field()
     XraySourceBox: dict[float, Path] | None = _dict_of_paths_field()
     inputs: InputParameters | None = attrs.field(default=None)
 
@@ -328,7 +332,7 @@ class RunCache:
         if inputs.astro_options.USE_TS_FLUCT:
             others |= {"TsBox": {}}
         if inputs.matter_options.USE_HALO_FIELD:
-            others |= {"PerturbHaloField": {}, "XraySourceBox": {}, "HaloBox": {}}
+            others |= {"HaloField": {}, "XraySourceBox": {}, "HaloBox": {}}
 
         for z in inputs.node_redshifts:
             for name, val in others.items():
@@ -541,7 +545,6 @@ class CacheConfig:
     ionized_box: bool = attrs.field(default=True, converter=bool)
     brightness_temp: bool = attrs.field(default=True, converter=bool)
     halobox: bool = attrs.field(default=True, converter=bool)
-    perturbed_halo_field: bool = attrs.field(default=True, converter=bool)
     halo_field: bool = attrs.field(default=True, converter=bool)
     xray_source_box: bool = attrs.field(default=True, converter=bool)
 
@@ -560,7 +563,6 @@ class CacheConfig:
             ionized_box=False,
             brightness_temp=False,
             halobox=False,
-            perturbed_halo_field=False,
             halo_field=False,
             xray_source_box=False,
         )
@@ -575,8 +577,7 @@ class CacheConfig:
             ionized_box=False,
             brightness_temp=False,
             halobox=False,
-            perturbed_halo_field=True,
-            halo_field=False,
+            halo_field=True,
             xray_source_box=False,
         )
 
@@ -596,7 +597,6 @@ class CacheConfig:
             ionized_box=False,
             brightness_temp=False,
             halobox=True,
-            perturbed_halo_field=True,
-            halo_field=False,
+            halo_field=True,
             xray_source_box=False,
         )

--- a/src/py21cmfast/src/HaloBox.h
+++ b/src/py21cmfast/src/HaloBox.h
@@ -47,11 +47,13 @@ typedef struct IntegralCondition {
 void set_integral_constants(IntegralCondition *consts, double redshift, double M_min, double M_max,
                             double M_cell);
 
-int ComputeHaloBox(double redshift, InitialConditions *ini_boxes, PerturbHaloField *halos,
+int ComputeHaloBox(double redshift, InitialConditions *ini_boxes, HaloField *halos,
                    TsBox *previous_spin_temp, IonizedBox *previous_ionize_box, HaloBox *grids);
 
 void get_cell_integrals(double dens, double l10_mturn_a, double l10_mturn_m,
                         ScalingConstants *consts, IntegralCondition *int_consts,
                         HaloProperties *properties);
+void set_halo_properties(double halo_mass, double M_turn_a, double M_turn_m,
+                         ScalingConstants *consts, double *input_rng, HaloProperties *output);
 
 #endif

--- a/src/py21cmfast/src/_functionprototypes_wrapper.h
+++ b/src/py21cmfast/src/_functionprototypes_wrapper.h
@@ -25,7 +25,7 @@ int ComputeIonizedBox(float redshift, float prev_redshift, PerturbedField *pertu
 int ComputeBrightnessTemp(float redshift, TsBox *spin_temp, IonizedBox *ionized_box,
                           PerturbedField *perturb_field, BrightnessTemp *box);
 
-int ComputeHaloBox(double redshift, InitialConditions *ini_boxes, PerturbHaloField *halos,
+int ComputeHaloBox(double redshift, InitialConditions *ini_boxes, HaloField *halos,
                    TsBox *previous_spin_temp, IonizedBox *previous_ionize_box, HaloBox *grids);
 
 int UpdateXraySourceBox(HaloBox *halobox, double R_inner, double R_outer, int R_ct,

--- a/src/py21cmfast/src/indexing.c
+++ b/src/py21cmfast/src/indexing.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 
 #include "InputParameters.h"
+#include "logger.h"
 
 // Minutia: Testing showed that the while loops were faster than a modulus
 // for uniformly distributed positions on a grid size greater than 8

--- a/src/py21cmfast/src/indexing.c
+++ b/src/py21cmfast/src/indexing.c
@@ -8,8 +8,8 @@
 
 #include "InputParameters.h"
 
-// Minutia: I'm guessing that since particles will rarely be wrapped, the branching
-//  will be faster than a modulus, either way this is not likely to be a bottleneck
+// Minutia: Testing showed that the while loops were faster than a modulus
+// for uniformly distributed positions on a grid size greater than 8
 void wrap_position(double pos[3], double size[3]) {
     // wrap the coordinates to the box size
     while (pos[0] >= size[0]) {

--- a/src/py21cmfast/src/map_mass.c
+++ b/src/py21cmfast/src/map_mass.c
@@ -101,7 +101,7 @@ static inline void do_cic_interpolation_float(float *resampled_box, double pos[3
     }
 }
 
-static inline double cic_read_float(float *box, double pos[3], double box_dim[3]) {
+static inline double cic_read_float(float *box, double pos[3], int box_dim[3]) {
     // get the CIC indices and distances
     int ipos[3], iposp1[3];
     double dist[3];
@@ -395,17 +395,18 @@ void move_halo_galprops(double redshift, HaloField *halos, float *vel_pointers[3
             pos[0] = pos[0] * out_dim[0] / box_size[0];
             pos[1] = pos[1] * out_dim[1] / box_size[1];
             pos[2] = pos[2] * out_dim[2] / box_size[2];
-            wrap_position(pos, out_dim);
 
-            M_turn_a = pow(10, cic_read_float(mturn_a_grid, pos, out_dim));
-            M_turn_m = pow(10, cic_read_float(mturn_m_grid, pos, out_dim));
+            if (astro_options_global->USE_MINI_HALOS) {
+                M_turn_a = pow(10, cic_read_float(mturn_a_grid, pos, out_dim));
+                M_turn_m = pow(10, cic_read_float(mturn_m_grid, pos, out_dim));
+            }
             halo_rng[0] = halos->star_rng[i];
             halo_rng[1] = halos->sfr_rng[i];
             halo_rng[2] = halos->xray_rng[i];
 
             // CIC interpolation
             set_halo_properties(hmass, M_turn_a, M_turn_m, consts, halo_rng, &properties);
-            do_cic_interpolation(boxes->halo_sfr, pos, out_dim, properties.stellar_mass);
+            do_cic_interpolation(boxes->halo_sfr, pos, out_dim, properties.halo_sfr);
             do_cic_interpolation(boxes->n_ion, pos, out_dim, properties.n_ion);
             if (astro_options_global->USE_MINI_HALOS) {
                 do_cic_interpolation(boxes->halo_sfr_mini, pos, out_dim, properties.sfr_mini);

--- a/src/py21cmfast/src/map_mass.h
+++ b/src/py21cmfast/src/map_mass.h
@@ -1,5 +1,6 @@
 
 #include "HaloBox.h"
+#include "HaloField.h"
 #include "OutputStructs.h"
 #include "scaling_relations.h"
 
@@ -11,3 +12,8 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
                         float *vel_pointers[3], float *vel_pointers_2LPT[3], int vel_dim[3],
                         HaloBox *boxes, int out_dim[3], float *mturn_a_grid, float *mturn_m_grid,
                         ScalingConstants *consts, IntegralCondition *integral_cond);
+
+void move_halo_galprops(double redshift, HaloField *halos, float *vel_pointers[3],
+                        float *vel_pointers_2LPT[3], int vel_dim[3], float *mturn_a_grid,
+                        float *mturn_m_grid, HaloBox *boxes, int out_dim[3],
+                        ScalingConstants *consts);

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -605,6 +605,29 @@ class InitialConditions(OutputStruct):
             keep.append("lowres_density")  # for the cmfs
         if self.matter_options.USE_RELATIVE_VELOCITIES:
             keep.append("lowres_vcb")
+
+        if self.matter_options.USE_HALO_FIELD:
+            if not self.matter_options.PERTURB_ON_HIGH_RES:
+                keep.append("lowres_density")
+                keep.append("lowres_vx")
+                keep.append("lowres_vy")
+                keep.append("lowres_vz")
+
+                if self.matter_options.PERTURB_ALGORITHM == "2LPT":
+                    keep.append("lowres_vx_2LPT")
+                    keep.append("lowres_vy_2LPT")
+                    keep.append("lowres_vz_2LPT")
+
+            else:
+                keep.append("hires_vx")
+                keep.append("hires_vy")
+                keep.append("hires_vz")
+
+                if self.matter_options.PERTURB_ALGORITHM == "2LPT":
+                    keep.append("hires_vx_2LPT")
+                    keep.append("hires_vy_2LPT")
+                    keep.append("hires_vz_2LPT")
+
         self.prepare(keep=keep, force=force)
 
     def get_required_input_arrays(self, input_box: OutputStruct) -> list[str]:


### PR DESCRIPTION
Next step in the new source model: The 2LPT for the halo fields is now done on-the-fly within `Halobox.c`. We use a Cloud-in-Cell both to read the turnover mass grids and to sum halo properties onto the `HII_DIM` grid.

This has effects on memory and time that are not straightforward: We should be using approximately half the memory in the halo loop from the fields since we no longer have the `PerturbHaloField` in the main run. however we need to hang onto the IC velocity fields for the entire run.

If a user wants the real location of halos, they can call `perturb_halo_field` outside of a full simulation. Since there is no RNG there this should be fine.

TODOs for this PR:
- Make this work properly with the `PERTURB_ON_HIGH_RES` flag
- Perhaps make `PerturbHaloField` return real halo properties instead of the RNG fields, since it's a post-processing field now
- fix any failing tests
- examine the new power-spectra, since we expect a reduction in shot noise from the CIC