### PR TITLE
ci: update pypi publish branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,6 +30,6 @@ jobs:
           python -m build .
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Updates the PyPI release action to not be master which is deprecated