### PR TITLE
ci: only create sdists

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install libfftw3-dev
           sudo apt-get install libgsl0-dev
 
-      - name: Build a binary wheel
+      - name: Build a source distribution
         run: |
           python -m build --sdist .
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build a binary wheel
         run: |
-          python -m build .
+          python -m build --sdist .
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
I think this is the one. The problem was that the build creates both a wheel (binary format) and a source distribution. Since this code is not cross-platform (i.e. it has C code) we can only create the source dist, not the wheel.