### PR TITLE
New Halo class for easier inspection of individual halos

### DIFF
--- a/.github/workflows/fork_pr_benchmarks_run.yml
+++ b/.github/workflows/fork_pr_benchmarks_run.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Non-Python Dependencies
         run: |
-          conda install fftw gsl numba
+          conda install pip fftw gsl numba compilers pkg-config
 
       - name: Install 21cmFAST
         run: |

--- a/.github/workflows/run-tutorials.yaml
+++ b/.github/workflows/run-tutorials.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install Non-Python Dependencies
         run: |
-          conda install fftw gsl
+          conda install pip fftw gsl numba compilers pkg-config
 
       - name: Install 21cmFAST
         run: |

--- a/src/py21cmfast/drivers/_param_config.py
+++ b/src/py21cmfast/drivers/_param_config.py
@@ -170,7 +170,7 @@ class _OutputStructComputationInspect:
 
         if recurse:
             for k, v in kwargs.items():
-                if hasattr(v, "__len__") and isinstance(v[0], OutputStruct):
+                if isinstance(v, (list, tuple)) and isinstance(v[0], OutputStruct):
                     d |= {f"{k}_{i}": vv for i, vv in enumerate(v)}
 
         return d

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -759,6 +759,22 @@ class PerturbedField(OutputStructZ):
         return self.velocity_z  # for backwards compatibility
 
 
+@attrs.define(frozen=True, slots=True)
+class Halo:
+    """Represents a single halo from a HaloCatalog.
+
+    This class wraps individual halo data extracted from a HaloCatalog,
+    providing easy access to its properties (mass, coordinates, RNG seeds, etc.).
+    """
+
+    mass: float
+    coords: np.ndarray
+    redshift: float
+    star_rng: float | None = None
+    sfr_rng: float | None = None
+    xray_rng: float | None = None
+
+
 @attrs.define(slots=False, kw_only=True)
 class HaloCatalog(OutputStructZ):
     """A class containing all fields related to halos."""
@@ -864,6 +880,28 @@ class HaloCatalog(OutputStructZ):
             ics.random_seed,
             descendant_halos,
         )
+
+    def __getitem__(self, index: int) -> Halo:
+        """Get a specific halo by index."""
+        if not isinstance(index, int) or index < 0 or index >= self.n_halos:
+            raise IndexError(f"Halo index {index} out of range [0, {self.n_halos})")
+        return Halo(
+            mass=float(self.halo_masses.value[index]),
+            coords=self.halo_coords.value[index].copy(),
+            redshift=self.redshift,
+            star_rng=float(self.star_rng.value[index]),
+            sfr_rng=float(self.sfr_rng.value[index]),
+            xray_rng=float(self.xray_rng.value[index]),
+        )
+
+    def __iter__(self):
+        """Iterate over halos in the catalog, yielding Halo objects."""
+        for i in range(self.n_halos):
+            yield self[i]
+
+    def __len__(self):
+        """Return the number of halos in the catalog."""
+        return self.n_halos
 
 
 @attrs.define(slots=False, kw_only=True)
@@ -986,6 +1024,25 @@ class PerturbedHaloCatalog(OutputStructZ):
             previous_ionize_box,
             halo_catalog,
         )
+
+    def __getitem__(self, index: int) -> Halo:
+        """Get a specific halo by index."""
+        if not isinstance(index, int) or index < 0 or index >= self.n_halos:
+            raise IndexError(f"Halo index {index} out of range [0, {self.n_halos})")
+        return Halo(
+            mass=float(self.halo_masses.value[index]),
+            coords=self.halo_coords.value[index].copy(),
+            redshift=self.redshift,
+        )
+
+    def __iter__(self):
+        """Iterate over halos in the catalog, yielding Halo objects."""
+        for i in range(self.n_halos):
+            yield self[i]
+
+    def __len__(self):
+        """Return the number of halos in the catalog."""
+        return self.n_halos
 
 
 @attrs.define(slots=False, kw_only=True)

--- a/tests/test_output_structs.py
+++ b/tests/test_output_structs.py
@@ -10,6 +10,8 @@ from py21cmfast import (
     InitialConditions,  # An example of an output struct
     InputParameters,
     config,
+    determine_halo_catalog,
+    perturb_halo_catalog,
 )
 from py21cmfast.wrapper import outputs as ox
 from py21cmfast.wrapper.arrays import Array
@@ -18,6 +20,21 @@ from py21cmfast.wrapper.arrays import Array
 @pytest.fixture
 def init(default_input_struct: InputParameters):
     return InitialConditions.new(inputs=default_input_struct)
+
+
+@pytest.fixture
+def halo_cat(ic: InitialConditions, default_input_struct: InputParameters):
+    return determine_halo_catalog(
+        redshift=10.0, initial_conditions=ic, inputs=default_input_struct
+    )
+
+
+@pytest.fixture
+def pert_halo_cat(ic: InitialConditions, halo_cat: ox.HaloCatalog):
+    return perturb_halo_catalog(
+        initial_conditions=ic,
+        halo_catalog=halo_cat,
+    )
 
 
 def test_different_seeds(
@@ -282,3 +299,68 @@ def test_bad_required_array(default_input_struct, struct):
 
     with pytest.raises(ValueError, match="is not an input required for"):
         _ = output.get_required_input_arrays(bt)
+
+
+def test_halocatalog_iteration(halo_cat: ox.HaloCatalog):
+    """Test HaloCatalog iteration, len, and indexing."""
+    # Test len
+    assert len(halo_cat) == halo_cat.n_halos
+
+    # Test iteration and indexing
+    halo_list = []
+    for halo in halo_cat:
+        halo_list.append(halo)
+        assert isinstance(halo, ox.Halo)
+        assert halo.mass is not None
+        assert halo.coords is not None
+        assert halo.star_rng is not None
+        assert halo.sfr_rng is not None
+        assert halo.xray_rng is not None
+        assert halo.redshift is not None
+
+    assert len(halo_list) == halo_cat.n_halos
+
+    # Test indexing
+    first_halo = halo_cat[0]
+    assert isinstance(first_halo, ox.Halo)
+    assert first_halo.mass == halo_list[0].mass
+    assert np.all(first_halo.coords == halo_list[0].coords)
+
+
+def test_perturbed_halocatalog_iteration(pert_halo_cat: ox.PerturbedHaloCatalog):
+    """Test PerturbedHaloCatalog iteration, len, and indexing."""
+    # Test len
+    assert len(pert_halo_cat) == pert_halo_cat.n_halos
+
+    # Test iteration and indexing
+    halo_list = []
+    for halo in pert_halo_cat:
+        halo_list.append(halo)
+        assert isinstance(halo, ox.Halo)
+        assert halo.mass is not None
+        assert halo.coords is not None
+        assert halo.redshift is not None
+
+    assert len(halo_list) == pert_halo_cat.n_halos
+
+    # Test indexing
+    first_halo = pert_halo_cat[0]
+    assert isinstance(first_halo, ox.Halo)
+    assert first_halo.mass == halo_list[0].mass
+    assert np.all(first_halo.coords == halo_list[0].coords)
+
+
+def test_bad_indices_for_halocatalog(
+    halo_cat: ox.HaloCatalog, pert_halo_cat: ox.PerturbedHaloCatalog
+):
+    """Test bad indices for halo catalog and perturbed halo catalog."""
+    with pytest.raises(IndexError, match=f"Halo index {halo_cat.n_halos} out of range"):
+        halo_cat[halo_cat.n_halos]
+    with pytest.raises(IndexError, match="Halo index -1 out of range"):
+        halo_cat[-1]
+    with pytest.raises(
+        IndexError, match=f"Halo index {pert_halo_cat.n_halos} out of range"
+    ):
+        pert_halo_cat[pert_halo_cat.n_halos]
+    with pytest.raises(IndexError, match="Halo index -1 out of range"):
+        pert_halo_cat[-1]


### PR DESCRIPTION
## Summary of Changes

### New `Halo` Class
- Introduced a new `Halo` class to represent individual halos from a catalog
- Provides clean access to halo properties: `mass`, `coords`, `redshift`, and optional RNG fields (`star_rng`, `sfr_rng`, `xray_rng`)
- RNG fields are optional (default to `None`) since they are only available in `HaloCatalog`, not in `PerturbedHaloCatalog`

### Enhanced `HaloCatalog`
- Added `__getitem__()` method to retrieve individual halos by index with bounds checking
- Added `__iter__()` method to enable iteration over halos in the catalog
- Added `__len__()` method to return the total number of halos
- Enables intuitive Pythonic access: `halo_catalog[0]` and `for halo in halo_catalog:`

### Enhanced `PerturbedHaloCatalog`
- Added the same `__getitem__()`, `__iter__()`, and `__len__()` methods for consistency
- Returns `Halo` objects containing only `mass`, `coords`, and `redshift` (no RNG fields)
- Maintains the same interface as `HaloCatalog` while respecting data availability

### Comprehensive Tests
- Added `halo_cat` and `pert_halo_cat` fixtures to reduce code duplication
- Added `test_halocatalog_iteration()` to verify iteration, indexing, and data integrity for `HaloCatalog`
- Added `test_perturbed_halocatalog_iteration()` to verify the same for `PerturbedHaloCatalog`
- Added `test_bad_indices_for_halocatalog()` to ensure proper bounds checking and error handling for both catalog types

### Design Rationale
This change enables easier inspection of individual halos from catalogs while gracefully handling differences between `HaloCatalog` (with RNG fields) and `PerturbedHaloCatalog` (without them). The optional RNG fields allow a single `Halo` class to represent halos from both sources.

## Summary by Sourcery

Introduce a Halo value object and Pythonic access patterns for halo catalogs.

New Features:
- Add an immutable Halo class to represent individual halos with mass, coordinates, redshift, and optional RNG properties.
- Enable index-based access, iteration, and len() support on HaloCatalog and PerturbedHaloCatalog, returning Halo instances.

Tests:
- Add fixtures for halo and perturbed halo catalogs and tests covering iteration, indexing, and length on both catalog types.
- Add tests ensuring out-of-range halo indices on both catalog types raise clear IndexError exceptions.