### PR TITLE
Optional quantities

### DIFF
--- a/src/py21cmfast/src/InputParameters.c
+++ b/src/py21cmfast/src/InputParameters.c
@@ -11,12 +11,14 @@ bool allocated_cosmo_tables = false;
 void Broadcast_struct_global_all(SimulationOptions *simulation_options,
                                  MatterOptions *matter_options, CosmoParams *cosmo_params,
                                  AstroParams *astro_params, AstroOptions *astro_options,
-                                 CosmoTables *cosmo_tables) {
+                                 CosmoTables *cosmo_tables,
+                                 OptionalQuantities *optional_quantities) {
     simulation_options_global = simulation_options;
     matter_options_global = matter_options;
     cosmo_params_global = cosmo_params;
     astro_params_global = astro_params;
     astro_options_global = astro_options;
+    optional_quantities_global = optional_quantities;
     int n;
     if (!allocated_cosmo_tables) {
         cosmo_tables_global = malloc(sizeof(CosmoTables));
@@ -89,6 +91,7 @@ CosmoParams *cosmo_params_global;
 AstroParams *astro_params_global;
 AstroOptions *astro_options_global;
 CosmoTables *cosmo_tables_global;
+OptionalQuantities *optional_quantities_global;
 
 // data paths, wisdoms, etc
 ConfigSettings config_settings;

--- a/src/py21cmfast/src/InputParameters.h
+++ b/src/py21cmfast/src/InputParameters.h
@@ -9,7 +9,8 @@
 void Broadcast_struct_global_all(SimulationOptions *simulation_options,
                                  MatterOptions *matter_options, CosmoParams *cosmo_params,
                                  AstroParams *astro_params, AstroOptions *astro_options,
-                                 CosmoTables *cosmo_tables);
+                                 CosmoTables *cosmo_tables,
+                                 OptionalQuantities *optional_quantities);
 void Broadcast_struct_global_noastro(SimulationOptions *simulation_options,
                                      MatterOptions *matter_options, CosmoParams *cosmo_params);
 

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -771,7 +771,6 @@ void calculate_fcoll_grid(IonizedBox *box, IonizedBox *previous_ionize_box,
                           struct RadiusSpec *rspec) {
     double f_coll_total = 0., f_coll_MINI_total = 0.;
     // TODO: make proper error tracking through the parallel region
-    bool error_flag;
     ScalingConstants *sc_ptr = &(consts->scale_consts);
 
     int fc_r_idx;
@@ -1191,8 +1190,8 @@ void set_ionized_temperatures(IonizedBox *box, PerturbedField *perturbed_field, 
     int box_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
                       HII_D_PARA};
 
+    unsigned long long int idx;
     if (optional_quantities_global->kinetic_temperature) {
-        unsigned long long int idx;
 #pragma omp parallel private(x, y, z, idx) num_threads(simulation_options_global -> N_THREADS)
         {
             float thistk;

--- a/src/py21cmfast/src/_functionprototypes_wrapper.h
+++ b/src/py21cmfast/src/_functionprototypes_wrapper.h
@@ -73,7 +73,8 @@ void Broadcast_struct_global_noastro(SimulationOptions *simulation_options,
 void Broadcast_struct_global_all(SimulationOptions *simulation_options,
                                  MatterOptions *matter_options, CosmoParams *cosmo_params,
                                  AstroParams *astro_params, AstroOptions *astro_options,
-                                 CosmoTables *cosmo_tables);
+                                 CosmoTables *cosmo_tables,
+                                 OptionalQuantities *optional_quantities);
 void Free_cosmo_tables_global();
 void initialiseSigmaMInterpTable(float M_Min, float M_Max);
 void initialise_GL(double lnM_Min, double lnM_Max);

--- a/src/py21cmfast/src/_inputparams_wrapper.h
+++ b/src/py21cmfast/src/_inputparams_wrapper.h
@@ -153,6 +153,12 @@ typedef struct AstroOptions {
     int INTEGRATION_METHOD_MINI;
 } AstroOptions;
 
+typedef struct OptionalQuantities {
+    bool kinetic_temp_neutral;
+    bool kinetic_temperature;
+    bool mean_free_path;
+} OptionalQuantities;
+
 typedef struct Table1D {
     int size;
     double *x_values;
@@ -191,5 +197,5 @@ extern CosmoParams *cosmo_params_global;
 extern AstroParams *astro_params_global;
 extern AstroOptions *astro_options_global;
 extern CosmoTables *cosmo_tables_global;
-
+extern OptionalQuantities *optional_quantities_global;
 extern ConfigSettings config_settings;

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -33,6 +33,7 @@ def broadcast_input_struct(inputs: InputParameters):
         inputs.astro_params.cstruct,
         inputs.astro_options.cstruct,
         inputs.cosmo_tables.cstruct,
+        inputs.optional_quantities.cstruct,
     )
 
 

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -523,7 +523,9 @@ def get_delta_crit(*, inputs: InputParameters, mass: float, redshift: float):
     """Get the critical collapse density given a mass, redshift and parameters."""
     sigma, _ = evaluate_sigma(inputs=inputs, masses=np.array([mass]))
     growth = get_growth_factor(inputs=inputs, redshift=redshift)
-    return get_delta_crit_nu(inputs.matter_options.cdict["HMF"], sigma, growth)
+    return get_delta_crit_nu(
+        inputs.matter_options.cdict["HMF"], float(sigma[0]), growth
+    )
 
 
 def get_delta_crit_nu(hmf_int_flag: int, sigma: float, growth: float):

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -1370,11 +1370,11 @@ class IonizedBox(OutputStructZ):
 
     neutral_fraction = _arrayfield()
     ionisation_rate_G12 = _arrayfield()
-    mean_free_path = _arrayfield(optional=True)  # never used
+    mean_free_path = _arrayfield(optional=True)
     z_reion = _arrayfield()
     cumulative_recombinations = _arrayfield(optional=True)
-    kinetic_temperature = _arrayfield(optional=True)  # never used
-    unnormalised_nion = _arrayfield()  # not sure about this one
+    kinetic_temperature = _arrayfield(optional=True)
+    unnormalised_nion = _arrayfield()
     unnormalised_nion_mini = _arrayfield(optional=True)
     log10_Mturnover_ave: float = attrs.field(default=None)
     log10_Mturnover_MINI_ave: float = attrs.field(default=None)

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -1237,7 +1237,7 @@ class TsBox(OutputStructZ):
 
     spin_temperature = _arrayfield()
     xray_ionised_fraction = _arrayfield()
-    kinetic_temp_neutral = _arrayfield()
+    kinetic_temp_neutral = _arrayfield(optional=True)
     J_21_LW = _arrayfield(optional=True)
     Q_HI: float = attrs.field(default=1.0)
 
@@ -1266,8 +1266,10 @@ class TsBox(OutputStructZ):
         out = {
             "spin_temperature": Array(shape, dtype=np.float32),
             "xray_ionised_fraction": Array(shape, dtype=np.float32),
-            "kinetic_temp_neutral": Array(shape, dtype=np.float32),
         }
+        if inputs.optional_quantities.kinetic_temp_neutral:
+            out["kinetic_temp_neutral"] = Array(shape, dtype=np.float32)
+
         if inputs.astro_options.USE_MINI_HALOS:
             out["J_21_LW"] = Array(shape, dtype=np.float32)
         return cls(inputs=inputs, redshift=redshift, **out, **kw)
@@ -1315,10 +1317,12 @@ class TsBox(OutputStructZ):
             required += ["density"]
         elif isinstance(input_box, TsBox):
             required += [
-                "kinetic_temp_neutral",
                 "xray_ionised_fraction",
                 "spin_temperature",
             ]
+            if self.inputs.optional_quantities.kinetic_temp_neutral:
+                required += ["kinetic_temp_neutral"]
+
             if self.astro_options.USE_MINI_HALOS:
                 required += ["J_21_LW"]
         elif isinstance(input_box, XraySourceBox):
@@ -1366,10 +1370,10 @@ class IonizedBox(OutputStructZ):
 
     neutral_fraction = _arrayfield()
     ionisation_rate_G12 = _arrayfield()
-    mean_free_path = _arrayfield()  # never used
+    mean_free_path = _arrayfield(optional=True)  # never used
     z_reion = _arrayfield()
     cumulative_recombinations = _arrayfield(optional=True)
-    kinetic_temperature = _arrayfield()  # never used
+    kinetic_temperature = _arrayfield(optional=True)  # never used
     unnormalised_nion = _arrayfield()  # not sure about this one
     unnormalised_nion_mini = _arrayfield(optional=True)
     log10_Mturnover_ave: float = attrs.field(default=None)
@@ -1430,11 +1434,14 @@ class IonizedBox(OutputStructZ):
         out = {
             "neutral_fraction": Array(shape, initfunc=np.ones, dtype=np.float32),
             "ionisation_rate_G12": Array(shape, dtype=np.float32),
-            "mean_free_path": Array(shape, dtype=np.float32),
             "z_reion": Array(shape, dtype=np.float32),
-            "kinetic_temperature": Array(shape, dtype=np.float32),
             "unnormalised_nion": Array(filter_shape, dtype=np.float32),
         }
+
+        if inputs.optional_quantities.kinetic_temp_neutral:
+            out["kinetic_temperature"] = Array(shape, dtype=np.float32)
+        if inputs.optional_quantities.mean_free_path:
+            out["mean_free_path"] = Array(shape, dtype=np.float32)
 
         if inputs.astro_options.INHOMO_RECO:
             out["cumulative_recombinations"] = Array(shape, dtype=np.float32)
@@ -1469,7 +1476,9 @@ class IonizedBox(OutputStructZ):
         elif isinstance(input_box, PerturbedField):
             required += ["density"]
         elif isinstance(input_box, TsBox):
-            required += ["kinetic_temp_neutral", "xray_ionised_fraction"]
+            required += ["xray_ionised_fraction"]
+            if self.inputs.optional_quantities.kinetic_temperature:
+                required += ["kinetic_temp_neutral"]
             if self.astro_options.USE_MINI_HALOS:
                 required += ["J_21_LW"]
         elif isinstance(input_box, IonizedBox):

--- a/tests/test_minimize_memory.py
+++ b/tests/test_minimize_memory.py
@@ -33,3 +33,17 @@ def test_minimize_memory_on_global_evolution(source_model: str):
         global_evolution_minmem.quantities["brightness_temp"],
         atol=0.1,  # mK
     )
+
+
+def test_kinetic_temperature_validator():
+    """Test that kinetic_temperature validator raises error when kinetic_temp_neutral is False."""
+    with pytest.raises(
+        ValueError,
+        match="You cannot compute the kinetic temperature of the IGM if you are not",
+    ):
+        p21c.InputParameters.from_template(
+            ["park19", "tiny"],
+            random_seed=1234,
+            kinetic_temp_neutral=False,
+            kinetic_temperature=True,
+        )


### PR DESCRIPTION
This PR adds the general ability for us to have "optional quantities" that can be output for the user, but otherwise are not required. For starters, I've added the three easiest of these (mean free path, kinetic_temp_neutral and kinetic_temperature). 

This adds a new InputStruct, but since it is a simple one, old boxes and templates should all read in just fine.