### PR TITLE
Fix large-grid density normalization overflow

### DIFF
--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -167,7 +167,7 @@ HaloProperties get_halobox_averages(HaloBox *grids) {
 
 #pragma omp parallel for reduction(+ : mean_count, mean_mass, mean_stars, mean_stars_mini, \
                                        mean_sfr, mean_sfr_mini, mean_n_ion, mean_xray, mean_wsfr)
-    for (int i = 0; i < HII_TOT_NUM_PIXELS; i++) {
+    for (unsigned long long int i = 0; i < HII_TOT_NUM_PIXELS; i++) {
         mean_sfr += grids->halo_sfr[i];
         mean_n_ion += grids->n_ion[i];
         if (astro_options_global->USE_TS_FLUCT) {

--- a/src/py21cmfast/src/PerturbedField.c
+++ b/src/py21cmfast/src/PerturbedField.c
@@ -184,9 +184,9 @@ void normalise_delta_grid(fftwf_complex *deltap1_grid) {
                      HII_D_PARA};
     int hi_dim[3] = {simulation_options_global->DIM, simulation_options_global->DIM, D_PARA};
     // Renormalise the lowres box
-    double mass_factor =
-        matter_options_global->PERTURB_ON_HIGH_RES ? 1.0
-                                                    : HII_TOT_NUM_PIXELS / (double)TOT_NUM_PIXELS;
+    double mass_factor = matter_options_global->PERTURB_ON_HIGH_RES
+                             ? 1.0
+                             : HII_TOT_NUM_PIXELS / (double)TOT_NUM_PIXELS;
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
         unsigned long long int grid_index;

--- a/src/py21cmfast/src/PerturbedField.c
+++ b/src/py21cmfast/src/PerturbedField.c
@@ -185,9 +185,8 @@ void normalise_delta_grid(fftwf_complex *deltap1_grid) {
     int hi_dim[3] = {simulation_options_global->DIM, simulation_options_global->DIM, D_PARA};
     // Renormalise the lowres box
     double mass_factor =
-        matter_options_global->PERTURB_ON_HIGH_RES
-            ? 1.0
-            : (lo_dim[0] * lo_dim[1] * lo_dim[2]) / (double)(hi_dim[0] * hi_dim[1] * hi_dim[2]);
+        matter_options_global->PERTURB_ON_HIGH_RES ? 1.0
+                                                    : HII_TOT_NUM_PIXELS / (double)TOT_NUM_PIXELS;
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
         unsigned long long int grid_index;
@@ -244,7 +243,7 @@ void smooth_and_clip_density(fftwf_complex *lowres_grid, fftwf_complex *density_
                       simulation_options_global->HII_DIM, 2 * (HII_D_PARA / 2 + 1), "  ");
 
     // normalize after FFT
-    int bad_count = 0;
+    unsigned long long int bad_count = 0;
 #pragma omp parallel shared(lowres_grid) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS) reduction(+ : bad_count)
     {
@@ -271,7 +270,7 @@ void smooth_and_clip_density(fftwf_complex *lowres_grid, fftwf_complex *density_
             }
         }
     }
-    if (bad_count >= 5) LOG_WARNING("Total number of bad indices: %d", bad_count);
+    if (bad_count >= 5) LOG_WARNING("Total number of bad indices: %llu", bad_count);
     LOG_SUPER_DEBUG("delta normalized: ");
     debugSummarizeBox((float *)lowres_grid, simulation_options_global->HII_DIM,
                       simulation_options_global->HII_DIM, 2 * (HII_D_PARA / 2 + 1), "  ");

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -186,7 +186,7 @@ void alloc_global_arrays() {
 
         delNL0 = (float **)calloc(num_R_boxes, sizeof(float *));
         for (i = 0; i < num_R_boxes; i++) {
-            delNL0[i] = (float *)calloc((float)HII_TOT_NUM_PIXELS, sizeof(float));
+            delNL0[i] = (float *)calloc(HII_TOT_NUM_PIXELS, sizeof(float));
         }
         if (astro_options_global->USE_MINI_HALOS) {
             log10_Mcrit_LW = (float **)calloc(num_R_boxes, sizeof(float *));

--- a/src/py21cmfast/src/map_mass.c
+++ b/src/py21cmfast/src/map_mass.c
@@ -224,8 +224,8 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
     double box_size[3] = {boxlen, boxlen, boxlen_z};
     double dim_ratio_vel = (double)vel_dim[0] / (double)dens_dim[0];
     double dim_ratio_out = (double)out_dim[0] / (double)dens_dim[0];
-    double vol_ratio_out = (double)(out_dim[0] * out_dim[1] * out_dim[2]) /
-                           (double)(dens_dim[0] * dens_dim[1] * dens_dim[2]);
+    double vol_ratio_out = ((double)out_dim[0] * out_dim[1] * out_dim[2]) /
+                           ((double)dens_dim[0] * dens_dim[1] * dens_dim[2]);
 
     double prefactor_mass = RHOcrit * cosmo_params_global->OMm * vol_ratio_out;
     double prefactor_stars = RHOcrit * cosmo_params_global->OMb * consts->fstar_10 * vol_ratio_out;
@@ -340,7 +340,7 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
     // Without stochasticity, these grids are the same to a constant
     double prefactor_wsfr = 1 / consts->t_h / consts->t_star;
     if (astro_options_global->INHOMO_RECO) {
-        for (int i = 0; i < HII_TOT_NUM_PIXELS; i++) {
+        for (unsigned long long int i = 0; i < HII_TOT_NUM_PIXELS; i++) {
             boxes->whalo_sfr[i] = boxes->n_ion[i] * prefactor_wsfr;
         }
     }


### PR DESCRIPTION
Hi,

We encountered anomalous results when running 21cmFAST with a large grid size, e.g. DIM = 1300. In particular, the density field was found to be -1 across all pixels. We attempted to identify and resolve this issue. Please see the attached figure: the left panel shows the result before applying the fix, while the right panel shows the result after applying the fix.

<img width="1430" height="654" alt="Weixin Image_20260527092014_29_772" src="https://github.com/user-attachments/assets/65bcf4b4-53b0-4dd0-addf-af8f2ae16aab" />

Simulation codes:
```
N_THREADS = 24
HII_DIM = 650
BOX_LEN = 1000
DIM = 1300
KEEP_3D_VELOCITIES = True

inputs = p21c.InputParameters.from_template(
    ['latest', 'gpc'],
    random_seed=1234,
    node_redshifts=p21c.wrapper.inputs.get_logspaced_redshifts(
        min_redshift=13,
        z_step_factor=1.1,
        max_redshift=36
    ),
    INHOMO_RECO=True,
    USE_MINI_HALOS=False,
    USE_RELATIVE_VELOCITIES=True,
    MINIMIZE_MEMORY=False
).evolve_input_structs(
    BOX_LEN=BOX_LEN,
    HIRES_TO_LOWRES_FACTOR=2,
    HII_DIM=HII_DIM,
    N_THREADS=N_THREADS,
    KEEP_3D_VELOCITIES=KEEP_3D_VELOCITIES
)
```
  Description

  This PR fixes integer overflow issues that can occur when running large-grid simulations.

  The main fix updates density normalization to use the existing pixel-count constants directly, avoiding intermediate int multiplications that can overflow for large grids. It also
  updates several loop counters and counters from int to unsigned long long int where they iterate over HII_TOT_NUM_PIXELS, and fixes one calloc call that was incorrectly casting the
  allocation size through float.

  Changes

  - Avoid overflow in normalise_delta_grid by computing mass_factor from HII_TOT_NUM_PIXELS / TOT_NUM_PIXELS.
  - Prevent overflow in volume-ratio calculations by casting dimensions before multiplication.
  - Use unsigned long long int loop counters for large pixel-count loops.
  - Use an unsigned counter and matching %llu format for large bad_count values.
  - Remove unsafe float cast from a calloc(HII_TOT_NUM_PIXELS, sizeof(float)) allocation.
  
  Contributors: 

Yepeng Yan, Le Zhang, Quan Guo, Yun Yu, Xiaolong Yang, Yiming Wang, Peng Wang, Hongmin Cao

## Summary by Sourcery

Fix overflow-related issues in large-grid density normalization and related grid processing loops to ensure correct results for high-resolution simulations.

Bug Fixes:
- Correct density normalization mass factor computation to avoid integer overflow for large grid sizes.
- Prevent overflow in volume ratio calculations by casting grid dimensions before multiplication.
- Avoid overflow of loop counters and counters that iterate over HII_TOT_NUM_PIXELS by using 64-bit unsigned integers.
- Fix incorrect logging format for large bad_count values in density smoothing.
- Remove unsafe float cast from calloc when allocating per-pixel arrays for large HII_TOT_NUM_PIXELS.