### PR TITLE
fix: bug in which cstruct attrs weren't being set for CosmoTables

### DIFF
--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -522,7 +522,7 @@ def get_delta_crit(*, inputs: InputParameters, mass: float, redshift: float):
     """Get the critical collapse density given a mass, redshift and parameters."""
     sigma, _ = evaluate_sigma(inputs=inputs, masses=np.array([mass]))
     growth = get_growth_factor(inputs=inputs, redshift=redshift)
-    return get_delta_crit_nu(inputs.matter_options.cdict["HMF"], sigma, growth)
+    return get_delta_crit_nu(inputs.matter_options.cdict["HMF"], sigma[0], growth)
 
 
 def get_delta_crit_nu(hmf_int_flag: int, sigma: float, growth: float):

--- a/src/py21cmfast/wrapper/inputs.py
+++ b/src/py21cmfast/wrapper/inputs.py
@@ -376,7 +376,7 @@ class CosmoTables:
             val = getattr(self, k)
             if isinstance(val, Table1D):
                 setattr(self.struct.cstruct, k, val.cstruct)
-            else:
+            elif val is not None:
                 setattr(self.struct.cstruct, k, val)
 
         return self.struct.cstruct

--- a/src/py21cmfast/wrapper/inputs.py
+++ b/src/py21cmfast/wrapper/inputs.py
@@ -376,7 +376,7 @@ class CosmoTables:
             val = getattr(self, k)
             if isinstance(val, Table1D):
                 setattr(self.struct.cstruct, k, val.cstruct)
-            elif isinstance(val, (float | bool)):
+            else:
                 setattr(self.struct.cstruct, k, val)
 
         return self.struct.cstruct


### PR DESCRIPTION
@jordanflitter the problem here was that when you read floats etc. from an HDF5 file, the type that you get is `np.float64` rather than simply `float`, so we were missing setting these values on the backend  cstruct properly.