### PR TITLE
Fixed a bug with const-zeta and updated requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "cosmotile>=0.2.5",
         "attrs",
         "tqdm",
-        "classy",
+        "classy>=3.3.4",
         "cyclopts",
         "tomlkit",
         "hmf",

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -962,10 +962,15 @@ int global_reion_properties(double zp, double x_e_ave, double *log10_Mcrit_LW_av
     LOG_DEBUG("nion zp = %.3e (%.3e MINI)", sum_nion, sum_nion_mini);
 
     double ION_EFF_FACTOR, ION_EFF_FACTOR_MINI;
-    ION_EFF_FACTOR = astro_params_global->F_STAR10 * astro_params_global->F_ESC10 *
-                     astro_params_global->POP2_ION;
-    ION_EFF_FACTOR_MINI = astro_params_global->F_STAR7_MINI * astro_params_global->F_ESC7_MINI *
-                          astro_params_global->POP3_ION;
+    if (matter_options_global->SOURCE_MODEL > 0) {
+        ION_EFF_FACTOR = astro_params_global->F_STAR10 * astro_params_global->F_ESC10 *
+                         astro_params_global->POP2_ION;
+        ION_EFF_FACTOR_MINI = astro_params_global->F_STAR7_MINI * astro_params_global->F_ESC7_MINI *
+                              astro_params_global->POP3_ION;
+    } else {
+        // no mini-halos when SOURCE_MODEL=0 (constant ionization efficiency)
+        ION_EFF_FACTOR = astro_params_global->HII_EFF_FACTOR;
+    }
 
     // NOTE: only used without MASS_DEPENDENT_ZETA
     *Q_HI = 1 - (ION_EFF_FACTOR * sum_nion + ION_EFF_FACTOR_MINI * sum_nion_mini) / (1.0 - x_e_ave);


### PR DESCRIPTION
Fix #599.

Note that `test_integration_features.py` still passes without updating the database. I believe it's because:
1. Our fiducial parameters indicate that `F_STAR10 * F_ESC10 * POP2_ION = 25`, while `HII_EFF_FACTOR = 30`. So the change is not huge when the fiducial parameters are considered.
2. This change affects only the volume filling factor `Q_HI`, but since our tests end at `z=18`, it remains `Q_HI ~ 1`.

I also updated setup.py so @DanielaBreitman could be happy :)