### PR TITLE
Fixed debugging printouts

### DIFF
--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -1361,7 +1361,7 @@ int ComputeIonizedBox(float redshift, float prev_redshift, PerturbedField *pertu
 
         LOG_SUPER_DEBUG("z_reion init: ");
         debugSummarizeBox(box->z_reion, simulation_options_global->HII_DIM,
-                          simulation_options_global->HII_DIM, HII_D_PARA, "  ");
+                          simulation_options_global->HII_DIM, HII_D_PARA, STANDARD_LAYOUT, "  ");
 
         // Modify the current sampled redshift to a redshift which matches the expected filling
         // factor given our astrophysical parameterisation. This is the photon non-conservation
@@ -1573,7 +1573,8 @@ int ComputeIonizedBox(float redshift, float prev_redshift, PerturbedField *pertu
 #if LOG_LEVEL >= ULTRA_DEBUG_LEVEL
                 LOG_ULTRA_DEBUG("z_reion after R=%f: ", curr_radius.R);
                 debugSummarizeBox(box->z_reion, simulation_options_global->HII_DIM,
-                                  simulation_options_global->HII_DIM, HII_D_PARA, "  ");
+                                  simulation_options_global->HII_DIM, HII_D_PARA, STANDARD_LAYOUT,
+                                  "  ");
 #endif
             }
             if (!matter_options_global->MINIMIZE_MEMORY) {

--- a/src/py21cmfast/src/PerturbedField.c
+++ b/src/py21cmfast/src/PerturbedField.c
@@ -108,7 +108,8 @@ void make_density_grid(float redshift, fftwf_complex *fft_density_grid, InitialC
                          box_dim, resampled_box, box_dim);
 
         LOG_SUPER_DEBUG("resampled_box: ");
-        debugSummarizeBoxDouble(resampled_box, box_dim[0], box_dim[1], box_dim[2], "  ");
+        debugSummarizeBoxDouble(resampled_box, box_dim[0], box_dim[1], box_dim[2], STANDARD_LAYOUT,
+                                "  ");
 
         // Resample back to a fftw float for remaining algorithm
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
@@ -129,7 +130,7 @@ void make_density_grid(float redshift, fftwf_complex *fft_density_grid, InitialC
 
         LOG_SUPER_DEBUG("density_perturb: ");
         debugSummarizeBox((float *)fft_density_grid, box_dim[0], box_dim[1],
-                          2 * (box_dim[2] / 2 + 1), "  ");
+                          2 * (box_dim[2] / 2 + 1), FFTW_REAL_LAYOUT, "  ");
     }
 }
 
@@ -205,7 +206,8 @@ void normalise_delta_grid(fftwf_complex *deltap1_grid) {
         }
     }
     LOG_SUPER_DEBUG("delta after normalisation: ");
-    debugSummarizeBox((float *)deltap1_grid, lo_dim[0], lo_dim[1], 2 * (lo_dim[2] / 2 + 1), "  ");
+    debugSummarizeBox((float *)deltap1_grid, lo_dim[0], lo_dim[1], 2 * (lo_dim[2] / 2 + 1),
+                      FFTW_REAL_LAYOUT, "  ");
 }
 
 void smooth_and_clip_density(fftwf_complex *lowres_grid, fftwf_complex *density_perturb_saved) {
@@ -227,7 +229,8 @@ void smooth_and_clip_density(fftwf_complex *lowres_grid, fftwf_complex *density_
 
     LOG_SUPER_DEBUG("delta_k after smoothing: ");
     debugSummarizeBox((float *)lowres_grid, simulation_options_global->HII_DIM,
-                      simulation_options_global->HII_DIM, 2 * (HII_D_PARA / 2 + 1), "  ");
+                      simulation_options_global->HII_DIM, 2 * (HII_D_PARA / 2 + 1),
+                      FFTW_REAL_LAYOUT, "  ");
 
     // save a copy of the k-space density field for velocity computation
     // TODO: The grid saving is awkward, it happens in different functions depending on the
@@ -241,7 +244,8 @@ void smooth_and_clip_density(fftwf_complex *lowres_grid, fftwf_complex *density_
 
     LOG_SUPER_DEBUG("delta back in real space: ");
     debugSummarizeBox((float *)lowres_grid, simulation_options_global->HII_DIM,
-                      simulation_options_global->HII_DIM, 2 * (HII_D_PARA / 2 + 1), "  ");
+                      simulation_options_global->HII_DIM, 2 * (HII_D_PARA / 2 + 1),
+                      FFTW_REAL_LAYOUT, "  ");
 
     // normalize after FFT
     int bad_count = 0;
@@ -274,7 +278,8 @@ void smooth_and_clip_density(fftwf_complex *lowres_grid, fftwf_complex *density_
     if (bad_count >= 5) LOG_WARNING("Total number of bad indices: %d", bad_count);
     LOG_SUPER_DEBUG("delta normalized: ");
     debugSummarizeBox((float *)lowres_grid, simulation_options_global->HII_DIM,
-                      simulation_options_global->HII_DIM, 2 * (HII_D_PARA / 2 + 1), "  ");
+                      simulation_options_global->HII_DIM, 2 * (HII_D_PARA / 2 + 1),
+                      FFTW_REAL_LAYOUT, "  ");
 }
 
 void compute_perturbed_velocities(unsigned short axis, double redshift,
@@ -346,8 +351,8 @@ void compute_perturbed_velocities(unsigned short axis, double redshift,
     }
 
     LOG_SUPER_DEBUG("density_perturb after modification by dDdt: ");
-    debugSummarizeBoxComplex((float complex *)velocity_fft_grid, box_dim[0], box_dim[1],
-                             box_dim[2] / 2 + 1, "  ");
+    debugSummarizeBoxComplex((fftwf_complex *)velocity_fft_grid, box_dim[0], box_dim[1],
+                             box_dim[2] / 2 + 1, FFTW_COMPLEX_LAYOUT, "  ");
 
     if (matter_options_global->PERTURB_ON_HIGH_RES &&
         simulation_options_global->DIM != simulation_options_global->HII_DIM) {
@@ -379,7 +384,7 @@ void compute_perturbed_velocities(unsigned short axis, double redshift,
     }
     LOG_SUPER_DEBUG("velocity: ");
     debugSummarizeBox(velocity, simulation_options_global->HII_DIM,
-                      simulation_options_global->HII_DIM, HII_D_PARA, "  ");
+                      simulation_options_global->HII_DIM, HII_D_PARA, STANDARD_LAYOUT, "  ");
 }
 
 int ComputePerturbedField(float redshift, InitialConditions *boxes,

--- a/src/py21cmfast/src/debugging.c
+++ b/src/py21cmfast/src/debugging.c
@@ -189,28 +189,56 @@ void writeAstroOptions(AstroOptions *p) {
         p->INTEGRATION_METHOD_MINI);
 }
 
-void get_corner_indices(int size_x, int size_y, int size_z, unsigned long long indices[8]) {
-    indices[0] = 0;                                                       //(x0,y0,z0)
-    indices[1] = (unsigned long long)(size_z) * (size_y * (size_x - 1));  //(x1,y0,z0)
-    indices[2] = (unsigned long long)(size_z) * ((size_y - 1));           //(x0,y1,z0)
-    indices[3] =
-        (unsigned long long)(size_z) * ((size_y - 1) + size_y * (size_x - 1));  //(x1,y1,z0)
-    indices[4] = (size_z - 1);                                                  //(x0,y0,z1)
-    indices[5] =
-        (size_z - 1) + (unsigned long long)(size_z) * (size_y * (size_x - 1));  //(x1,y0,z1)
-    indices[6] = (size_z - 1) + (unsigned long long)(size_z) * ((size_y - 1));  //(x0,y1,z1)
-    indices[7] = (size_z - 1) + (unsigned long long)(size_z) *
-                                    ((size_y - 1) + size_y * (size_x - 1));  //(x1,y1,z1)
+// Wrapper function to select appropriate indexing function based on layout
+static unsigned long long get_corner_index(int x, int y, int z, int dim[3], GridLayout layout) {
+    if (layout == FFTW_REAL_LAYOUT) {
+        return grid_index_fftw_r(x, y, z, dim);
+    } else if (layout == FFTW_COMPLEX_LAYOUT) {
+        return grid_index_fftw_c(x, y, z, dim);
+    } else {  // STANDARD_LAYOUT
+        return grid_index_general(x, y, z, dim);
+    }
 }
 
-void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, char *indent) {
+void get_corner_indices(int size_x, int size_y, int size_z, GridLayout layout,
+                        unsigned long long indices[8]) {
+    int original_z;
+    int dim[3];
+
+    dim[0] = size_x;
+    dim[1] = size_y;
+
+    // Extract unpadded z and set dim[2] based on layout
+    if (layout == FFTW_REAL_LAYOUT) {
+        original_z = 2 * (size_z / 2 - 1);
+        dim[2] = original_z;
+    } else if (layout == FFTW_COMPLEX_LAYOUT) {
+        original_z = 2 * (size_z - 1);
+        dim[2] = size_z;  // Keep padded dimension for complex indexing
+    } else {              // STANDARD_LAYOUT
+        original_z = size_z;
+        dim[2] = size_z;
+    }
+
+    // Compute all 8 corner indices using wrapper function
+    indices[0] = get_corner_index(0, 0, 0, dim, layout);
+    indices[1] = get_corner_index(size_x - 1, 0, 0, dim, layout);
+    indices[2] = get_corner_index(0, size_y - 1, 0, dim, layout);
+    indices[3] = get_corner_index(size_x - 1, size_y - 1, 0, dim, layout);
+    indices[4] = get_corner_index(0, 0, original_z - 1, dim, layout);
+    indices[5] = get_corner_index(size_x - 1, 0, original_z - 1, dim, layout);
+    indices[6] = get_corner_index(0, size_y - 1, original_z - 1, dim, layout);
+    indices[7] = get_corner_index(size_x - 1, size_y - 1, original_z - 1, dim, layout);
+}
+
+void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, GridLayout layout,
+                       char *indent) {
 #if LOG_LEVEL >= SUPER_DEBUG_LEVEL
     float corners[8];
     unsigned long long indices[8];
     unsigned long long idx;
-    unsigned long long tot_size = (unsigned long long)size_x * size_y * size_z;
 
-    get_corner_indices(size_x, size_y, size_z, indices);
+    get_corner_indices(size_x, size_y, size_z, layout, indices);
     for (idx = 0; idx < 8; idx++) {
         corners[idx] = box[indices[idx]];
     }
@@ -224,25 +252,50 @@ void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, char *ind
     mn = box[0];
     mx = box[0];
 
-    for (idx = 0; idx < tot_size; idx++) {
-        sum += box[idx];
-        mn = fminf(mn, box[idx]);
-        mx = fmaxf(mx, box[idx]);
+    // Select indexing function and extract unpadded z based on layout
+    int original_z;
+    int dim[3] = {size_x, size_y};
+
+    if (layout == FFTW_REAL_LAYOUT) {
+        original_z = 2 * (size_z / 2 - 1);
+        dim[2] = original_z;
+    } else if (layout == FFTW_COMPLEX_LAYOUT) {
+        original_z = 2 * (size_z - 1);
+        dim[2] = size_z;
+    } else {  // STANDARD_LAYOUT
+        original_z = size_z;
+        dim[2] = size_z;
     }
+
+    // Uniform loop using wrapper function
+    int i, j, k;
+    unsigned long long grid_idx;
+
+    for (i = 0; i < size_x; i++) {
+        for (j = 0; j < size_y; j++) {
+            for (k = 0; k < original_z; k++) {
+                grid_idx = get_corner_index(i, j, k, dim, layout);
+                sum += box[grid_idx];
+                mn = fminf(mn, box[grid_idx]);
+                mx = fmaxf(mx, box[grid_idx]);
+            }
+        }
+    }
+    unsigned long long tot_size = (unsigned long long)size_x * size_y * original_z;
     mean = sum / tot_size;
 
     LOG_SUPER_DEBUG("%sSum/Mean/Min/Max: %.4e, %.4e, %.4e, %.4e", indent, sum, mean, mn, mx);
 #endif
 }
 
-void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, char *indent) {
+void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, GridLayout layout,
+                             char *indent) {
 #if LOG_LEVEL >= SUPER_DEBUG_LEVEL
     double corners[8];
     unsigned long long indices[8];
     unsigned long long idx;
-    unsigned long long tot_size = (unsigned long long)size_x * size_y * size_z;
 
-    get_corner_indices(size_x, size_y, size_z, indices);
+    get_corner_indices(size_x, size_y, size_z, layout, indices);
     for (idx = 0; idx < 8; idx++) {
         corners[idx] = box[indices[idx]];
     }
@@ -256,32 +309,56 @@ void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, ch
     mn = box[0];
     mx = box[0];
 
-    for (idx = 0; idx < tot_size; idx++) {
-        sum += box[idx];
-        mn = fminf(mn, box[idx]);
-        mx = fmaxf(mx, box[idx]);
+    // Select indexing function and extract unpadded z based on layout
+    int original_z;
+    int dim[3] = {size_x, size_y};
+
+    if (layout == FFTW_REAL_LAYOUT) {
+        original_z = 2 * (size_z / 2 - 1);
+        dim[2] = original_z;
+    } else if (layout == FFTW_COMPLEX_LAYOUT) {
+        original_z = 2 * (size_z - 1);
+        dim[2] = size_z;
+    } else {  // STANDARD_LAYOUT
+        original_z = size_z;
+        dim[2] = size_z;
     }
+
+    // Uniform loop using wrapper function
+    int i, j, k;
+    unsigned long long grid_idx;
+
+    for (i = 0; i < size_x; i++) {
+        for (j = 0; j < size_y; j++) {
+            for (k = 0; k < original_z; k++) {
+                grid_idx = get_corner_index(i, j, k, dim, layout);
+                sum += box[grid_idx];
+                mn = fmin(mn, box[grid_idx]);
+                mx = fmax(mx, box[grid_idx]);
+            }
+        }
+    }
+    unsigned long long tot_size = (unsigned long long)size_x * size_y * original_z;
     mean = sum / tot_size;
 
     LOG_SUPER_DEBUG("%sSum/Mean/Min/Max: %.4e, %.4e, %.4e, %.4e", indent, sum, mean, mn, mx);
 #endif
 }
 
-void debugSummarizeBoxComplex(float complex *box, int size_x, int size_y, int size_z,
-                              char *indent) {
+void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int size_z,
+                              GridLayout layout, char *indent) {
 #if LOG_LEVEL >= SUPER_DEBUG_LEVEL
     float corners_real[8];
     float corners_imag[8];
     unsigned long long indices[8];
     unsigned long long idx;
-    unsigned long long tot_size = (unsigned long long)size_x * size_y * size_z;
-    float complex buf;
+    fftwf_complex buf;
 
-    get_corner_indices(size_x, size_y, size_z, indices);
+    get_corner_indices(size_x, size_y, size_z, layout, indices);
     for (idx = 0; idx < 8; idx++) {
         buf = box[indices[idx]];
-        corners_real[idx] = creal(buf);
-        corners_imag[idx] = cimag(buf);
+        corners_real[idx] = crealf(buf);
+        corners_imag[idx] = cimagf(buf);
     }
 
     LOG_SUPER_DEBUG("%sCorners (Real Part): %.4e %.4e %.4e %.4e %.4e %.4e %.4e %.4e", indent,
@@ -297,11 +374,36 @@ void debugSummarizeBoxComplex(float complex *box, int size_x, int size_y, int si
     mn = box[0];
     mx = box[0];
 
-    for (idx = 0; idx < tot_size; idx++) {
-        sum += box[idx];
-        mn = fminf(mn, box[idx]);
-        mx = fmaxf(mx, box[idx]);
+    // Select indexing function and extract unpadded z based on layout
+    int original_z;
+    int dim[3] = {size_x, size_y};
+
+    if (layout == FFTW_REAL_LAYOUT) {
+        original_z = 2 * (size_z / 2 - 1);
+        dim[2] = original_z;
+    } else if (layout == FFTW_COMPLEX_LAYOUT) {
+        original_z = 2 * (size_z - 1);
+        dim[2] = size_z;
+    } else {  // STANDARD_LAYOUT
+        original_z = size_z;
+        dim[2] = size_z;
     }
+
+    // Uniform loop using wrapper function
+    int i, j, k;
+    unsigned long long grid_idx;
+
+    for (i = 0; i < size_x; i++) {
+        for (j = 0; j < size_y; j++) {
+            for (k = 0; k < original_z; k++) {
+                grid_idx = get_corner_index(i, j, k, dim, layout);
+                sum += box[grid_idx];
+                mn = fminf(mn, box[grid_idx]);
+                mx = fmaxf(mx, box[grid_idx]);
+            }
+        }
+    }
+    unsigned long long tot_size = (unsigned long long)size_x * size_y * original_z;
     mean = sum / tot_size;
 
     LOG_SUPER_DEBUG("%sSum/Mean/Min/Max: %.4e+%.4ei, %.4e+%.4ei, %.4e+%.4ei, %.4e+%.4ei", indent,
@@ -313,25 +415,25 @@ void debugSummarizeBoxComplex(float complex *box, int size_x, int size_y, int si
 void debugSummarizeIC(InitialConditions *x, int HII_DIM, int DIM, float NCF) {
     LOG_SUPER_DEBUG("Summary of InitialConditions:");
     LOG_SUPER_DEBUG("  lowres_density: ");
-    debugSummarizeBox(x->lowres_density, HII_DIM, HII_DIM, HII_D_PARA, "    ");
+    debugSummarizeBox(x->lowres_density, HII_DIM, HII_DIM, HII_D_PARA, STANDARD_LAYOUT, "    ");
     LOG_SUPER_DEBUG("  hires_density: ");
-    debugSummarizeBox(x->hires_density, DIM, DIM, D_PARA, "    ");
+    debugSummarizeBox(x->hires_density, DIM, DIM, D_PARA, STANDARD_LAYOUT, "    ");
     LOG_SUPER_DEBUG("  lowres_vx: ");
-    debugSummarizeBox(x->lowres_vx, HII_DIM, HII_DIM, HII_D_PARA, "    ");
+    debugSummarizeBox(x->lowres_vx, HII_DIM, HII_DIM, HII_D_PARA, STANDARD_LAYOUT, "    ");
     LOG_SUPER_DEBUG("  lowres_vy: ");
-    debugSummarizeBox(x->lowres_vy, HII_DIM, HII_DIM, HII_D_PARA, "    ");
+    debugSummarizeBox(x->lowres_vy, HII_DIM, HII_DIM, HII_D_PARA, STANDARD_LAYOUT, "    ");
     LOG_SUPER_DEBUG("  lowres_vz: ");
-    debugSummarizeBox(x->lowres_vz, HII_DIM, HII_DIM, HII_D_PARA, "    ");
+    debugSummarizeBox(x->lowres_vz, HII_DIM, HII_DIM, HII_D_PARA, STANDARD_LAYOUT, "    ");
 }
 
 void debugSummarizePerturbedField(PerturbedField *x, int HII_DIM, float NCF) {
     LOG_SUPER_DEBUG("Summary of PerturbedField:");
     LOG_SUPER_DEBUG("  density: ");
-    debugSummarizeBox(x->density, HII_DIM, HII_DIM, HII_D_PARA, "    ");
+    debugSummarizeBox(x->density, HII_DIM, HII_DIM, HII_D_PARA, STANDARD_LAYOUT, "    ");
     LOG_SUPER_DEBUG("  velocity_x: ");
-    debugSummarizeBox(x->velocity_x, HII_DIM, HII_DIM, HII_D_PARA, "    ");
+    debugSummarizeBox(x->velocity_x, HII_DIM, HII_DIM, HII_D_PARA, STANDARD_LAYOUT, "    ");
     LOG_SUPER_DEBUG("  velocity_y: ");
-    debugSummarizeBox(x->velocity_y, HII_DIM, HII_DIM, HII_D_PARA, "    ");
+    debugSummarizeBox(x->velocity_y, HII_DIM, HII_DIM, HII_D_PARA, STANDARD_LAYOUT, "    ");
     LOG_SUPER_DEBUG("  velocity_z: ");
-    debugSummarizeBox(x->velocity_z, HII_DIM, HII_DIM, HII_D_PARA, "    ");
+    debugSummarizeBox(x->velocity_z, HII_DIM, HII_DIM, HII_D_PARA, STANDARD_LAYOUT, "    ");
 }

--- a/src/py21cmfast/src/debugging.c
+++ b/src/py21cmfast/src/debugging.c
@@ -200,25 +200,30 @@ static unsigned long long get_corner_index(int x, int y, int z, int dim[3], Grid
     }
 }
 
+// Helper to compute dimensions based on layout type
+static void compute_layout_dims(int size_x, int size_y, int size_z, GridLayout layout, int dim[3],
+                                int *original_z) {
+    dim[0] = size_x;
+    dim[1] = size_y;
+
+    if (layout == FFTW_REAL_LAYOUT) {
+        *original_z = 2 * (size_z / 2 - 1);
+        dim[2] = *original_z;
+    } else if (layout == FFTW_COMPLEX_LAYOUT) {
+        *original_z = 2 * (size_z - 1);
+        dim[2] = size_z;
+    } else {  // STANDARD_LAYOUT
+        *original_z = size_z;
+        dim[2] = size_z;
+    }
+}
+
 void get_corner_indices(int size_x, int size_y, int size_z, GridLayout layout,
                         unsigned long long indices[8]) {
     int original_z;
     int dim[3];
 
-    dim[0] = size_x;
-    dim[1] = size_y;
-
-    // Extract unpadded z and set dim[2] based on layout
-    if (layout == FFTW_REAL_LAYOUT) {
-        original_z = 2 * (size_z / 2 - 1);
-        dim[2] = original_z;
-    } else if (layout == FFTW_COMPLEX_LAYOUT) {
-        original_z = 2 * (size_z - 1);
-        dim[2] = size_z;  // Keep padded dimension for complex indexing
-    } else {              // STANDARD_LAYOUT
-        original_z = size_z;
-        dim[2] = size_z;
-    }
+    compute_layout_dims(size_x, size_y, size_z, layout, dim, &original_z);
 
     // Compute all 8 corner indices using wrapper function
     indices[0] = get_corner_index(0, 0, 0, dim, layout);
@@ -254,18 +259,9 @@ void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, GridLayou
 
     // Select indexing function and extract unpadded z based on layout
     int original_z;
-    int dim[3] = {size_x, size_y};
+    int dim[3];
 
-    if (layout == FFTW_REAL_LAYOUT) {
-        original_z = 2 * (size_z / 2 - 1);
-        dim[2] = original_z;
-    } else if (layout == FFTW_COMPLEX_LAYOUT) {
-        original_z = 2 * (size_z - 1);
-        dim[2] = size_z;
-    } else {  // STANDARD_LAYOUT
-        original_z = size_z;
-        dim[2] = size_z;
-    }
+    compute_layout_dims(size_x, size_y, size_z, layout, dim, &original_z);
 
     // Uniform loop using wrapper function
     int i, j, k;
@@ -311,18 +307,9 @@ void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, Gr
 
     // Select indexing function and extract unpadded z based on layout
     int original_z;
-    int dim[3] = {size_x, size_y};
+    int dim[3];
 
-    if (layout == FFTW_REAL_LAYOUT) {
-        original_z = 2 * (size_z / 2 - 1);
-        dim[2] = original_z;
-    } else if (layout == FFTW_COMPLEX_LAYOUT) {
-        original_z = 2 * (size_z - 1);
-        dim[2] = size_z;
-    } else {  // STANDARD_LAYOUT
-        original_z = size_z;
-        dim[2] = size_z;
-    }
+    compute_layout_dims(size_x, size_y, size_z, layout, dim, &original_z);
 
     // Uniform loop using wrapper function
     int i, j, k;
@@ -352,13 +339,12 @@ void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int si
     float corners_imag[8];
     unsigned long long indices[8];
     unsigned long long idx;
-    fftwf_complex buf;
 
     get_corner_indices(size_x, size_y, size_z, layout, indices);
     for (idx = 0; idx < 8; idx++) {
-        buf = box[indices[idx]];
-        corners_real[idx] = crealf(buf);
-        corners_imag[idx] = cimagf(buf);
+        float *elem = (float *)&box[indices[idx]];
+        corners_real[idx] = elem[0];
+        corners_imag[idx] = elem[1];
     }
 
     LOG_SUPER_DEBUG("%sCorners (Real Part): %.4e %.4e %.4e %.4e %.4e %.4e %.4e %.4e", indent,
@@ -376,18 +362,9 @@ void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int si
 
     // Select indexing function and extract unpadded z based on layout
     int original_z;
-    int dim[3] = {size_x, size_y};
+    int dim[3];
 
-    if (layout == FFTW_REAL_LAYOUT) {
-        original_z = 2 * (size_z / 2 - 1);
-        dim[2] = original_z;
-    } else if (layout == FFTW_COMPLEX_LAYOUT) {
-        original_z = 2 * (size_z - 1);
-        dim[2] = size_z;
-    } else {  // STANDARD_LAYOUT
-        original_z = size_z;
-        dim[2] = size_z;
-    }
+    compute_layout_dims(size_x, size_y, size_z, layout, dim, &original_z);
 
     // Uniform loop using wrapper function
     int i, j, k;

--- a/src/py21cmfast/src/debugging.h
+++ b/src/py21cmfast/src/debugging.h
@@ -8,10 +8,11 @@
 #include "OutputStructs.h"
 
 // Grid layout types for debug output
+// Indicates how size_z parameter is interpreted:
 typedef enum {
-    STANDARD_LAYOUT,     // Row-major layout: stride = size_z
-    FFTW_REAL_LAYOUT,    // FFT real-space layout: stride = 2*(size_z/2+1)
-    FFTW_COMPLEX_LAYOUT  // FFT complex-space layout: stride = size_z/2+1
+    STANDARD_LAYOUT,     // size_z is the actual dimension (no padding)
+    FFTW_REAL_LAYOUT,    // size_z is the padded real-space dimension: 2*(unpadded_z/2+1)
+    FFTW_COMPLEX_LAYOUT  // size_z is the padded complex dimension: unpadded_z/2+1
 } GridLayout;
 
 // Input debugging

--- a/src/py21cmfast/src/debugging.h
+++ b/src/py21cmfast/src/debugging.h
@@ -7,6 +7,13 @@
 #include "InputParameters.h"
 #include "OutputStructs.h"
 
+// Grid layout types for debug output
+typedef enum {
+    STANDARD_LAYOUT,     // Row-major layout: stride = size_z
+    FFTW_REAL_LAYOUT,    // FFT real-space layout: stride = 2*(size_z/2+1)
+    FFTW_COMPLEX_LAYOUT  // FFT complex-space layout: stride = size_z/2+1
+} GridLayout;
+
 // Input debugging
 void writeAstroOptions(AstroOptions *p);
 void writeSimulationOptions(SimulationOptions *p);
@@ -17,9 +24,12 @@ void writeAstroParams(AstroParams *p);
 // output debugging
 void debugSummarizeIC(InitialConditions *x, int HII_DIM, int DIM, float NCF);
 void debugSummarizePerturbedField(PerturbedField *x, int HII_DIM, float NCF);
-void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, char *indent);
-void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, char *indent);
-void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int size_z, char *indent);
+void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, GridLayout layout,
+                       char *indent);
+void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, GridLayout layout,
+                             char *indent);
+void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int size_z,
+                              GridLayout layout, char *indent);
 
 // error debugging
 int SomethingThatCatches(bool sub_func);


### PR DESCRIPTION
I fixed the bug in the debugging printouts, as was noticed in #700.

Note: I did not write a special test after making this fix (since I'm not sure if in our workflows we work with `LOG_LEVEL=SUPER_DEBUG`), but I simply checked that `resampled_box` and `density_perturb` now have the same printouts (when I run the code with the `tiny` template).

Hopefully, @DanielaBreitman's log should make more sense now :)

## Summary by Sourcery

Align debugging summaries with actual in-memory grid layouts to fix incorrect SUPER_DEBUG printouts for real and complex FFTW grids.

Bug Fixes:
- Correct debug summary indexing for FFTW real and complex grids so logged statistics and corner values match the true data layout.

Enhancements:
- Introduce a GridLayout enum and shared indexing helper to support multiple grid memory layouts in debug utilities.
- Extend debug summarization helpers to work uniformly with standard, FFTW real-space, and FFTW complex-space grids and update all call sites accordingly.