### PR TITLE
perf: don't allocation unnormalised_nion if unnecessary

### DIFF
--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -939,8 +939,10 @@ void calculate_fcoll_grid(IonizedBox *box, IonizedBox *previous_ionize_box,
                             Throw(InfinityorNaNError);
                         }
                     } else {
-                        box->unnormalised_nion[fc_r_idx * HII_TOT_NUM_PIXELS + index_r] =
-                            Splined_Fcoll;
+                        if (!consts->lagrangian_source_grids) {
+                            box->unnormalised_nion[fc_r_idx * HII_TOT_NUM_PIXELS + index_r] =
+                                Splined_Fcoll;
+                        }
                         f_coll_total += Splined_Fcoll;
                     }
                 }
@@ -1041,7 +1043,12 @@ void find_ionised_regions(IonizedBox *box, IonizedBox *previous_ionize_box,
                     else
                         curr_dens = *((float *)fg_struct->deltax_filtered + index_f);
 
-                    curr_fcoll = box->unnormalised_nion[fc_r_idx * HII_TOT_NUM_PIXELS + index_r];
+                    if (consts->lagrangian_source_grids) {
+                        curr_fcoll = *((float *)fg_struct->stars_filtered + index_f);
+                    } else {
+                        curr_fcoll =
+                            box->unnormalised_nion[fc_r_idx * HII_TOT_NUM_PIXELS + index_r];
+                    }
                     curr_fcoll = mean_fix_term_acg * curr_fcoll;
 
                     // Since the halo boxes give ionising photon output, this term accounts for the

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -1483,14 +1483,12 @@ class IonizedBox(OutputStructZ):
             if (
                 self.matter_options.mass_dependent_zeta
                 and self.astro_options.USE_MINI_HALOS
+                and not self.matter_options.lagrangian_source_grid
             ):
                 required += [
                     "unnormalised_nion",
+                    "unnormalised_nion_mini",
                 ]
-                if self.matter_options.SOURCE_MODEL == "E-INTEGRAL":
-                    required += [
-                        "unnormalised_nion_mini",
-                    ]
         elif isinstance(input_box, HaloBox):
             required += ["n_ion"]
             if self.astro_options.INHOMO_RECO:

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -1433,7 +1433,6 @@ class IonizedBox(OutputStructZ):
             "mean_free_path": Array(shape, dtype=np.float32),
             "z_reion": Array(shape, dtype=np.float32),
             "kinetic_temperature": Array(shape, dtype=np.float32),
-            "unnormalised_nion": Array(filter_shape, dtype=np.float32),
         }
 
         if inputs.astro_options.INHOMO_RECO:
@@ -1444,6 +1443,9 @@ class IonizedBox(OutputStructZ):
             and not inputs.matter_options.lagrangian_source_grid
         ):
             out["unnormalised_nion_mini"] = Array(filter_shape, dtype=np.float32)
+
+        if not inputs.matter_options.lagrangian_source_grid:
+            out["unnormalised_nion"] = Array(filter_shape, dtype=np.float32)
 
         return cls(inputs=inputs, redshift=redshift, **out, **kw)
 

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -1366,11 +1366,11 @@ class IonizedBox(OutputStructZ):
 
     neutral_fraction = _arrayfield()
     ionisation_rate_G12 = _arrayfield()
-    mean_free_path = _arrayfield()  # never used
+    mean_free_path = _arrayfield()
     z_reion = _arrayfield()
     cumulative_recombinations = _arrayfield(optional=True)
-    kinetic_temperature = _arrayfield()  # never used
-    unnormalised_nion = _arrayfield()  # not sure about this one
+    kinetic_temperature = _arrayfield()
+    unnormalised_nion = _arrayfield(optional=True)
     unnormalised_nion_mini = _arrayfield(optional=True)
     log10_Mturnover_ave: float = attrs.field(default=None)
     log10_Mturnover_MINI_ave: float = attrs.field(default=None)

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -1438,14 +1438,11 @@ class IonizedBox(OutputStructZ):
         if inputs.astro_options.INHOMO_RECO:
             out["cumulative_recombinations"] = Array(shape, dtype=np.float32)
 
-        if (
-            inputs.astro_options.USE_MINI_HALOS
-            and not inputs.matter_options.lagrangian_source_grid
-        ):
-            out["unnormalised_nion_mini"] = Array(filter_shape, dtype=np.float32)
-
         if not inputs.matter_options.lagrangian_source_grid:
             out["unnormalised_nion"] = Array(filter_shape, dtype=np.float32)
+
+            if inputs.astro_options.USE_MINI_HALOS:
+                out["unnormalised_nion_mini"] = Array(filter_shape, dtype=np.float32)
 
         return cls(inputs=inputs, redshift=redshift, **out, **kw)
 
@@ -1481,8 +1478,7 @@ class IonizedBox(OutputStructZ):
                     "cumulative_recombinations",
                 ]
             if (
-                self.matter_options.mass_dependent_zeta
-                and self.astro_options.USE_MINI_HALOS
+                self.astro_options.USE_MINI_HALOS
                 and not self.matter_options.lagrangian_source_grid
             ):
                 required += [


### PR DESCRIPTION
Removes allocation of `unnormalized_nion` when using Lagrangian source models, which is totally legit according to Mr. Claude.