### PR TITLE
Reducing more memory with MINIMIZE_MEMORY

### DIFF
--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -538,7 +538,9 @@ double set_fully_neutral_box(IonizedBox *box, TsBox *spin_temp, PerturbedField *
                 box->neutral_fraction[ct] =
                     1. - spin_temp->xray_ionised_fraction[ct];  // convert from x_e to xH
                 global_xH += box->neutral_fraction[ct];
-                box->kinetic_temperature[ct] = spin_temp->kinetic_temp_neutral[ct];
+                if (!matter_options_global->MINIMIZE_MEMORY) {
+                    box->kinetic_temperature[ct] = spin_temp->kinetic_temp_neutral[ct];
+                }
             }
         }
         global_xH /= (double)HII_TOT_NUM_PIXELS;
@@ -549,9 +551,11 @@ double set_fully_neutral_box(IonizedBox *box, TsBox *spin_temp, PerturbedField *
 #pragma omp for
             for (ct = 0; ct < HII_TOT_NUM_PIXELS; ct++) {
                 box->neutral_fraction[ct] = global_xH;
-                box->kinetic_temperature[ct] =
-                    consts->TK_nofluct *
-                    (1.0 + consts->adia_TK_term * perturbed_field->density[ct]);
+                if (!matter_options_global->MINIMIZE_MEMORY) {
+                    box->kinetic_temperature[ct] =
+                        consts->TK_nofluct *
+                        (1.0 + consts->adia_TK_term * perturbed_field->density[ct]);
+                }
             }
         }
     }
@@ -1122,7 +1126,9 @@ void find_ionised_regions(IonizedBox *box, IonizedBox *previous_ionize_box,
                                     rspec.R * (consts->gamma_prefactor * curr_fcoll +
                                                consts->gamma_prefactor_mini * curr_fcoll_mini);
                             }
-                            box->mean_free_path[index_r] = rspec.R;
+                            if (!matter_options_global->MINIMIZE_MEMORY) {
+                                box->mean_free_path[index_r] = rspec.R;
+                            }
                         }
 
                         // keep track of the first time this cell is ionized (earliest time)
@@ -1154,14 +1160,20 @@ void find_ionised_regions(IonizedBox *box, IonizedBox *previous_ionize_box,
                                  curr_fcoll_mini * consts->ion_eff_factor_mini;
                         // put the partial ionization here because we need to exclude
                         // xHII_from_xrays...
-                        if (astro_options_global->USE_TS_FLUCT) {
-                            box->kinetic_temperature[index_r] = ComputePartiallyIonizedTemperature(
-                                spin_temp->kinetic_temp_neutral[index_r], res_xH, consts->T_re);
-                        } else {
-                            box->kinetic_temperature[index_r] = ComputePartiallyIonizedTemperature(
-                                consts->TK_nofluct *
-                                    (1 + consts->adia_TK_term * perturbed_field->density[index_r]),
-                                res_xH, consts->T_re);
+                        if (!matter_options_global->MINIMIZE_MEMORY) {
+                            if (astro_options_global->USE_TS_FLUCT) {
+                                box->kinetic_temperature[index_r] =
+                                    ComputePartiallyIonizedTemperature(
+                                        spin_temp->kinetic_temp_neutral[index_r], res_xH,
+                                        consts->T_re);
+                            } else {
+                                box->kinetic_temperature[index_r] =
+                                    ComputePartiallyIonizedTemperature(
+                                        consts->TK_nofluct *
+                                            (1 + consts->adia_TK_term *
+                                                     perturbed_field->density[index_r]),
+                                        res_xH, consts->T_re);
+                            }
                         }
                         res_xH -= xHII_from_xrays;
 
@@ -1564,7 +1576,9 @@ int ComputeIonizedBox(float redshift, float prev_redshift, PerturbedField *pertu
                                   simulation_options_global->HII_DIM, HII_D_PARA, "  ");
 #endif
             }
-            set_ionized_temperatures(box, perturbed_field, spin_temp, &ionbox_constants);
+            if (!matter_options_global->MINIMIZE_MEMORY) {
+                set_ionized_temperatures(box, perturbed_field, spin_temp, &ionbox_constants);
+            }
 
             // find the neutral fraction
             global_xH = 0;

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -1366,10 +1366,10 @@ class IonizedBox(OutputStructZ):
 
     neutral_fraction = _arrayfield()
     ionisation_rate_G12 = _arrayfield()
-    mean_free_path = _arrayfield()
     z_reion = _arrayfield()
+    mean_free_path = _arrayfield(optional=True)
     cumulative_recombinations = _arrayfield(optional=True)
-    kinetic_temperature = _arrayfield()
+    kinetic_temperature = _arrayfield(optional=True)
     unnormalised_nion = _arrayfield(optional=True)
     unnormalised_nion_mini = _arrayfield(optional=True)
     log10_Mturnover_ave: float = attrs.field(default=None)
@@ -1430,10 +1430,12 @@ class IonizedBox(OutputStructZ):
         out = {
             "neutral_fraction": Array(shape, initfunc=np.ones, dtype=np.float32),
             "ionisation_rate_G12": Array(shape, dtype=np.float32),
-            "mean_free_path": Array(shape, dtype=np.float32),
             "z_reion": Array(shape, dtype=np.float32),
-            "kinetic_temperature": Array(shape, dtype=np.float32),
         }
+
+        if not inputs.matter_options.MINIMIZE_MEMORY:
+            out["mean_free_path"] = Array(shape, dtype=np.float32)
+            out["kinetic_temperature"] = Array(shape, dtype=np.float32)
 
         if inputs.astro_options.INHOMO_RECO:
             out["cumulative_recombinations"] = Array(shape, dtype=np.float32)


### PR DESCRIPTION
`mean_free_path` and `kinetic_temperature` are allocated and computed only if `MINIMIZE_MEMORY=False` (these fields are unnecessary for the evaluation of the brightness temperature). This could be useful to @DanielaBreitman.