### PR TITLE
fix: classy str bug

### DIFF
--- a/src/py21cmfast/wrapper/classy_interface.py
+++ b/src/py21cmfast/wrapper/classy_interface.py
@@ -80,7 +80,7 @@ def run_classy(**kwargs) -> Class:
         raise KeyError("You specified m_ncdm, but set N_ncdm=0.")
 
     # Set level to highest order, unless it is specified in kwargs
-    level = [kwargs.pop("level", "distortions")]
+    level = list(kwargs.pop("level", "distortions"))
 
     for k in kwargs:
         # "P_k_max_1/Mpc" cannot serve as a kwarg, but this is the input that CLASS expects to receive,


### PR DESCRIPTION
Small change to fix a bug from the classy interface when `level` is a string instead of a list.