### PR TITLE
docs: improve input parameter docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ autoapi_options=[
     'undoc-members', 
     'show-inheritance', 
     'show-module-summary', 
-    'special-members', 
+    #'special-members', 
     'imported-members',
     'inherited-members',
 ]
@@ -94,7 +94,8 @@ autoapi_python_class_content = 'init'
 autoapi_member_order = 'groupwise'
 autoapi_own_page_level = 'class'
 autoapi_keep_files = True
-autodoc_typehints = 'description'
+autodoc_typehints = 'both'
+autoapi_template_dir = 'templates/autoapi'
 
 autosummary_generate = False
 numpydoc_show_class_members = False
@@ -159,11 +160,3 @@ exclude_patterns = [
     "templates",
     "**.ipynb_checkpoints",
 ]
-
-def setup(app):
-    """Setup function for Sphinx."""
-    print("SETTING UP THE CLASS BASED DECORATOR DOCUMENTER")
-    app.add_autodocumenter(ClassDecoratedDocumenter)
-    return {
-        'parallel_read_safe': True
-    }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,8 @@
 .. toctree::
    :caption: API Reference
    :hidden:
+   :maxdepth: 1
+
    autoapi/py21cmfast/index
 
 .. toctree::

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,55 +1,77 @@
-Models
-======
+Description of Physical Models
+==============================
 
-``21cmFAST`` supports many physical models. A full list of the flags that control which model to apply can be viewed with
+``21cmFAST`` supports many physical models and effects that can often be toggled on or
+off interchangeably (though some depend on others). The
+:class:`~py21cmfast.MatterOptions` and
+:class:`~py21cmfast.AstroOptions` classes contain all of the flags
+that control which models to include in the simulation.
 
-    print(py21cmfast.InputParameters(random_seed=1).matter_options)
-    print(py21cmfast.InputParameters(random_seed=1).astro_options)
 
-Below we provide a brief explanation on how some of the flags modify the output of ``21cmFAST``.
+Below we provide a brief explanation on how some of the flags modify the output of
+``21cmFAST``.
 
-``matter_options``
-----------------
+Models of the Matter Field
+--------------------------
 
-The parameters and flags of ``matter_options`` are used to control how cosmological matter fields (e.g. densities, velocities and halo properties)
-are evaluated in the simulation.
+The parameters and flags of :class:`~py21cmfast.MatterOptions`
+are used to control how cosmological matter fields (e.g. densities, velocities and halo
+properties) are evaluated in the simulation.
 
-``SOURCE_MODEL``
-~~~~~~~~~~~~~
+Source Model
+~~~~~~~~~~~~
 
-To be filled.
-
-``astro_options``
-----------------
-
-The parameters and flags of ``astro_options`` are used to control how astrophysical quantities (e.g. star formation rate, UV and ionizing radiation)
-are evaluated in the simulation.
-
-It is important to stress that the generation of ``PerturbedField`` and ``HaloCatalog`` objects do not depend on these parameters
-(nor on ``astro_params``). Therefore, if the cache contains ``PerturbedField`` and ``HaloCatalog`` objects that had been previously
-generated with a different set of ``astro_options``, these objects will be loaded from the cache, instead of being re-evaluated.
-This architecture allows one to quickly simulate different astrophysical models, given a cosmological model.
-
-``USE_TS_FLUCT``
-~~~~~~~~~~~~~~~~
+.. note:: Set with the ``SOURCE_MODEL`` parameter of :class:`~py21cmfast.MatterOptions`.
 
 To be filled.
 
-``USE_MINI_HALOS``
-~~~~~~~~~~~~~~~~
+Astrophysical Models
+--------------------
+
+The parameters and flags of :class:`~py21cmfast.AstroOptions`
+are used to control how astrophysical quantities (e.g. star formation rate, UV and
+ionizing radiation) are evaluated in the simulation.
+
+It is important to stress that the generation of
+:class:`~py21cmfast.PerturbedField` and
+:class:`~py21cmfast.HaloCatalog` objects do not depend on these
+parameters (nor on :class:`~py21cmfast.AstroParams`). Therefore, if
+the cache contains :class:`~py21cmfast.PerturbedField` and
+:class:`~py21cmfast.HaloCatalog` objects that had been previously
+generated with a different set of :class:`~py21cmfast.AstroOptions`, these objects will
+be loaded from the cache, instead of being re-evaluated.
+This architecture allows one to quickly simulate different astrophysical models, given a
+cosmological model.
+
+Spin Temperature Fluctuations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To be filled.
 
-``LYA_MULTIPLE_SCATTERING``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Minihalos
+~~~~~~~~~
 
-The physical effect that enables the absorption feature in the 21-cm signal during cosmic dawn is the strong coupling between the spin temperature
-and the gas kinetic temperature. This coupling is obtained through Lyman alpha radiation that comes from the first stars and is absorbed by the IGM.
-Since the cross section for the interaction between photons near the Lyman alpha resonance frequency and HI atoms in the IGM has a non-negligible width,
-the Lyman alpha photons that are absorbed by the IGM had not traveled in straight lines, but rather had scattered along their path. This means that the
-effective Lyman alpha emissivity that the IGM "sees" becomes more local, thereby increasing the contrast in ``J_alpha`` (Lyman alpha flux) maps in
-the simulation, as can be seen below. In the context of the 21-cm signal, this effect becomes negligible at sufficiently low redshifts (normally below ``z<15``), once the spin
-temperature completely follows gas kinetic temperature. For more information on this effect in the simulation, see (Flitter, Munoz and Mesinger 2026)[https://arxiv.org/pdf/2601.14360].
+To be filled.
+
+Multiple Scattering of Lyman Alpha Photons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note:: Toggled with the ``LYA_MULTIPLE_SCATTERING`` flag of
+   :class:`~py21cmfast.AstroOptions` (default: ``False``).
+
+The physical effect that enables the absorption feature in the 21-cm signal during
+cosmic dawn is the strong coupling between the spin temperature and the gas kinetic
+temperature. This coupling is obtained through Lyman alpha radiation that comes from the
+first stars and is absorbed by the IGM. Since the cross section for the interaction
+between photons near the Lyman alpha resonance frequency and HI atoms in the IGM has a
+non-negligible width, the Lyman alpha photons that are absorbed by the IGM had not
+traveled in straight lines, but rather had scattered along their path. This means that
+the effective Lyman alpha emissivity that the IGM "sees" becomes more local, thereby
+increasing the contrast in ``J_alpha`` (Lyman alpha flux) maps in the simulation, as can
+be seen below. In the context of the 21-cm signal, this effect becomes negligible at
+sufficiently low redshifts (normally below :math:`z<15`), once the spin temperature
+completely follows gas kinetic temperature. For more information on this effect in the
+simulation, see `Flitter, Munoz and Mesinger 2026 <https://arxiv.org/pdf/2601.14360>`_.
 
 .. image:: ./images/papers/multiple_scattering/coevals_z20.png
     :width: 800px

--- a/docs/updates_from_v3.rst
+++ b/docs/updates_from_v3.rst
@@ -3,7 +3,7 @@ Changes from v3 to v4
 =====================
 
 This page outlines the main differences between the usage of ``21cmFAST`` versions 3 and
-1. Use this documentation as a reference for understanding and adapting to the updates in
+4. Use this documentation as a reference for understanding and adapting to the updates in
 ``21cmFAST`` version 4.
 
 Stochastic Halo Sampling

--- a/docs/updates_from_v3.rst
+++ b/docs/updates_from_v3.rst
@@ -1,9 +1,9 @@
-==============================
-Changes from 21cmFAST v3 to v4
-==============================
+=====================
+Changes from v3 to v4
+=====================
 
 This page outlines the main differences between the usage of ``21cmFAST`` versions 3 and
-4. Use this documentation as a reference for understanding and adapting to the updates in
+1. Use this documentation as a reference for understanding and adapting to the updates in
 ``21cmFAST`` version 4.
 
 Stochastic Halo Sampling

--- a/src/py21cmfast/__init__.py
+++ b/src/py21cmfast/__init__.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError:  # pragma: no cover
         __version__ = "unknown"
 
 __all__ = [
-    "DATA_PATH",
+    "_DATA_PATH",
     "AngularLightconer",
     "AstroOptions",
     "AstroParams",
@@ -73,7 +73,7 @@ __all__ = [
 
 from . import lightconers, plotting, wrapper
 from ._cfg import config
-from ._data import DATA_PATH
+from ._data import _DATA_PATH
 from ._logging import configure_logging
 from ._templates import create_params_from_template, list_templates, write_template
 from .drivers.coeval import Coeval, generate_coeval, run_coeval

--- a/src/py21cmfast/_cfg.py
+++ b/src/py21cmfast/_cfg.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import ClassVar
 
 from . import yaml
-from ._data import DATA_PATH
+from ._data import _DATA_PATH
 from .c_21cmfast import ffi, lib
 from .wrapper.structs import StructInstanceWrapper
 
@@ -23,7 +23,7 @@ class Config(dict):
     _defaults: ClassVar = {
         "direc": "~/21cmFAST-cache",
         "ignore_R_BUBBLE_MAX_error": False,
-        "external_table_path": DATA_PATH,
+        "external_table_path": _DATA_PATH,
         "HALO_CATALOG_MEM_FACTOR": 1.2,
         "EXTRA_HALOBOX_FIELDS": False,
         "safe_read": True,
@@ -106,3 +106,4 @@ class Config(dict):
 
 # On import, load the default config
 config = Config()
+"""A singleton Config object used to manage global configuration options."""

--- a/src/py21cmfast/_data/__init__.py
+++ b/src/py21cmfast/_data/__init__.py
@@ -1,3 +1,3 @@
 from pathlib import Path
 
-DATA_PATH = Path(__file__).parent
+_DATA_PATH = Path(__file__).parent

--- a/src/py21cmfast/io/h5.py
+++ b/src/py21cmfast/io/h5.py
@@ -205,7 +205,7 @@ def write_outputs_to_group(
         new = array.written_to_disk(H5Backend(group.file.filename, f"{group.name}/{k}"))
         setattr(output, k, new)
 
-    for k in output.struct.primitive_fields:
+    for k in output._struct.primitive_fields:
         try:
             group.attrs[k] = getattr(output, k)
         except TypeError as e:

--- a/src/py21cmfast/plotting.py
+++ b/src/py21cmfast/plotting.py
@@ -170,7 +170,7 @@ def coeval_sliceplot(
     """
     if kind is None:
         if isinstance(struct, outputs.OutputStruct):
-            kind = struct.struct.fieldnames[0]
+            kind = struct._struct.fieldnames[0]
         elif isinstance(struct, Coeval):
             kind = "brightness_temp"
 

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -27,12 +27,12 @@ logger = logging.getLogger(__name__)
 def broadcast_input_struct(inputs: InputParameters):
     """Broadcast the parameters to the C library."""
     lib.Broadcast_struct_global_all(
-        inputs.simulation_options.cstruct,
-        inputs.matter_options.cstruct,
-        inputs.cosmo_params.cstruct,
-        inputs.astro_params.cstruct,
-        inputs.astro_options.cstruct,
-        inputs.cosmo_tables.cstruct,
+        inputs.simulation_options._cstruct,
+        inputs.matter_options._cstruct,
+        inputs.cosmo_params._cstruct,
+        inputs.astro_params._cstruct,
+        inputs.astro_options._cstruct,
+        inputs.cosmo_tables._cstruct,
     )
 
 

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -454,7 +454,7 @@ class OutputStruct(ABC):
         # Construct the args. All StructWrapper objects need to actually pass their
         # underlying cstruct, rather than themselves.
         inputs = [
-            arg.cstruct if isinstance(arg, OutputStruct | InputStruct) else arg
+            arg._cstruct if isinstance(arg, OutputStruct | InputStruct) else arg
             for arg in args
         ]
         # Sync the python/C memory

--- a/tests/io/test_caching.py
+++ b/tests/io/test_caching.py
@@ -38,7 +38,7 @@ def create_full_run_cache(cachedir: Path) -> caching.RunCache:
                     setattr(o, k, v.with_value(v.value))
 
                 # Mock the primitive fields as well...
-                for fld in o.struct.primitive_fields:
+                for fld in o._struct.primitive_fields:
                     setattr(o, fld, 0.0)
 
                 h5.write_output_to_hdf5(o, fname)

--- a/tests/test_data_exists.py
+++ b/tests/test_data_exists.py
@@ -2,20 +2,20 @@
 
 import pytest
 
-from py21cmfast import DATA_PATH
+from py21cmfast import _DATA_PATH
 
 
 @pytest.fixture(scope="module")
 def datafiles():
-    return list(DATA_PATH.glob("*.dat"))
+    return list(_DATA_PATH.glob("*.dat"))
 
 
 def test_exists(datafiles):
     for fl in datafiles:
         assert fl.exists()
 
-    assert (DATA_PATH / "x_int_tables").exists()
-    assert (DATA_PATH / "x_int_tables").is_dir()
+    assert (_DATA_PATH / "x_int_tables").exists()
+    assert (_DATA_PATH / "x_int_tables").is_dir()
 
 
 def test_readable(datafiles):

--- a/tests/test_input_structs.py
+++ b/tests/test_input_structs.py
@@ -105,9 +105,9 @@ class TestInputStructSubclasses:
         c5 = CosmoParams.new(self.cosmo)
         assert c5 == self.cosmo
         assert c5.asdict() == self.cosmo.asdict()
-        assert c5._cdict == self.cosmo._cdict
+        assert c5.cdict == self.cosmo.cdict
         assert (
-            c5._cdict != c5.asdict()
+            c5.cdict != c5.asdict()
         )  # not the same because the former doesn't include dynamic parameters.
         assert c5 == self.cosmo
 

--- a/tests/test_input_structs.py
+++ b/tests/test_input_structs.py
@@ -98,16 +98,16 @@ class TestInputStructSubclasses:
         assert self.cosmo == c4
 
         # Make sure the c data gets loaded fine.
-        assert c4.cstruct.hlittle == self.cosmo.cstruct.hlittle
+        assert c4._cstruct.hlittle == self.cosmo._cstruct.hlittle
 
     def test_asdict(self):
         """Test the asdict() method works."""
         c5 = CosmoParams.new(self.cosmo)
         assert c5 == self.cosmo
         assert c5.asdict() == self.cosmo.asdict()
-        assert c5.cdict == self.cosmo.cdict
+        assert c5._cdict == self.cosmo._cdict
         assert (
-            c5.cdict != c5.asdict()
+            c5._cdict != c5.asdict()
         )  # not the same because the former doesn't include dynamic parameters.
         assert c5 == self.cosmo
 


### PR DESCRIPTION
Updates to the documentation:

* Improves the new `models.rst` documentation to be more "human friendly"
* Fixes the main index page of the documentation so that the API appears in the left-hand scrollbar
* Updates the input parameter docstrings so that inner lists appear correctly
* Makes some attributes of the `InputStruct` private because they were never meant to be user-facing and I realized that they clutter the documentation with methods that shouldn't be exposed.