### PR TITLE
Local primordial non-Gaussianities in initial conditions

### DIFF
--- a/src/py21cmfast/src/InitialConditions.c
+++ b/src/py21cmfast/src/InitialConditions.c
@@ -23,6 +23,8 @@
 #include "logger.h"
 #include "rng.h"
 
+typedef double (*k_weight_func)(double k_mag);
+
 void adj_complex_conj(fftwf_complex *HIRES_box) {
     /*****  Adjust the complex conjugate relations for a real array  *****/
 
@@ -543,6 +545,167 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
     }
 }
 
+/*
+    Returns the Poisson factor to convert from the overdensity field delta to the gravitational
+   potential Phi via the Poisson equation,
+
+                            Phi(k,z=0) = 3* H0^2 * Omega_m / (c^2 * k^2 * T(k)) * delta(k,z=0),
+
+    where T(k) is the linear matter density transfer function at z=0.
+    NOTE: It is important that T(k) follows the convention that it is normalized to unity at k->0
+   (e.g. EH, BBKS), otherwise the conversion is incorrect (the CLASS transfer function for example
+   is inadequate for this conversion)
+*/
+double Poisson_factor(double k) {
+    return (3. * Ho * Ho * cosmo_params_global->OMm /
+            (2. * physconst.c_cms * physconst.c_cms * k * k * transfer_function(k)) *
+            physconst.cm_per_Mpc * physconst.cm_per_Mpc);
+}
+
+// TODO: This shares similiarities with filter_box. Better to merge in the future
+void multiply_by_factor_in_Fourier_space(fftwf_complex *box, k_weight_func weight_func,
+                                         bool divide_not_mult) {
+    double factor;
+    int n_x, n_z, n_y;
+    double k_x, k_y, k_z, k_mag;
+    unsigned long long grid_index;
+    int hi_dim[3] = {
+        simulation_options_global->DIM, simulation_options_global->DIM,
+        (int)(simulation_options_global->NON_CUBIC_FACTOR * simulation_options_global->DIM)};
+    double delta_k[3] = {
+        2.0 * M_PI / simulation_options_global->BOX_LEN,
+        2.0 * M_PI / simulation_options_global->BOX_LEN,
+        2.0 * M_PI /
+            (simulation_options_global->BOX_LEN * simulation_options_global->NON_CUBIC_FACTOR)};
+
+    // loop through k-box
+#pragma omp parallel shared(box, hi_dim, delta_k, weight_func, divide_not_mult) \
+    private(n_x, n_z, n_y, k_x, k_y, k_z, k_mag, grid_index, factor)            \
+    num_threads(simulation_options_global -> N_THREADS)
+    {
+#pragma omp for
+        for (n_x = 0; n_x < hi_dim[0]; n_x++) {
+            if (n_x > (hi_dim[0] / 2)) {
+                k_x = (n_x - hi_dim[0]) * delta_k[0];
+            } else {
+                k_x = n_x * delta_k[0];
+            }
+            for (n_y = 0; n_y < hi_dim[1]; n_y++) {
+                if (n_y > (hi_dim[1] / 2)) {
+                    k_y = (n_y - hi_dim[1]) * delta_k[1];
+                } else {
+                    k_y = n_y * delta_k[1];
+                }
+                for (n_z = 0; n_z <= hi_dim[2] / 2; n_z++) {
+                    k_z = n_z * delta_k[2];  // no negative frequencies in z with fftw r2c/c2r
+                    k_mag = sqrt(k_x * k_x + k_y * k_y + k_z * k_z);
+                    grid_index = grid_index_fftw_c(n_x, n_y, n_z, hi_dim);
+                    if (k_mag == 0.) {
+                        box[grid_index] = 0.;
+                        continue;
+                    }
+                    factor = weight_func(k_mag);
+                    if (divide_not_mult) {
+                        factor = 1. / factor;
+                    }
+                    box[grid_index] *= factor;
+                }
+            }
+        }
+    }
+}
+
+/*
+    Add primordial non-Gaussianities to a Gaussian Phi box.
+    The Phi box is expected to be received and returned in real space.
+*/
+void add_pngs_to_Phi_box(fftwf_complex *box, InitialConditions *ics_boxes) {
+    int i, j, k;
+    int hi_dim[3] = {
+        simulation_options_global->DIM, simulation_options_global->DIM,
+        (int)(simulation_options_global->NON_CUBIC_FACTOR * simulation_options_global->DIM)};
+    float value, variance;
+    unsigned long long int index_f, index_r;
+
+    variance = 0.;
+// Compute first the variance of the Phi box
+#pragma omp parallel shared(box, hi_dim, variance) private(i, j, k, index_f, value) \
+    num_threads(simulation_options_global -> N_THREADS)
+    {
+#pragma omp for reduction(+ : variance)
+        for (i = 0; i < hi_dim[0]; i++) {
+            for (j = 0; j < hi_dim[1]; j++) {
+                for (k = 0; k < hi_dim[2]; k++) {
+                    index_f = grid_index_fftw_r(i, j, k, hi_dim);
+                    value = *((float *)box + index_f);
+                    variance += value * value;
+                }
+            }
+        }
+    }
+    variance /= TOT_NUM_PIXELS;
+
+// Now add the non-Gaussianities to the Phi box
+#pragma omp parallel shared(box, hi_dim, variance) private(i, j, k, index_r, index_f, value) \
+    num_threads(simulation_options_global -> N_THREADS)
+    {
+#pragma omp for
+        for (i = 0; i < hi_dim[0]; i++) {
+            for (j = 0; j < hi_dim[1]; j++) {
+                for (k = 0; k < hi_dim[2]; k++) {
+                    index_r = grid_index_general(i, j, k, hi_dim);
+                    index_f = grid_index_fftw_r(i, j, k, hi_dim);
+                    value = *((float *)box + index_f);
+                    value += cosmo_params_global->f_NL * (value * value - variance);
+                    *((float *)box + index_f) = value;
+                    ics_boxes->hires_Phi[index_r] = value;
+                }
+            }
+        }
+    }
+}
+
+/*
+    Add primordial non-Gaussianities to a Gaussian delta box.
+    The delta box is expected to be received and returned in Fourier space.
+*/
+void add_pngs_to_delta_box(fftwf_complex *box, InitialConditions *ics_boxes) {
+    int i, j, k;
+    int hi_dim[3] = {
+        simulation_options_global->DIM, simulation_options_global->DIM,
+        (int)(simulation_options_global->NON_CUBIC_FACTOR * simulation_options_global->DIM)};
+    unsigned long long int index_f;
+
+    multiply_by_factor_in_Fourier_space(box, Poisson_factor, false);
+    LOG_SUPER_DEBUG("Converted delta_G to Phi_G in Fourier space.");
+    // FFT back to real space
+    dft_c2r_cube(matter_options_global->USE_FFTW_WISDOM, simulation_options_global->DIM, D_PARA,
+                 simulation_options_global->N_THREADS, box);
+// remember to add the factor of 1/TOT_NUM_PIXELS when converting from k-space to real space
+#pragma omp parallel shared(box, hi_dim) private(i, j, k, index_f) \
+    num_threads(simulation_options_global -> N_THREADS)
+    {
+#pragma omp for
+        for (i = 0; i < hi_dim[0]; i++) {
+            for (j = 0; j < hi_dim[1]; j++) {
+                for (k = 0; k < hi_dim[2]; k++) {
+                    index_f = grid_index_fftw_r(i, j, k, hi_dim);
+                    *((float *)box + index_f) *= 1. / TOT_NUM_PIXELS;
+                }
+            }
+        }
+    }
+    add_pngs_to_Phi_box(box, ics_boxes);
+    LOG_SUPER_DEBUG("Added png to Phi_G in real space.");
+    // FFT to Fourier space
+    dft_r2c_cube(matter_options_global->USE_FFTW_WISDOM, simulation_options_global->DIM, D_PARA,
+                 simulation_options_global->N_THREADS, box);
+    multiply_by_factor_in_Fourier_space(
+        box, Poisson_factor,
+        true);  // we divide by the Poisson factor since the last argument is true
+    LOG_SUPER_DEBUG("Converted Phi_NG to delta_NG in Fourier space.");
+}
+
 // Re-write of init.c for original 21cmFAST
 int ComputeInitialConditions(unsigned long long random_seed, InitialConditions *boxes) {
     //     Generates the initial conditions: gaussian random density field
@@ -666,6 +829,10 @@ int ComputeInitialConditions(unsigned long long random_seed, InitialConditions *
         } else {
             sample_ic_modes(HIRES_box, hi_dim, box_len, r);
 
+            if (matter_options_global->PRIMORDIAL_NON_GAUSSIANITIES) {
+                add_pngs_to_delta_box(HIRES_box, boxes);
+            }
+
             memcpy(HIRES_box_saved, HIRES_box, sizeof(fftwf_complex) * KSPACE_NUM_PIXELS);
 
             /* ASSIGN HIRES DENSITY */
@@ -695,6 +862,7 @@ int ComputeInitialConditions(unsigned long long random_seed, InitialConditions *
 
             LOG_SUPER_DEBUG("Saved HIRES_box to struct.");
         }
+
         /* FILTER AND ASSIGN LOWRES DENSITY */
         memcpy(HIRES_box, HIRES_box_saved, sizeof(fftwf_complex) * KSPACE_NUM_PIXELS);
 

--- a/src/py21cmfast/src/_inputparams_wrapper.h
+++ b/src/py21cmfast/src/_inputparams_wrapper.h
@@ -17,6 +17,7 @@ typedef struct CosmoParams {
     float OMtot;
     float Y_He;
     float wl;
+    float f_NL;
 
 } CosmoParams;
 
@@ -68,6 +69,7 @@ typedef struct MatterOptions {
     int FILTER;
     int HALO_FILTER;
     bool SMOOTH_EVOLVED_DENSITY_FIELD;
+    bool PRIMORDIAL_NON_GAUSSIANITIES;
 
     int SOURCE_MODEL;
     int SAMPLE_METHOD;

--- a/src/py21cmfast/src/_outputstructs_wrapper.h
+++ b/src/py21cmfast/src/_outputstructs_wrapper.h
@@ -9,6 +9,7 @@ typedef struct InitialConditions {
     float *hires_density, *hires_vx, *hires_vy, *hires_vz, *hires_vx_2LPT, *hires_vy_2LPT,
         *hires_vz_2LPT;  // cw addition
     float *lowres_vcb;
+    float *hires_Phi;
 } InitialConditions;
 
 typedef struct PerturbedField {

--- a/src/py21cmfast/src/cosmology.h
+++ b/src/py21cmfast/src/cosmology.h
@@ -14,6 +14,7 @@ void free_ps();              /* deallocates the gsl structures from init_ps */
 double power_in_k(double k); /* Returns the value of the linear power spectrum density (i.e.
                                 <|delta_k|^2>/V) at a given k mode at z=0 */
 
+double transfer_function(double k);
 double TF_CLASS(double k, int flag_int,
                 int flag_dv);  // transfer function of matter (flag_dv=0) and relative velocities
                                // (flag_dv=1) fluctuations from CLASS

--- a/src/py21cmfast/wrapper/inputs.py
+++ b/src/py21cmfast/wrapper/inputs.py
@@ -412,6 +412,9 @@ class CosmoParams(InputStruct):
         Spectral index of the power spectrum.
     A_s: float, optional
         Amplitude of primordial curvature power spectrum, at k_pivot = 0.05 Mpc^-1.
+    f_NL: float, optional
+        This parameter controls how much local non-Gaussianity there is in the initial conditions.
+        Becomes relevant only if PRIMORDIAL_NON_GAUSSIANITIES = True in matter_options.
     """
 
     _DEFAULT_SIGMA_8: ClassVar[float] = 0.8102
@@ -451,6 +454,7 @@ class CosmoParams(InputStruct):
     )  # TODO: force this to be the sum of the others
     Y_He: float = field(default=0.24, converter=float, validator=validators.ge(0))
     wl: float = field(default=-1.0, converter=float)
+    f_NL: float = field(default=0.0, converter=float)
 
     # TODO: Combined validation via Astropy?
 
@@ -625,6 +629,8 @@ class MatterOptions(InputStruct):
     KEEP_3D_VELOCITIES: bool, optional
         Whether to keep the 3D velocities in the ICs.
         If False, only the z velocity is kept.
+    PRIMORDIAL_NON_GAUSSIANITIES: bool, optional
+        Whether to add primordial local non-Gaussianities to the initial conditions.
     SOURCE_MODEL: str, optional
         The source model to use in the simulation. Options are:
         E-INTEGRAL : The traditional excursion-set formalism, where source properties are
@@ -675,6 +681,7 @@ class MatterOptions(InputStruct):
         default="2LPT",
     )
     USE_FFTW_WISDOM: bool = field(default=False, converter=bool)
+    PRIMORDIAL_NON_GAUSSIANITIES: bool = field(default=False, converter=bool)
 
     SOURCE_MODEL: Literal[
         "CONST-ION-EFF", "E-INTEGRAL", "L-INTEGRAL", "DEXM-ESF", "CHMF-SAMPLER"

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -526,6 +526,7 @@ class InitialConditions(OutputStruct):
     hires_vz_2LPT = _arrayfield(optional=True)
 
     lowres_vcb = _arrayfield(optional=True)
+    hires_Phi = _arrayfield(optional=True)
 
     @classmethod
     def new(cls, inputs: InputParameters, **kw) -> Self:
@@ -575,6 +576,9 @@ class InitialConditions(OutputStruct):
 
         if inputs.matter_options.USE_RELATIVE_VELOCITIES:
             out["lowres_vcb"] = Array(shape, dtype=np.float32)
+
+        if inputs.matter_options.PRIMORDIAL_NON_GAUSSIANITIES:
+            out["hires_Phi"] = Array(hires_shape, dtype=np.float32)
 
         return cls(inputs=inputs, **out, **kw)
 


### PR DESCRIPTION
This PR includes the ability to have local PNGs in the initial conditions. At this moment, it only works with `POWER_SPECTRUM!=CLASS`, which is why it's in a draft state. The CLASS transfer function, being defined differently than the other transfer functions, requires a different implementation, so this PR will be in a draft state until there's also a support with having `POWER_SPECTRUM=CLASS` and `PRIMORDIAL_NON_GAUSSIANITIES=True`.

Some notes:

* According to this paper, [https://arxiv.org/pdf/1304.8049](https://arxiv.org/pdf/1304.8049), it is not enough to simply change the initial conditions, but it's also necessary to modify EPS (eq. 5). This requires computing analytically the 3-point function in linear theory. This is much harder and will be done in a future PR.
* I added an output called `hires_Phi`, just to be able to see directly how the primordial gravitational field is modified due to PNGs. It is only allocated when `PRIMORDIAL_NON_GAUSSIANITIES=True`, and it's a single (high-resolution) box in the initial conditions (unlike output boxes that we make at each node_redshift), so I'm not sure if users should be concerned about this extra memory allocation.
* I added some functions in `InitialConditions.c` like `add_pngs_to_delta_box`, `add_pngs_to_Phi_box`, `multiply_by_factor_in_Fourier_space` and `Poisson_factor`. I am not entirely sure that the last two functions should indeed be placed in `InitialConditions.c`. There is a lot of resemblance between `filter_box` and `multiply_by_factor_in_Fourier_space`, and I actually think that we could use the latter to perform the former (since filtering is actually multiplying the box in Fourier space by a k-dependent factor, this is exactly what `multiply_by_factor_in_Fourier_space` does). I am not sure this PR is the best place to do this, but I do think it worths of making an issue.