### PR TITLE
Fixed huge integers into `unsigned long long int`

### DIFF
--- a/src/py21cmfast/src/BrightnessTemperatureBox.c
+++ b/src/py21cmfast/src/BrightnessTemperatureBox.c
@@ -60,7 +60,7 @@ int ComputeBrightnessTemp(float redshift, TsBox *spin_temp, IonizedBox *ionized_
                                 T_rad) private(i, j, k, pixel_deltax, pixel_x_HI)               \
     num_threads(simulation_options_global -> N_THREADS)
         {
-            index_t index;
+            index_huge index;
 #pragma omp for reduction(+ : ave)
             for (i = 0; i < simulation_options_global->HII_DIM; i++) {
                 for (j = 0; j < simulation_options_global->HII_DIM; j++) {

--- a/src/py21cmfast/src/BrightnessTemperatureBox.c
+++ b/src/py21cmfast/src/BrightnessTemperatureBox.c
@@ -60,7 +60,7 @@ int ComputeBrightnessTemp(float redshift, TsBox *spin_temp, IonizedBox *ionized_
                                 T_rad) private(i, j, k, pixel_deltax, pixel_x_HI)               \
     num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long int index;
+            index_t index;
 #pragma omp for reduction(+ : ave)
             for (i = 0; i < simulation_options_global->HII_DIM; i++) {
                 for (j = 0; j < simulation_options_global->HII_DIM; j++) {

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -167,7 +167,7 @@ HaloProperties get_halobox_averages(HaloBox *grids) {
 
 #pragma omp parallel for reduction(+ : mean_count, mean_mass, mean_stars, mean_stars_mini, \
                                        mean_sfr, mean_sfr_mini, mean_n_ion, mean_xray, mean_wsfr)
-    for (unsigned long long int i = 0; i < HII_TOT_NUM_PIXELS; i++) {
+    for (index_t i = 0; i < HII_TOT_NUM_PIXELS; i++) {
         mean_sfr += grids->halo_sfr[i];
         mean_n_ion += grids->n_ion[i];
         if (astro_options_global->USE_TS_FLUCT) {
@@ -212,7 +212,7 @@ void mean_fix_grids(double M_min, double M_max, HaloBox *grids, ScalingConstants
     HaloProperties averages_hbox;
     averages_hbox = get_halobox_averages(grids);
 
-    unsigned long long int idx;
+    index_t idx;
 #pragma omp parallel for num_threads(simulation_options_global->N_THREADS) private(idx)
     for (idx = 0; idx < HII_TOT_NUM_PIXELS; idx++) {
         grids->halo_sfr[idx] *= averages_global.halo_sfr / averages_hbox.halo_sfr;
@@ -318,7 +318,7 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes, fl
     float *vel_pointers[3];
     float *vel_pointers_2LPT[3];
     int grid_dim[3];
-    unsigned long long int num_pixels;
+    index_t num_pixels;
     float *dens_pointer;
     int out_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
                       HII_D_PARA};  // always output to lowres grid
@@ -354,7 +354,7 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes, fl
     set_integral_constants(&integral_cond, ev_consts->redshift, M_min, M_max, M_cell);
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
     {
-        unsigned long long int i;
+        index_t i;
         double dens;
 #pragma omp for reduction(min : min_density) reduction(max : max_density)
         for (i = 0; i < num_pixels; i++) {
@@ -473,7 +473,7 @@ void get_log10_turnovers(InitialConditions *ini_boxes, TsBox *previous_spin_temp
 
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
     {
-        unsigned long long int i;
+        index_t i;
         double J21_val, Gamma12_val, zre_val;
         double curr_vcb = consts->vcb_norel;
         double M_turn_m;
@@ -576,7 +576,7 @@ int ComputeHaloBox(double redshift, InitialConditions *ini_boxes, HaloCatalog *h
 
         LOG_DEBUG("Resetting halobox dim %d %llu %llu", simulation_options_global->HII_DIM,
                   HII_D_PARA, HII_TOT_NUM_PIXELS);
-        unsigned long long int idx;
+        index_t idx;
 #pragma omp parallel for num_threads(simulation_options_global->N_THREADS) private(idx)
         for (idx = 0; idx < HII_TOT_NUM_PIXELS; idx++) {
             grids->n_ion[idx] = 0.0;
@@ -666,7 +666,7 @@ int ComputeHaloBox(double redshift, InitialConditions *ini_boxes, HaloCatalog *h
 // test function for getting halo properties from the wrapper, can use a lot of memory for large
 // catalogs
 int test_halo_props(double redshift, float *vcb_grid, float *J21_LW_grid, float *z_re_grid,
-                    float *Gamma12_ion_grid, unsigned long long int n_halos, float *halo_masses,
+                    float *Gamma12_ion_grid, index_t n_halos, float *halo_masses,
                     float *halo_coords, float *star_rng, float *sfr_rng, float *xray_rng,
                     float *halo_props_out) {
     int status;
@@ -688,7 +688,7 @@ int test_halo_props(double redshift, float *vcb_grid, float *J21_LW_grid, float 
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
         {
             int x, y, z;
-            unsigned long long int i_halo, i_cell;
+            index_t i_halo, i_cell;
             double m;
             double J21_val, Gamma12_val, zre_val;
 
@@ -812,7 +812,7 @@ int convert_halo_props(double redshift, InitialConditions *ics, TsBox *prev_ts,
         simulation_options_global->HII_DIM / (double)simulation_options_global->DIM;
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
     {
-        unsigned long long int i_halo;
+        index_t i_halo;
         double m;
 
         double M_turn_m = hbox_consts.mturn_m_nofb;

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -167,7 +167,7 @@ HaloProperties get_halobox_averages(HaloBox *grids) {
 
 #pragma omp parallel for reduction(+ : mean_count, mean_mass, mean_stars, mean_stars_mini, \
                                        mean_sfr, mean_sfr_mini, mean_n_ion, mean_xray, mean_wsfr)
-    for (index_t i = 0; i < HII_TOT_NUM_PIXELS; i++) {
+    for (index_huge i = 0; i < HII_TOT_NUM_PIXELS; i++) {
         mean_sfr += grids->halo_sfr[i];
         mean_n_ion += grids->n_ion[i];
         if (astro_options_global->USE_TS_FLUCT) {
@@ -212,7 +212,7 @@ void mean_fix_grids(double M_min, double M_max, HaloBox *grids, ScalingConstants
     HaloProperties averages_hbox;
     averages_hbox = get_halobox_averages(grids);
 
-    index_t idx;
+    index_huge idx;
 #pragma omp parallel for num_threads(simulation_options_global->N_THREADS) private(idx)
     for (idx = 0; idx < HII_TOT_NUM_PIXELS; idx++) {
         grids->halo_sfr[idx] *= averages_global.halo_sfr / averages_hbox.halo_sfr;
@@ -318,7 +318,7 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes, fl
     float *vel_pointers[3];
     float *vel_pointers_2LPT[3];
     int grid_dim[3];
-    index_t num_pixels;
+    size_huge num_pixels;
     float *dens_pointer;
     int out_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
                       HII_D_PARA};  // always output to lowres grid
@@ -354,7 +354,7 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes, fl
     set_integral_constants(&integral_cond, ev_consts->redshift, M_min, M_max, M_cell);
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
     {
-        index_t i;
+        index_huge i;
         double dens;
 #pragma omp for reduction(min : min_density) reduction(max : max_density)
         for (i = 0; i < num_pixels; i++) {
@@ -473,7 +473,7 @@ void get_log10_turnovers(InitialConditions *ini_boxes, TsBox *previous_spin_temp
 
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
     {
-        index_t i;
+        index_huge i;
         double J21_val, Gamma12_val, zre_val;
         double curr_vcb = consts->vcb_norel;
         double M_turn_m;
@@ -576,7 +576,7 @@ int ComputeHaloBox(double redshift, InitialConditions *ini_boxes, HaloCatalog *h
 
         LOG_DEBUG("Resetting halobox dim %d %llu %llu", simulation_options_global->HII_DIM,
                   HII_D_PARA, HII_TOT_NUM_PIXELS);
-        index_t idx;
+        index_huge idx;
 #pragma omp parallel for num_threads(simulation_options_global->N_THREADS) private(idx)
         for (idx = 0; idx < HII_TOT_NUM_PIXELS; idx++) {
             grids->n_ion[idx] = 0.0;
@@ -666,7 +666,7 @@ int ComputeHaloBox(double redshift, InitialConditions *ini_boxes, HaloCatalog *h
 // test function for getting halo properties from the wrapper, can use a lot of memory for large
 // catalogs
 int test_halo_props(double redshift, float *vcb_grid, float *J21_LW_grid, float *z_re_grid,
-                    float *Gamma12_ion_grid, index_t n_halos, float *halo_masses,
+                    float *Gamma12_ion_grid, size_huge n_halos, float *halo_masses,
                     float *halo_coords, float *star_rng, float *sfr_rng, float *xray_rng,
                     float *halo_props_out) {
     int status;
@@ -688,7 +688,7 @@ int test_halo_props(double redshift, float *vcb_grid, float *J21_LW_grid, float 
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
         {
             int x, y, z;
-            index_t i_halo, i_cell;
+            index_huge i_halo, i_cell;
             double m;
             double J21_val, Gamma12_val, zre_val;
 
@@ -812,7 +812,7 @@ int convert_halo_props(double redshift, InitialConditions *ics, TsBox *prev_ts,
         simulation_options_global->HII_DIM / (double)simulation_options_global->DIM;
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
     {
-        index_t i_halo;
+        index_huge i_halo;
         double m;
 
         double M_turn_m = hbox_consts.mturn_m_nofb;

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -167,7 +167,7 @@ HaloProperties get_halobox_averages(HaloBox *grids) {
 
 #pragma omp parallel for reduction(+ : mean_count, mean_mass, mean_stars, mean_stars_mini, \
                                        mean_sfr, mean_sfr_mini, mean_n_ion, mean_xray, mean_wsfr)
-    for (int i = 0; i < HII_TOT_NUM_PIXELS; i++) {
+    for (unsigned long long int i = 0; i < HII_TOT_NUM_PIXELS; i++) {
         mean_sfr += grids->halo_sfr[i];
         mean_n_ion += grids->n_ion[i];
         if (astro_options_global->USE_TS_FLUCT) {

--- a/src/py21cmfast/src/HaloCatalog.c
+++ b/src/py21cmfast/src/HaloCatalog.c
@@ -72,7 +72,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
         float growth_factor, R, delta_m, M, Delta_R, delta_crit;
         char *in_halo, *forbidden;
         int i, j, k, x, y, z;
-        long long unsigned int total_halo_num, r_halo_num;
+        unsigned long long int total_halo_num, r_halo_num;
         float R_temp, M_MIN;
 
         LOG_DEBUG("Begin Initialisation");
@@ -404,7 +404,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
             // Now downsample the highres grid to get the lowres version
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
             {
-                int index, hi_index;
+                unsigned long long int index, hi_index;
 #pragma omp for
                 for (i = 0; i < simulation_options_global->HII_DIM; i++) {
                     for (j = 0; j < simulation_options_global->HII_DIM; j++) {
@@ -471,7 +471,7 @@ int check_halo(char *in_halo, float R, int x, int y, int z, int check_type) {
     int x_curr, y_curr, z_curr, x_min, x_max, y_min, y_max, z_min, z_max, R_index;
     float Rsq_curr_index;
     int x_index, y_index, z_index;
-    long long unsigned int curr_index;
+    unsigned long long int curr_index;
 
     if (check_type == 1) {
         // scale R to a effective overlap size, using R_OVERLAP_FACTOR
@@ -552,7 +552,7 @@ int check_halo(char *in_halo, float R, int x, int y, int z, int check_type) {
     return 0;
 }
 
-void init_halo_coords(HaloCatalog *halos, long long unsigned int n_halos) {
+void init_halo_coords(HaloCatalog *halos, unsigned long long int n_halos) {
     // Minimise memory usage by only storing the halo mass and positions
     halos->n_halos = n_halos;
     unsigned long long int alloc_size = fmax(1, n_halos);

--- a/src/py21cmfast/src/HaloCatalog.c
+++ b/src/py21cmfast/src/HaloCatalog.c
@@ -30,13 +30,13 @@
 #include "logger.h"
 
 int check_halo(char *in_halo, float R, int x, int y, int z, int check_type);
-void init_halo_coords(HaloCatalog *halos, index_t n_halos);
+void init_halo_coords(HaloCatalog *halos, size_huge n_halos);
 int pixel_in_halo(int grid_dim, int z_dim, int x, int x_index, int y, int y_index, int z,
                   int z_index, float Rsq_curr_index);
 void free_halo_catalog(HaloCatalog *halos);
 
 int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *boxes,
-                       index_t random_seed, HaloCatalog *halos_desc, HaloCatalog *halos) {
+                       random_huge random_seed, HaloCatalog *halos_desc, HaloCatalog *halos) {
     int status;
 
     Try {  // This Try brackets the whole function, so we don't indent.
@@ -71,7 +71,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
         float growth_factor, R, delta_m, M, Delta_R, delta_crit;
         char *in_halo, *forbidden;
         int i, j, k, x, y, z;
-        index_t total_halo_num, r_halo_num;
+        size_huge total_halo_num, r_halo_num;
         float R_temp, M_MIN;
 
         LOG_DEBUG("Begin Initialisation");
@@ -131,7 +131,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
 #pragma omp parallel shared(boxes, density_field) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
         {
-            index_t index_r, index_f;
+            index_huge index_r, index_f;
 #pragma omp for
             for (i = 0; i < grid_dim; i++) {
                 for (j = 0; j < grid_dim; j++) {
@@ -246,7 +246,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
             // now lets scroll through the box, flagging all pixels with delta_m > delta_crit
             r_halo_num = 0;
 
-            index_t idx_r, idx_f;
+            index_huge idx_r, idx_f;
             // THREADING: Fix the race condition propertly to thread: it doesn't matter which thread
             // finds the halo first
             //   but if two threads find a halo in the same region simultaneously (before the first
@@ -339,7 +339,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
         // thread before
         //       OR assign a buffer of size n_halo * n_thread (in case the last thread has all the
         //       halos), copy the structure from stochasticity.c with the assignment and condensing
-        index_t count = 0;
+        size_huge count = 0;
         float halo_buf = 0;
         for (x = 0; x < grid_dim; x++) {
             for (y = 0; y < grid_dim; y++) {
@@ -368,7 +368,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
             // we don't need the density field anymore so we reuse it
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
             {
-                index_t index_r, index_f;
+                index_huge index_r, index_f;
 #pragma omp for
                 for (i = 0; i < grid_dim; i++) {
                     for (j = 0; j < grid_dim; j++) {
@@ -403,7 +403,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
             // Now downsample the highres grid to get the lowres version
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
             {
-                index_t index, hi_index;
+                index_huge index, hi_index;
 #pragma omp for
                 for (i = 0; i < simulation_options_global->HII_DIM; i++) {
                     for (j = 0; j < simulation_options_global->HII_DIM; j++) {
@@ -470,7 +470,7 @@ int check_halo(char *in_halo, float R, int x, int y, int z, int check_type) {
     int x_curr, y_curr, z_curr, x_min, x_max, y_min, y_max, z_min, z_max, R_index;
     float Rsq_curr_index;
     int x_index, y_index, z_index;
-    index_t curr_index;
+    index_huge curr_index;
 
     if (check_type == 1) {
         // scale R to a effective overlap size, using R_OVERLAP_FACTOR
@@ -551,10 +551,10 @@ int check_halo(char *in_halo, float R, int x, int y, int z, int check_type) {
     return 0;
 }
 
-void init_halo_coords(HaloCatalog *halos, index_t n_halos) {
+void init_halo_coords(HaloCatalog *halos, size_huge n_halos) {
     // Minimise memory usage by only storing the halo mass and positions
     halos->n_halos = n_halos;
-    index_t alloc_size = fmax(1, n_halos);
+    size_huge alloc_size = fmax(1, n_halos);
     halos->halo_masses = (float *)calloc(alloc_size, sizeof(float));
     halos->halo_coords = (float *)calloc(3 * alloc_size, sizeof(float));
 

--- a/src/py21cmfast/src/HaloCatalog.c
+++ b/src/py21cmfast/src/HaloCatalog.c
@@ -30,14 +30,13 @@
 #include "logger.h"
 
 int check_halo(char *in_halo, float R, int x, int y, int z, int check_type);
-void init_halo_coords(HaloCatalog *halos, long long unsigned int n_halos);
+void init_halo_coords(HaloCatalog *halos, index_t n_halos);
 int pixel_in_halo(int grid_dim, int z_dim, int x, int x_index, int y, int y_index, int z,
                   int z_index, float Rsq_curr_index);
 void free_halo_catalog(HaloCatalog *halos);
 
 int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *boxes,
-                       unsigned long long int random_seed, HaloCatalog *halos_desc,
-                       HaloCatalog *halos) {
+                       index_t random_seed, HaloCatalog *halos_desc, HaloCatalog *halos) {
     int status;
 
     Try {  // This Try brackets the whole function, so we don't indent.
@@ -72,7 +71,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
         float growth_factor, R, delta_m, M, Delta_R, delta_crit;
         char *in_halo, *forbidden;
         int i, j, k, x, y, z;
-        unsigned long long int total_halo_num, r_halo_num;
+        index_t total_halo_num, r_halo_num;
         float R_temp, M_MIN;
 
         LOG_DEBUG("Begin Initialisation");
@@ -112,12 +111,12 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
         }
 
         // Unused variables, for future threading
-        //  unsigned long long int nhalo_threads[simulation_options_global->N_THREADS];
-        //  unsigned long long int istart_threads[simulation_options_global->N_THREADS];
+        //  index_t nhalo_threads[simulation_options_global->N_THREADS];
+        //  index_t istart_threads[simulation_options_global->N_THREADS];
         //  //expected TOTAL halos in box from minimum source mass
 
-        // unsigned long long int arraysize_total = halos->buffer_size;
-        // unsigned long long int arraysize_local = arraysize_total /
+        // index_t arraysize_total = halos->buffer_size;
+        // index_t arraysize_local = arraysize_total /
         // simulation_options_global->N_THREADS;
 
 #if LOG_LEVEL >= DEBUG_LEVEL
@@ -132,7 +131,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
 #pragma omp parallel shared(boxes, density_field) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long int index_r, index_f;
+            index_t index_r, index_f;
 #pragma omp for
             for (i = 0; i < grid_dim; i++) {
                 for (j = 0; j < grid_dim; j++) {
@@ -247,7 +246,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
             // now lets scroll through the box, flagging all pixels with delta_m > delta_crit
             r_halo_num = 0;
 
-            unsigned long long int idx_r, idx_f;
+            index_t idx_r, idx_f;
             // THREADING: Fix the race condition propertly to thread: it doesn't matter which thread
             // finds the halo first
             //   but if two threads find a halo in the same region simultaneously (before the first
@@ -340,7 +339,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
         // thread before
         //       OR assign a buffer of size n_halo * n_thread (in case the last thread has all the
         //       halos), copy the structure from stochasticity.c with the assignment and condensing
-        unsigned long long int count = 0;
+        index_t count = 0;
         float halo_buf = 0;
         for (x = 0; x < grid_dim; x++) {
             for (y = 0; y < grid_dim; y++) {
@@ -369,7 +368,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
             // we don't need the density field anymore so we reuse it
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
             {
-                unsigned long long int index_r, index_f;
+                index_t index_r, index_f;
 #pragma omp for
                 for (i = 0; i < grid_dim; i++) {
                     for (j = 0; j < grid_dim; j++) {
@@ -404,7 +403,7 @@ int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *b
             // Now downsample the highres grid to get the lowres version
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
             {
-                unsigned long long int index, hi_index;
+                index_t index, hi_index;
 #pragma omp for
                 for (i = 0; i < simulation_options_global->HII_DIM; i++) {
                     for (j = 0; j < simulation_options_global->HII_DIM; j++) {
@@ -471,7 +470,7 @@ int check_halo(char *in_halo, float R, int x, int y, int z, int check_type) {
     int x_curr, y_curr, z_curr, x_min, x_max, y_min, y_max, z_min, z_max, R_index;
     float Rsq_curr_index;
     int x_index, y_index, z_index;
-    unsigned long long int curr_index;
+    index_t curr_index;
 
     if (check_type == 1) {
         // scale R to a effective overlap size, using R_OVERLAP_FACTOR
@@ -552,10 +551,10 @@ int check_halo(char *in_halo, float R, int x, int y, int z, int check_type) {
     return 0;
 }
 
-void init_halo_coords(HaloCatalog *halos, unsigned long long int n_halos) {
+void init_halo_coords(HaloCatalog *halos, index_t n_halos) {
     // Minimise memory usage by only storing the halo mass and positions
     halos->n_halos = n_halos;
-    unsigned long long int alloc_size = fmax(1, n_halos);
+    index_t alloc_size = fmax(1, n_halos);
     halos->halo_masses = (float *)calloc(alloc_size, sizeof(float));
     halos->halo_coords = (float *)calloc(3 * alloc_size, sizeof(float));
 

--- a/src/py21cmfast/src/HaloCatalog.h
+++ b/src/py21cmfast/src/HaloCatalog.h
@@ -4,9 +4,9 @@
 
 #include "InputParameters.h"
 #include "OutputStructs.h"
+#include "indexing.h"
 
 int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *boxes,
-                       unsigned long long int random_seed, HaloCatalog *halos_desc,
-                       HaloCatalog *halos);
+                       index_t random_seed, HaloCatalog *halos_desc, HaloCatalog *halos);
 
 #endif

--- a/src/py21cmfast/src/HaloCatalog.h
+++ b/src/py21cmfast/src/HaloCatalog.h
@@ -7,6 +7,6 @@
 #include "indexing.h"
 
 int ComputeHaloCatalog(float redshift_desc, float redshift, InitialConditions *boxes,
-                       index_t random_seed, HaloCatalog *halos_desc, HaloCatalog *halos);
+                       random_huge random_seed, HaloCatalog *halos_desc, HaloCatalog *halos);
 
 #endif

--- a/src/py21cmfast/src/InitialConditions.c
+++ b/src/py21cmfast/src/InitialConditions.c
@@ -460,7 +460,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
         // Now sum the stored components to get the laplacian of phi_2 (eq. D13b)
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long index, index_f;
+            unsigned long long int index, index_f;
             double component_ii, component_jj, component_ij;
 #pragma omp for
             for (i = 0; i < hi_dim[0]; i++) {
@@ -544,7 +544,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
 }
 
 // Re-write of init.c for original 21cmFAST
-int ComputeInitialConditions(unsigned long long random_seed, InitialConditions *boxes) {
+int ComputeInitialConditions(unsigned long long int random_seed, InitialConditions *boxes) {
     //     Generates the initial conditions: gaussian random density field
     //     (simulation_options_global->DIM^3) as well as the equal or lower resolution velocity
     //     fields, and smoothed density field (simulation_options_global->HII_DIM^3).

--- a/src/py21cmfast/src/InitialConditions.c
+++ b/src/py21cmfast/src/InitialConditions.c
@@ -35,7 +35,7 @@ void adj_complex_conj(fftwf_complex *HIRES_box) {
         mid_index[i] = box_dim[i] / 2;
     }
 
-    unsigned long long int corner_indices[8] = {
+    index_t corner_indices[8] = {
         grid_index_fftw_c(0, 0, mid_index[2], box_dim),
         grid_index_fftw_c(0, mid_index[1], 0, box_dim),
         grid_index_fftw_c(0, mid_index[1], mid_index[2], box_dim),
@@ -54,8 +54,8 @@ void adj_complex_conj(fftwf_complex *HIRES_box) {
 #pragma omp parallel shared(HIRES_box) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long int index;
-        unsigned long long int index_rx, index_ry, index_rxy;
+        index_t index;
+        index_t index_rx, index_ry, index_rxy;
 #pragma omp for
         for (i = 1; i < mid_index[0]; i++) {
             // just j corners
@@ -85,8 +85,8 @@ void adj_complex_conj(fftwf_complex *HIRES_box) {
 #pragma omp parallel shared(HIRES_box) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long int index;
-        unsigned long long int index_ry;
+        index_t index;
+        index_t index_ry;
 #pragma omp for
         for (i = 0; i <= mid_index[0]; i += mid_index[0]) {
             for (j = 1; j < mid_index[1]; j++) {
@@ -159,7 +159,7 @@ void compute_relative_velocities(fftwf_complex *box, fftwf_complex *box_saved, f
         {
             double k_x, k_y, k_z, k_mag;
             double p, p_vcb;
-            unsigned long long int index;
+            index_t index;
             double kvec[3];
 #pragma omp for
             for (n_x = 0; n_x < hi_dim[0]; n_x++) {
@@ -208,7 +208,7 @@ void compute_relative_velocities(fftwf_complex *box, fftwf_complex *box_saved, f
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
             double vcb_i;
-            unsigned long long int index_r, index_f;
+            index_t index_r, index_f;
             int resampled_index[3];
 #pragma omp for
             for (i = 0; i < lo_dim[0]; i++) {
@@ -242,7 +242,7 @@ void compute_f_gradient(fftwf_complex *box_in, fftwf_complex *box_out, int dim[3
     int n_x, n_y, n_z;
 #pragma omp parallel private(n_x, n_y, n_z) num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long int index;
+        index_t index;
         double k_x, k_y, k_z, k_sq;
 #pragma omp for
         for (n_x = 0; n_x < dim[0]; n_x++) {
@@ -271,7 +271,7 @@ void compute_f_laplacian(fftwf_complex *box_in, fftwf_complex *box_out, int dim[
     int n_x, n_y, n_z;
 #pragma omp parallel private(n_x, n_y, n_z) num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long int index;
+        index_t index;
         double k_x, k_y, k_z, k_sq;
 #pragma omp for
         for (n_x = 0; n_x < dim[0]; n_x++) {
@@ -343,7 +343,7 @@ void compute_velocity_fields(fftwf_complex *box, fftwf_complex *box_saved, float
         // now sample the filtered box
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long int index, index_f;
+            index_t index, index_f;
             int resampled_index[3];
 #pragma omp for
             for (i = 0; i < pt_dim[0]; i++) {
@@ -405,7 +405,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
     // First zero the workspace box for summation
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long int index;
+        index_t index;
 #pragma omp for
         for (i = 0; i < hi_dim[0]; i++) {
             for (j = 0; j < hi_dim[1]; j++) {
@@ -431,8 +431,8 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
         // This will usually be in the allocated hires_vi_2LPT boxes
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long int index;
-            unsigned long long int index_f;
+            index_t index;
+            index_t index_f;
 #pragma omp for
             for (i = 0; i < hi_dim[0]; i++) {
                 for (j = 0; j < hi_dim[1]; j++) {
@@ -460,7 +460,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
         // Now sum the stored components to get the laplacian of phi_2 (eq. D13b)
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long int index, index_f;
+            index_t index, index_f;
             double component_ii, component_jj, component_ij;
 #pragma omp for
             for (i = 0; i < hi_dim[0]; i++) {
@@ -485,7 +485,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
 
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long int index;
+        index_t index;
 #pragma omp for
         for (i = 0; i < hi_dim[0]; i++) {
             for (j = 0; j < hi_dim[1]; j++) {
@@ -525,7 +525,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
         // now sample the filtered box
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long int index, index_f;
+            index_t index, index_f;
             int resampled_index[3];
 #pragma omp for
             for (i = 0; i < pt_dim[0]; i++) {
@@ -544,7 +544,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
 }
 
 // Re-write of init.c for original 21cmFAST
-int ComputeInitialConditions(unsigned long long int random_seed, InitialConditions *boxes) {
+int ComputeInitialConditions(index_t random_seed, InitialConditions *boxes) {
     //     Generates the initial conditions: gaussian random density field
     //     (simulation_options_global->DIM^3) as well as the equal or lower resolution velocity
     //     fields, and smoothed density field (simulation_options_global->HII_DIM^3).
@@ -566,7 +566,7 @@ int ComputeInitialConditions(unsigned long long int random_seed, InitialConditio
 #endif
 
         int i, j, k;
-        unsigned long long int box_ct;
+        index_t box_ct;
 
         gsl_rng *r[simulation_options_global->N_THREADS];
         seed_rng_threads(r, random_seed);
@@ -639,7 +639,7 @@ int ComputeInitialConditions(unsigned long long int random_seed, InitialConditio
 #pragma omp parallel shared(boxes, HIRES_box) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
             {
-                unsigned long long int index_r, index_f;
+                index_t index_r, index_f;
 #pragma omp for
                 for (i = 0; i < hi_dim[0]; i++) {
                     for (j = 0; j < hi_dim[1]; j++) {
@@ -679,7 +679,7 @@ int ComputeInitialConditions(unsigned long long int random_seed, InitialConditio
 #pragma omp parallel shared(boxes, HIRES_box) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
             {
-                unsigned long long int index_r, index_f;
+                index_t index_r, index_f;
 #pragma omp for
                 for (i = 0; i < hi_dim[0]; i++) {
                     for (j = 0; j < hi_dim[1]; j++) {
@@ -715,7 +715,7 @@ int ComputeInitialConditions(unsigned long long int random_seed, InitialConditio
 #pragma omp parallel shared(boxes, HIRES_box, dim_ratio_hi_lo) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long int index_r, index_f;
+            index_t index_r, index_f;
             int resampled_index[3];
 #pragma omp for
             for (i = 0; i < lo_dim[0]; i++) {

--- a/src/py21cmfast/src/InitialConditions.c
+++ b/src/py21cmfast/src/InitialConditions.c
@@ -35,7 +35,7 @@ void adj_complex_conj(fftwf_complex *HIRES_box) {
         mid_index[i] = box_dim[i] / 2;
     }
 
-    index_t corner_indices[8] = {
+    index_huge corner_indices[8] = {
         grid_index_fftw_c(0, 0, mid_index[2], box_dim),
         grid_index_fftw_c(0, mid_index[1], 0, box_dim),
         grid_index_fftw_c(0, mid_index[1], mid_index[2], box_dim),
@@ -54,8 +54,8 @@ void adj_complex_conj(fftwf_complex *HIRES_box) {
 #pragma omp parallel shared(HIRES_box) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
     {
-        index_t index;
-        index_t index_rx, index_ry, index_rxy;
+        index_huge index;
+        index_huge index_rx, index_ry, index_rxy;
 #pragma omp for
         for (i = 1; i < mid_index[0]; i++) {
             // just j corners
@@ -85,8 +85,8 @@ void adj_complex_conj(fftwf_complex *HIRES_box) {
 #pragma omp parallel shared(HIRES_box) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
     {
-        index_t index;
-        index_t index_ry;
+        index_huge index;
+        index_huge index_ry;
 #pragma omp for
         for (i = 0; i <= mid_index[0]; i += mid_index[0]) {
             for (j = 1; j < mid_index[1]; j++) {
@@ -159,7 +159,7 @@ void compute_relative_velocities(fftwf_complex *box, fftwf_complex *box_saved, f
         {
             double k_x, k_y, k_z, k_mag;
             double p, p_vcb;
-            index_t index;
+            index_huge index;
             double kvec[3];
 #pragma omp for
             for (n_x = 0; n_x < hi_dim[0]; n_x++) {
@@ -208,7 +208,7 @@ void compute_relative_velocities(fftwf_complex *box, fftwf_complex *box_saved, f
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
             double vcb_i;
-            index_t index_r, index_f;
+            index_huge index_r, index_f;
             int resampled_index[3];
 #pragma omp for
             for (i = 0; i < lo_dim[0]; i++) {
@@ -242,7 +242,7 @@ void compute_f_gradient(fftwf_complex *box_in, fftwf_complex *box_out, int dim[3
     int n_x, n_y, n_z;
 #pragma omp parallel private(n_x, n_y, n_z) num_threads(simulation_options_global -> N_THREADS)
     {
-        index_t index;
+        index_huge index;
         double k_x, k_y, k_z, k_sq;
 #pragma omp for
         for (n_x = 0; n_x < dim[0]; n_x++) {
@@ -271,7 +271,7 @@ void compute_f_laplacian(fftwf_complex *box_in, fftwf_complex *box_out, int dim[
     int n_x, n_y, n_z;
 #pragma omp parallel private(n_x, n_y, n_z) num_threads(simulation_options_global -> N_THREADS)
     {
-        index_t index;
+        index_huge index;
         double k_x, k_y, k_z, k_sq;
 #pragma omp for
         for (n_x = 0; n_x < dim[0]; n_x++) {
@@ -343,7 +343,7 @@ void compute_velocity_fields(fftwf_complex *box, fftwf_complex *box_saved, float
         // now sample the filtered box
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            index_t index, index_f;
+            index_huge index, index_f;
             int resampled_index[3];
 #pragma omp for
             for (i = 0; i < pt_dim[0]; i++) {
@@ -405,7 +405,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
     // First zero the workspace box for summation
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
-        index_t index;
+        index_huge index;
 #pragma omp for
         for (i = 0; i < hi_dim[0]; i++) {
             for (j = 0; j < hi_dim[1]; j++) {
@@ -431,8 +431,8 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
         // This will usually be in the allocated hires_vi_2LPT boxes
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            index_t index;
-            index_t index_f;
+            index_huge index;
+            index_huge index_f;
 #pragma omp for
             for (i = 0; i < hi_dim[0]; i++) {
                 for (j = 0; j < hi_dim[1]; j++) {
@@ -460,7 +460,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
         // Now sum the stored components to get the laplacian of phi_2 (eq. D13b)
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            index_t index, index_f;
+            index_huge index, index_f;
             double component_ii, component_jj, component_ij;
 #pragma omp for
             for (i = 0; i < hi_dim[0]; i++) {
@@ -485,7 +485,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
 
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
-        index_t index;
+        index_huge index;
 #pragma omp for
         for (i = 0; i < hi_dim[0]; i++) {
             for (j = 0; j < hi_dim[1]; j++) {
@@ -525,7 +525,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
         // now sample the filtered box
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            index_t index, index_f;
+            index_huge index, index_f;
             int resampled_index[3];
 #pragma omp for
             for (i = 0; i < pt_dim[0]; i++) {
@@ -544,7 +544,7 @@ void compute_velocity_fields_2LPT(fftwf_complex *box, fftwf_complex *box_saved,
 }
 
 // Re-write of init.c for original 21cmFAST
-int ComputeInitialConditions(index_t random_seed, InitialConditions *boxes) {
+int ComputeInitialConditions(random_huge random_seed, InitialConditions *boxes) {
     //     Generates the initial conditions: gaussian random density field
     //     (simulation_options_global->DIM^3) as well as the equal or lower resolution velocity
     //     fields, and smoothed density field (simulation_options_global->HII_DIM^3).
@@ -566,7 +566,7 @@ int ComputeInitialConditions(index_t random_seed, InitialConditions *boxes) {
 #endif
 
         int i, j, k;
-        index_t box_ct;
+        index_huge box_ct;
 
         gsl_rng *r[simulation_options_global->N_THREADS];
         seed_rng_threads(r, random_seed);
@@ -639,7 +639,7 @@ int ComputeInitialConditions(index_t random_seed, InitialConditions *boxes) {
 #pragma omp parallel shared(boxes, HIRES_box) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
             {
-                index_t index_r, index_f;
+                index_huge index_r, index_f;
 #pragma omp for
                 for (i = 0; i < hi_dim[0]; i++) {
                     for (j = 0; j < hi_dim[1]; j++) {
@@ -679,7 +679,7 @@ int ComputeInitialConditions(index_t random_seed, InitialConditions *boxes) {
 #pragma omp parallel shared(boxes, HIRES_box) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
             {
-                index_t index_r, index_f;
+                index_huge index_r, index_f;
 #pragma omp for
                 for (i = 0; i < hi_dim[0]; i++) {
                     for (j = 0; j < hi_dim[1]; j++) {
@@ -715,7 +715,7 @@ int ComputeInitialConditions(index_t random_seed, InitialConditions *boxes) {
 #pragma omp parallel shared(boxes, HIRES_box, dim_ratio_hi_lo) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS)
         {
-            index_t index_r, index_f;
+            index_huge index_r, index_f;
             int resampled_index[3];
 #pragma omp for
             for (i = 0; i < lo_dim[0]; i++) {

--- a/src/py21cmfast/src/InitialConditions.h
+++ b/src/py21cmfast/src/InitialConditions.h
@@ -8,6 +8,6 @@
 #include "OutputStructs.h"
 #include "indexing.h"
 
-int ComputeInitialConditions(index_t random_seed, InitialConditions *boxes);
+int ComputeInitialConditions(random_huge random_seed, InitialConditions *boxes);
 
 #endif

--- a/src/py21cmfast/src/InitialConditions.h
+++ b/src/py21cmfast/src/InitialConditions.h
@@ -6,7 +6,8 @@
 
 #include "InputParameters.h"
 #include "OutputStructs.h"
+#include "indexing.h"
 
-int ComputeInitialConditions(unsigned long long random_seed, InitialConditions *boxes);
+int ComputeInitialConditions(index_t random_seed, InitialConditions *boxes);
 
 #endif

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -320,7 +320,7 @@ void free_fftw_grids(struct FilteredGrids *fg_struct) {
 void prepare_box_for_filtering(float *input_box, fftwf_complex *output_c_box, double const_factor,
                                double limit_min, double limit_max) {
     int i, j, k;
-    unsigned long long int ct;
+    index_t ct;
     // NOTE: Meraxes just applies a pointer cast box = (fftwf_complex *) input. Figure out why this
     // works. They pad the input by a factor of 2 to cover the complex part, but from the type I
     // thought it would be stored [(r,c),(r,c)...] Not [(r,r,r,r....),(c,c,c....)] so the alignment
@@ -329,7 +329,7 @@ void prepare_box_for_filtering(float *input_box, fftwf_complex *output_c_box, do
                       HII_D_PARA};
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long int index, index_f;
+        index_t index, index_f;
         double curr_cell;
 #pragma omp for collapse(3)
         for (i = 0; i < box_dim[0]; i++) {
@@ -363,7 +363,7 @@ void setup_first_z_prevbox(IonizedBox *previous_ionize_box, PerturbedField *prev
                            int n_radii) {
     LOG_DEBUG("first redshift, do some initialization");
     int i, j, k;
-    unsigned long long int ct;
+    index_t ct;
     int box_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
                       HII_D_PARA};
 
@@ -412,7 +412,7 @@ void calculate_mcrit_boxes(IonizedBox *prev_ionbox, TsBox *spin_temp, InitialCon
         double Mcrit_RE, Mcrit_LW;
         double curr_Mt, curr_Mt_MINI;
         double curr_vcb = consts->scale_consts.vcb_norel;
-        unsigned long long int index, index_f;
+        index_t index, index_f;
 #pragma omp for reduction(+ : ave_log10_Mturnover, ave_log10_Mturnover_MINI)
         for (x = 0; x < box_dim[0]; x++) {
             for (y = 0; y < box_dim[1]; y++) {
@@ -529,7 +529,7 @@ void set_mean_fcoll(struct IonBoxConstants *c, IonizedBox *prev_box, IonizedBox 
 double set_fully_neutral_box(IonizedBox *box, TsBox *spin_temp, PerturbedField *perturbed_field,
                              struct IonBoxConstants *consts) {
     double global_xH = 0.;
-    unsigned long long int ct;
+    index_t ct;
     if (astro_options_global->USE_TS_FLUCT) {
 #pragma omp parallel private(ct) num_threads(simulation_options_global -> N_THREADS)
         {
@@ -674,7 +674,7 @@ void clip_and_get_extrema(fftwf_complex *grid, double lower_limit, double upper_
     {
         int x, y, z;
         float curr;
-        unsigned long long int index;
+        index_t index;
 #pragma omp for reduction(max : max_buf) reduction(min : min_buf)
         for (x = 0; x < simulation_options_global->HII_DIM; x++) {
             for (y = 0; y < simulation_options_global->HII_DIM; y++) {
@@ -787,7 +787,7 @@ void calculate_fcoll_grid(IonizedBox *box, IonizedBox *previous_ionize_box,
         double prev_dens = 0, prev_Splined_Fcoll = 0., prev_Splined_Fcoll_MINI = 0.;
         // is only overwritten with minihalos
         log10_Mturnover = log10(consts->scale_consts.mturn_a_nofb);
-        unsigned long long int index_r, index_f;
+        index_t index_r, index_f;
 #pragma omp for reduction(+ : f_coll_total, f_coll_MINI_total)
         for (x = 0; x < box_dim[0]; x++) {
             for (y = 0; y < box_dim[1]; y++) {
@@ -1029,7 +1029,7 @@ void find_ionised_regions(IonizedBox *box, IonizedBox *previous_ionize_box,
         int x, y, z;
         double curr_dens, curr_fcoll, curr_fcoll_mini;
         double rec, xHII_from_xrays, res_xH;
-        unsigned long long int index_r, index_f;
+        index_t index_r, index_f;
 #pragma omp for
         for (x = 0; x < box_dim[0]; x++) {
             for (y = 0; y < box_dim[1]; y++) {
@@ -1198,7 +1198,7 @@ void set_ionized_temperatures(IonizedBox *box, PerturbedField *perturbed_field, 
     int box_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
                       HII_D_PARA};
 
-    unsigned long long int idx;
+    index_t idx;
 #pragma omp parallel private(x, y, z, idx) num_threads(simulation_options_global -> N_THREADS)
     {
         float thistk;
@@ -1257,7 +1257,7 @@ void set_recombination_rates(IonizedBox *box, IonizedBox *previous_ionize_box,
         int x, y, z;
         double curr_dens, dNrec;
         double z_eff;
-        unsigned long long int idx;
+        index_t idx;
 #pragma omp for
         for (x = 0; x < simulation_options_global->HII_DIM; x++) {
             for (y = 0; y < simulation_options_global->HII_DIM; y++) {
@@ -1331,7 +1331,7 @@ int ComputeIonizedBox(float redshift, float prev_redshift, PerturbedField *pertu
         // Do each time to avoid Python garbage collection issues
         omp_set_num_threads(simulation_options_global->N_THREADS);
 
-        unsigned long long ct;
+        index_t ct;
 
         double global_xH;
 

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -320,7 +320,7 @@ void free_fftw_grids(struct FilteredGrids *fg_struct) {
 void prepare_box_for_filtering(float *input_box, fftwf_complex *output_c_box, double const_factor,
                                double limit_min, double limit_max) {
     int i, j, k;
-    index_t ct;
+    index_huge ct;
     // NOTE: Meraxes just applies a pointer cast box = (fftwf_complex *) input. Figure out why this
     // works. They pad the input by a factor of 2 to cover the complex part, but from the type I
     // thought it would be stored [(r,c),(r,c)...] Not [(r,r,r,r....),(c,c,c....)] so the alignment
@@ -329,7 +329,7 @@ void prepare_box_for_filtering(float *input_box, fftwf_complex *output_c_box, do
                       HII_D_PARA};
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
-        index_t index, index_f;
+        index_huge index, index_f;
         double curr_cell;
 #pragma omp for collapse(3)
         for (i = 0; i < box_dim[0]; i++) {
@@ -363,7 +363,7 @@ void setup_first_z_prevbox(IonizedBox *previous_ionize_box, PerturbedField *prev
                            int n_radii) {
     LOG_DEBUG("first redshift, do some initialization");
     int i, j, k;
-    index_t ct;
+    index_huge ct;
     int box_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
                       HII_D_PARA};
 
@@ -412,7 +412,7 @@ void calculate_mcrit_boxes(IonizedBox *prev_ionbox, TsBox *spin_temp, InitialCon
         double Mcrit_RE, Mcrit_LW;
         double curr_Mt, curr_Mt_MINI;
         double curr_vcb = consts->scale_consts.vcb_norel;
-        index_t index, index_f;
+        index_huge index, index_f;
 #pragma omp for reduction(+ : ave_log10_Mturnover, ave_log10_Mturnover_MINI)
         for (x = 0; x < box_dim[0]; x++) {
             for (y = 0; y < box_dim[1]; y++) {
@@ -529,7 +529,7 @@ void set_mean_fcoll(struct IonBoxConstants *c, IonizedBox *prev_box, IonizedBox 
 double set_fully_neutral_box(IonizedBox *box, TsBox *spin_temp, PerturbedField *perturbed_field,
                              struct IonBoxConstants *consts) {
     double global_xH = 0.;
-    index_t ct;
+    index_huge ct;
     if (astro_options_global->USE_TS_FLUCT) {
 #pragma omp parallel private(ct) num_threads(simulation_options_global -> N_THREADS)
         {
@@ -674,7 +674,7 @@ void clip_and_get_extrema(fftwf_complex *grid, double lower_limit, double upper_
     {
         int x, y, z;
         float curr;
-        index_t index;
+        index_huge index;
 #pragma omp for reduction(max : max_buf) reduction(min : min_buf)
         for (x = 0; x < simulation_options_global->HII_DIM; x++) {
             for (y = 0; y < simulation_options_global->HII_DIM; y++) {
@@ -787,7 +787,7 @@ void calculate_fcoll_grid(IonizedBox *box, IonizedBox *previous_ionize_box,
         double prev_dens = 0, prev_Splined_Fcoll = 0., prev_Splined_Fcoll_MINI = 0.;
         // is only overwritten with minihalos
         log10_Mturnover = log10(consts->scale_consts.mturn_a_nofb);
-        index_t index_r, index_f;
+        index_huge index_r, index_f;
 #pragma omp for reduction(+ : f_coll_total, f_coll_MINI_total)
         for (x = 0; x < box_dim[0]; x++) {
             for (y = 0; y < box_dim[1]; y++) {
@@ -1029,7 +1029,7 @@ void find_ionised_regions(IonizedBox *box, IonizedBox *previous_ionize_box,
         int x, y, z;
         double curr_dens, curr_fcoll, curr_fcoll_mini;
         double rec, xHII_from_xrays, res_xH;
-        index_t index_r, index_f;
+        index_huge index_r, index_f;
 #pragma omp for
         for (x = 0; x < box_dim[0]; x++) {
             for (y = 0; y < box_dim[1]; y++) {
@@ -1198,7 +1198,7 @@ void set_ionized_temperatures(IonizedBox *box, PerturbedField *perturbed_field, 
     int box_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
                       HII_D_PARA};
 
-    index_t idx;
+    index_huge idx;
 #pragma omp parallel private(x, y, z, idx) num_threads(simulation_options_global -> N_THREADS)
     {
         float thistk;
@@ -1257,7 +1257,7 @@ void set_recombination_rates(IonizedBox *box, IonizedBox *previous_ionize_box,
         int x, y, z;
         double curr_dens, dNrec;
         double z_eff;
-        index_t idx;
+        index_huge idx;
 #pragma omp for
         for (x = 0; x < simulation_options_global->HII_DIM; x++) {
             for (y = 0; y < simulation_options_global->HII_DIM; y++) {
@@ -1331,7 +1331,7 @@ int ComputeIonizedBox(float redshift, float prev_redshift, PerturbedField *pertu
         // Do each time to avoid Python garbage collection issues
         omp_set_num_threads(simulation_options_global->N_THREADS);
 
-        index_t ct;
+        index_huge ct;
 
         double global_xH;
 

--- a/src/py21cmfast/src/PerturbedField.c
+++ b/src/py21cmfast/src/PerturbedField.c
@@ -320,7 +320,7 @@ void compute_perturbed_velocities(unsigned short axis, double redshift,
 #pragma omp parallel private(n_x, n_y, n_z, k_x, k_y, k_z, k_sq, kvec) \
     num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long grid_index;
+        unsigned long long int grid_index;
 #pragma omp for
         for (n_x = 0; n_x < box_dim[0]; n_x++) {
             k_x = index_to_k(n_x, box_len[0], box_dim[0]);

--- a/src/py21cmfast/src/PerturbedField.c
+++ b/src/py21cmfast/src/PerturbedField.c
@@ -65,7 +65,7 @@ void make_density_grid(float redshift, fftwf_complex *fft_density_grid, InitialC
     if (matter_options_global->PERTURB_ALGORITHM == 0) {
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            index_t grid_index, fft_index;
+            index_huge grid_index, fft_index;
 #pragma omp for
             for (i = 0; i < box_dim[0]; i++) {
                 for (j = 0; j < box_dim[1]; j++) {
@@ -82,7 +82,7 @@ void make_density_grid(float redshift, fftwf_complex *fft_density_grid, InitialC
         // Apply Zel'dovich/2LPT correction
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            index_t fft_index;
+            index_huge fft_index;
 #pragma omp for
             for (i = 0; i < box_dim[0]; i++) {
                 for (j = 0; j < box_dim[1]; j++) {
@@ -114,7 +114,7 @@ void make_density_grid(float redshift, fftwf_complex *fft_density_grid, InitialC
         // Resample back to a fftw float for remaining algorithm
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            index_t grid_index, fft_index;
+            index_huge grid_index, fft_index;
 #pragma omp for
             for (i = 0; i < box_dim[0]; i++) {
                 for (j = 0; j < box_dim[1]; j++) {
@@ -190,7 +190,7 @@ void normalise_delta_grid(fftwf_complex *deltap1_grid) {
                              : HII_TOT_NUM_PIXELS / (double)TOT_NUM_PIXELS;
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
-        index_t grid_index;
+        index_huge grid_index;
         float *cell_ptr;
 #pragma omp for
         for (i = 0; i < lo_dim[0]; i++) {
@@ -247,11 +247,11 @@ void smooth_and_clip_density(fftwf_complex *lowres_grid, fftwf_complex *density_
                       FFTW_REAL_LAYOUT, "  ");
 
     // normalize after FFT
-    index_t bad_count = 0;
+    size_huge bad_count = 0;
 #pragma omp parallel shared(lowres_grid) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS) reduction(+ : bad_count)
     {
-        index_t grid_index;
+        index_huge grid_index;
 #pragma omp for
         for (i = 0; i < simulation_options_global->HII_DIM; i++) {
             for (j = 0; j < simulation_options_global->HII_DIM; j++) {
@@ -290,7 +290,7 @@ void compute_perturbed_velocities(unsigned short axis, double redshift,
 
     float kvec[3];
     double dDdt_over_D = ddickedt(redshift) / dicke(redshift);
-    index_t n_k_pixels, n_r_pixels;
+    size_huge n_k_pixels, n_r_pixels;
     // Function for deciding the dimensions of loops when we could
     // use either the low or high resolution grids.
     int box_dim[3];
@@ -320,7 +320,7 @@ void compute_perturbed_velocities(unsigned short axis, double redshift,
 #pragma omp parallel private(n_x, n_y, n_z, k_x, k_y, k_z, k_sq, kvec) \
     num_threads(simulation_options_global -> N_THREADS)
     {
-        index_t grid_index;
+        index_huge grid_index;
 #pragma omp for
         for (n_x = 0; n_x < box_dim[0]; n_x++) {
             k_x = index_to_k(n_x, box_len[0], box_dim[0]);
@@ -366,7 +366,7 @@ void compute_perturbed_velocities(unsigned short axis, double redshift,
 
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
-        index_t grid_index_f, grid_index_r;
+        index_huge grid_index_f, grid_index_r;
         int grid_ipos[3];
 #pragma omp for
         for (i = 0; i < lo_dim[0]; i++) {
@@ -449,7 +449,7 @@ int ComputePerturbedField(float redshift, InitialConditions *boxes,
                          HII_D_PARA};
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
         {
-            index_t index_r, index_f;
+            index_huge index_r, index_f;
 #pragma omp for
             for (int i = 0; i < lo_dim[0]; i++) {
                 for (int j = 0; j < lo_dim[1]; j++) {

--- a/src/py21cmfast/src/PerturbedField.c
+++ b/src/py21cmfast/src/PerturbedField.c
@@ -184,9 +184,9 @@ void normalise_delta_grid(fftwf_complex *deltap1_grid) {
                      HII_D_PARA};
     int hi_dim[3] = {simulation_options_global->DIM, simulation_options_global->DIM, D_PARA};
     // Renormalise the lowres box
-    double mass_factor =
-        matter_options_global->PERTURB_ON_HIGH_RES ? 1.0
-                                                    : HII_TOT_NUM_PIXELS / (double)TOT_NUM_PIXELS;
+    double mass_factor = matter_options_global->PERTURB_ON_HIGH_RES
+                             ? 1.0
+                             : HII_TOT_NUM_PIXELS / (double)TOT_NUM_PIXELS;
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
         unsigned long long int grid_index;

--- a/src/py21cmfast/src/PerturbedField.c
+++ b/src/py21cmfast/src/PerturbedField.c
@@ -185,9 +185,8 @@ void normalise_delta_grid(fftwf_complex *deltap1_grid) {
     int hi_dim[3] = {simulation_options_global->DIM, simulation_options_global->DIM, D_PARA};
     // Renormalise the lowres box
     double mass_factor =
-        matter_options_global->PERTURB_ON_HIGH_RES
-            ? 1.0
-            : (lo_dim[0] * lo_dim[1] * lo_dim[2]) / (double)(hi_dim[0] * hi_dim[1] * hi_dim[2]);
+        matter_options_global->PERTURB_ON_HIGH_RES ? 1.0
+                                                    : HII_TOT_NUM_PIXELS / (double)TOT_NUM_PIXELS;
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
         unsigned long long int grid_index;
@@ -244,7 +243,7 @@ void smooth_and_clip_density(fftwf_complex *lowres_grid, fftwf_complex *density_
                       simulation_options_global->HII_DIM, 2 * (HII_D_PARA / 2 + 1), "  ");
 
     // normalize after FFT
-    int bad_count = 0;
+    unsigned long long int bad_count = 0;
 #pragma omp parallel shared(lowres_grid) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS) reduction(+ : bad_count)
     {
@@ -271,7 +270,7 @@ void smooth_and_clip_density(fftwf_complex *lowres_grid, fftwf_complex *density_
             }
         }
     }
-    if (bad_count >= 5) LOG_WARNING("Total number of bad indices: %d", bad_count);
+    if (bad_count >= 5) LOG_WARNING("Total number of bad indices: %llu", bad_count);
     LOG_SUPER_DEBUG("delta normalized: ");
     debugSummarizeBox((float *)lowres_grid, simulation_options_global->HII_DIM,
                       simulation_options_global->HII_DIM, 2 * (HII_D_PARA / 2 + 1), "  ");

--- a/src/py21cmfast/src/PerturbedField.c
+++ b/src/py21cmfast/src/PerturbedField.c
@@ -65,7 +65,7 @@ void make_density_grid(float redshift, fftwf_complex *fft_density_grid, InitialC
     if (matter_options_global->PERTURB_ALGORITHM == 0) {
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long int grid_index, fft_index;
+            index_t grid_index, fft_index;
 #pragma omp for
             for (i = 0; i < box_dim[0]; i++) {
                 for (j = 0; j < box_dim[1]; j++) {
@@ -82,7 +82,7 @@ void make_density_grid(float redshift, fftwf_complex *fft_density_grid, InitialC
         // Apply Zel'dovich/2LPT correction
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long int fft_index;
+            index_t fft_index;
 #pragma omp for
             for (i = 0; i < box_dim[0]; i++) {
                 for (j = 0; j < box_dim[1]; j++) {
@@ -114,7 +114,7 @@ void make_density_grid(float redshift, fftwf_complex *fft_density_grid, InitialC
         // Resample back to a fftw float for remaining algorithm
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
-            unsigned long long int grid_index, fft_index;
+            index_t grid_index, fft_index;
 #pragma omp for
             for (i = 0; i < box_dim[0]; i++) {
                 for (j = 0; j < box_dim[1]; j++) {
@@ -190,7 +190,7 @@ void normalise_delta_grid(fftwf_complex *deltap1_grid) {
                              : HII_TOT_NUM_PIXELS / (double)TOT_NUM_PIXELS;
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long int grid_index;
+        index_t grid_index;
         float *cell_ptr;
 #pragma omp for
         for (i = 0; i < lo_dim[0]; i++) {
@@ -247,11 +247,11 @@ void smooth_and_clip_density(fftwf_complex *lowres_grid, fftwf_complex *density_
                       FFTW_REAL_LAYOUT, "  ");
 
     // normalize after FFT
-    unsigned long long int bad_count = 0;
+    index_t bad_count = 0;
 #pragma omp parallel shared(lowres_grid) private(i, j, k) \
     num_threads(simulation_options_global -> N_THREADS) reduction(+ : bad_count)
     {
-        unsigned long long int grid_index;
+        index_t grid_index;
 #pragma omp for
         for (i = 0; i < simulation_options_global->HII_DIM; i++) {
             for (j = 0; j < simulation_options_global->HII_DIM; j++) {
@@ -290,7 +290,7 @@ void compute_perturbed_velocities(unsigned short axis, double redshift,
 
     float kvec[3];
     double dDdt_over_D = ddickedt(redshift) / dicke(redshift);
-    unsigned long long int n_k_pixels, n_r_pixels;
+    index_t n_k_pixels, n_r_pixels;
     // Function for deciding the dimensions of loops when we could
     // use either the low or high resolution grids.
     int box_dim[3];
@@ -320,7 +320,7 @@ void compute_perturbed_velocities(unsigned short axis, double redshift,
 #pragma omp parallel private(n_x, n_y, n_z, k_x, k_y, k_z, k_sq, kvec) \
     num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long int grid_index;
+        index_t grid_index;
 #pragma omp for
         for (n_x = 0; n_x < box_dim[0]; n_x++) {
             k_x = index_to_k(n_x, box_len[0], box_dim[0]);
@@ -366,7 +366,7 @@ void compute_perturbed_velocities(unsigned short axis, double redshift,
 
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
     {
-        unsigned long long int grid_index_f, grid_index_r;
+        index_t grid_index_f, grid_index_r;
         int grid_ipos[3];
 #pragma omp for
         for (i = 0; i < lo_dim[0]; i++) {
@@ -449,7 +449,7 @@ int ComputePerturbedField(float redshift, InitialConditions *boxes,
                          HII_D_PARA};
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
         {
-            unsigned long long int index_r, index_f;
+            index_t index_r, index_f;
 #pragma omp for
             for (int i = 0; i < lo_dim[0]; i++) {
                 for (int j = 0; j < lo_dim[1]; j++) {

--- a/src/py21cmfast/src/PerturbedHaloCatalog.c
+++ b/src/py21cmfast/src/PerturbedHaloCatalog.c
@@ -44,7 +44,7 @@ int ComputePerturbedHaloCatalog(float redshift, InitialConditions *boxes, TsBox 
 
         float growth_factor, displacement_factor_2LPT, init_growth_factor,
             init_displacement_factor_2LPT;
-        index_t i_halo;
+        index_huge i_halo;
 
         // Function for deciding the dimensions of loops when we could
         // use either the low or high resolution grids.
@@ -96,13 +96,13 @@ int ComputePerturbedHaloCatalog(float redshift, InitialConditions *boxes, TsBox 
         halos_perturbed->n_halos = halos->n_halos;
 
         // ******************   END INITIALIZATION     ******************************** //
-        index_t n_exact_dim = 0;
+        size_huge n_exact_dim = 0;
         bool error_in_parallel = false;
 #pragma omp parallel private(i_halo) num_threads(simulation_options_global -> N_THREADS) \
     reduction(+ : n_exact_dim)
         {
             double pos[3];
-            index_t grid_index;
+            index_huge grid_index;
             int ipos[3];
 #pragma omp for
             for (i_halo = 0; i_halo < halos->n_halos; i_halo++) {

--- a/src/py21cmfast/src/PerturbedHaloCatalog.c
+++ b/src/py21cmfast/src/PerturbedHaloCatalog.c
@@ -102,7 +102,7 @@ int ComputePerturbedHaloCatalog(float redshift, InitialConditions *boxes, TsBox 
     reduction(+ : n_exact_dim)
         {
             double pos[3];
-            unsigned long long grid_index;
+            unsigned long long int grid_index;
             int ipos[3];
 #pragma omp for
             for (i_halo = 0; i_halo < halos->n_halos; i_halo++) {

--- a/src/py21cmfast/src/PerturbedHaloCatalog.c
+++ b/src/py21cmfast/src/PerturbedHaloCatalog.c
@@ -44,7 +44,7 @@ int ComputePerturbedHaloCatalog(float redshift, InitialConditions *boxes, TsBox 
 
         float growth_factor, displacement_factor_2LPT, init_growth_factor,
             init_displacement_factor_2LPT;
-        unsigned long long int i_halo;
+        index_t i_halo;
 
         // Function for deciding the dimensions of loops when we could
         // use either the low or high resolution grids.
@@ -96,13 +96,13 @@ int ComputePerturbedHaloCatalog(float redshift, InitialConditions *boxes, TsBox 
         halos_perturbed->n_halos = halos->n_halos;
 
         // ******************   END INITIALIZATION     ******************************** //
-        unsigned long long int n_exact_dim = 0;
+        index_t n_exact_dim = 0;
         bool error_in_parallel = false;
 #pragma omp parallel private(i_halo) num_threads(simulation_options_global -> N_THREADS) \
     reduction(+ : n_exact_dim)
         {
             double pos[3];
-            unsigned long long int grid_index;
+            index_t grid_index;
             int ipos[3];
 #pragma omp for
             for (i_halo = 0; i_halo < halos->n_halos; i_halo++) {

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -505,7 +505,7 @@ void calculate_spectral_factors(double zp) {
 void prepare_filter_boxes(double redshift, float *input_dens, float *input_vcb, float *input_j21,
                           fftwf_complex *output_dens, fftwf_complex *output_LW) {
     int i, j, k;
-    unsigned long long int ct, index_f;
+    index_t ct, index_f;
     double curr_vcb, curr_j21, M_buf;
     int box_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
                       HII_D_PARA};
@@ -608,7 +608,7 @@ void fill_Rbox_table(float **result, fftwf_complex *unfiltered_box, double *R_ar
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
             float curr;
-            unsigned long long int index_r, index_f;
+            index_t index_r, index_f;
 #pragma omp for reduction(+ : ave_buffer) reduction(max : max_out_R) reduction(min : min_out_R)
             for (i = 0; i < box_dim[0]; i++) {
                 for (j = 0; j < box_dim[1]; j++) {
@@ -650,7 +650,7 @@ void fill_Rbox_table(float **result, fftwf_complex *unfiltered_box, double *R_ar
 void one_annular_filter(float *input_box, float *output_box, double R_inner, double R_outer,
                         double *u_avg, double *f_avg) {
     int i, j, k;
-    unsigned long long int ct;
+    index_t ct;
     double unfiltered_avg = 0;
     double filtered_avg = 0;
     int box_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
@@ -665,7 +665,7 @@ void one_annular_filter(float *input_box, float *output_box, double R_inner, dou
     reduction(+ : unfiltered_avg)
     {
         float curr_val;
-        unsigned long long int index_r, index_f;
+        index_t index_r, index_f;
 #pragma omp for
         for (i = 0; i < box_dim[0]; i++) {
             for (j = 0; j < box_dim[1]; j++) {
@@ -714,7 +714,7 @@ void one_annular_filter(float *input_box, float *output_box, double R_inner, dou
     reduction(+ : filtered_avg)
     {
         float curr_val;
-        unsigned long long int index_f, index_r;
+        index_t index_f, index_r;
 #pragma omp for
         for (i = 0; i < box_dim[0]; i++) {
             for (j = 0; j < box_dim[1]; j++) {
@@ -883,7 +883,7 @@ void fill_freqint_tables(double zp, double x_e_ave, double filling_factor_of_HI_
 // construct a Ts table above Z_HEAT_MAX, this can happen if we are computing the first box or if we
 // request a redshift above Z_HEAT_MAX
 void init_first_Ts(TsBox *box, float *dens, float z, float zp, double *x_e_ave, double *Tk_ave) {
-    unsigned long long int box_ct;
+    index_t box_ct;
     // zp is the requested redshift, z is the perturbed field redshift
     float growth_factor_zp;
     float inverse_growth_factor_z;
@@ -1024,7 +1024,7 @@ void calculate_sfrd_from_grid(int R_ct, float *dens_R_grid, float *Mcrit_R_grid,
 
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
     {
-        unsigned long long int box_ct;
+        index_t box_ct;
         double curr_dens;
         double curr_mcrit = 0.;
         double fcoll, dfcoll;
@@ -1376,7 +1376,7 @@ void ts_main(float redshift, float prev_redshift, float perturbed_field_redshift
              PerturbedField *perturbed_field, XraySourceBox *source_box, TsBox *previous_spin_temp,
              InitialConditions *ini_boxes, TsBox *this_spin_temp) {
     int R_ct;
-    unsigned long long int box_ct;
+    index_t box_ct;
     double x_e_ave_p, Tk_ave_p;
     double growth_factor_z, growth_factor_zp;
     double inverse_growth_factor_z;

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -505,7 +505,7 @@ void calculate_spectral_factors(double zp) {
 void prepare_filter_boxes(double redshift, float *input_dens, float *input_vcb, float *input_j21,
                           fftwf_complex *output_dens, fftwf_complex *output_LW) {
     int i, j, k;
-    index_t ct, index_f;
+    index_huge ct, index_f;
     double curr_vcb, curr_j21, M_buf;
     int box_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
                       HII_D_PARA};
@@ -608,7 +608,7 @@ void fill_Rbox_table(float **result, fftwf_complex *unfiltered_box, double *R_ar
 #pragma omp parallel private(i, j, k) num_threads(simulation_options_global -> N_THREADS)
         {
             float curr;
-            index_t index_r, index_f;
+            index_huge index_r, index_f;
 #pragma omp for reduction(+ : ave_buffer) reduction(max : max_out_R) reduction(min : min_out_R)
             for (i = 0; i < box_dim[0]; i++) {
                 for (j = 0; j < box_dim[1]; j++) {
@@ -650,7 +650,7 @@ void fill_Rbox_table(float **result, fftwf_complex *unfiltered_box, double *R_ar
 void one_annular_filter(float *input_box, float *output_box, double R_inner, double R_outer,
                         double *u_avg, double *f_avg) {
     int i, j, k;
-    index_t ct;
+    index_huge ct;
     double unfiltered_avg = 0;
     double filtered_avg = 0;
     int box_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
@@ -665,7 +665,7 @@ void one_annular_filter(float *input_box, float *output_box, double R_inner, dou
     reduction(+ : unfiltered_avg)
     {
         float curr_val;
-        index_t index_r, index_f;
+        index_huge index_r, index_f;
 #pragma omp for
         for (i = 0; i < box_dim[0]; i++) {
             for (j = 0; j < box_dim[1]; j++) {
@@ -714,7 +714,7 @@ void one_annular_filter(float *input_box, float *output_box, double R_inner, dou
     reduction(+ : filtered_avg)
     {
         float curr_val;
-        index_t index_f, index_r;
+        index_huge index_f, index_r;
 #pragma omp for
         for (i = 0; i < box_dim[0]; i++) {
             for (j = 0; j < box_dim[1]; j++) {
@@ -883,7 +883,7 @@ void fill_freqint_tables(double zp, double x_e_ave, double filling_factor_of_HI_
 // construct a Ts table above Z_HEAT_MAX, this can happen if we are computing the first box or if we
 // request a redshift above Z_HEAT_MAX
 void init_first_Ts(TsBox *box, float *dens, float z, float zp, double *x_e_ave, double *Tk_ave) {
-    index_t box_ct;
+    index_huge box_ct;
     // zp is the requested redshift, z is the perturbed field redshift
     float growth_factor_zp;
     float inverse_growth_factor_z;
@@ -1024,7 +1024,7 @@ void calculate_sfrd_from_grid(int R_ct, float *dens_R_grid, float *Mcrit_R_grid,
 
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
     {
-        index_t box_ct;
+        index_huge box_ct;
         double curr_dens;
         double curr_mcrit = 0.;
         double fcoll, dfcoll;
@@ -1376,7 +1376,7 @@ void ts_main(float redshift, float prev_redshift, float perturbed_field_redshift
              PerturbedField *perturbed_field, XraySourceBox *source_box, TsBox *previous_spin_temp,
              InitialConditions *ini_boxes, TsBox *this_spin_temp) {
     int R_ct;
-    index_t box_ct;
+    index_huge box_ct;
     double x_e_ave_p, Tk_ave_p;
     double growth_factor_z, growth_factor_zp;
     double inverse_growth_factor_z;

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -186,7 +186,7 @@ void alloc_global_arrays() {
 
         delNL0 = (float **)calloc(num_R_boxes, sizeof(float *));
         for (i = 0; i < num_R_boxes; i++) {
-            delNL0[i] = (float *)calloc((float)HII_TOT_NUM_PIXELS, sizeof(float));
+            delNL0[i] = (float *)calloc(HII_TOT_NUM_PIXELS, sizeof(float));
         }
         if (astro_options_global->USE_MINI_HALOS) {
             log10_Mcrit_LW = (float **)calloc(num_R_boxes, sizeof(float *));

--- a/src/py21cmfast/src/Stochasticity.c
+++ b/src/py21cmfast/src/Stochasticity.c
@@ -242,7 +242,7 @@ void set_prop_rng(gsl_rng *rng, bool from_catalog, double *interp, double *input
 }
 
 // This is the function called to assign halo properties to an entire catalogue, used for DexM halos
-int add_properties_cat(unsigned long long int seed, float redshift, HaloCatalog *halos) {
+int add_properties_cat(index_t seed, float redshift, HaloCatalog *halos) {
     // set up the rng
     gsl_rng *rng_stoc[simulation_options_global->N_THREADS];
     seed_rng_threads_fast(rng_stoc, seed);
@@ -250,7 +250,7 @@ int add_properties_cat(unsigned long long int seed, float redshift, HaloCatalog 
     LOG_DEBUG("computing rng for %llu halos", halos->n_halos);
 
     // loop through the halos and assign properties
-    unsigned long long int i;
+    index_t i;
     double buf[3];
     double dummy[3];  // we don't need interpolation here
 #pragma omp parallel for private(i, buf)
@@ -731,10 +731,10 @@ int stoc_sample(struct HaloSamplingConstants *hs_constants, gsl_rng *rng, int *n
 // Halo lists are partitioned per thread for sampling
 //   so have trailing zeros in each thread.
 //   This function condenses the array
-void condense_sparse_halolist(HaloCatalog *halofield, unsigned long long int *istart_threads,
-                              unsigned long long int *nhalo_threads) {
+void condense_sparse_halolist(HaloCatalog *halofield, index_t *istart_threads,
+                              index_t *nhalo_threads) {
     int i = 0;
-    unsigned long long int count_total = 0;
+    index_t count_total = 0;
     for (i = 0; i < simulation_options_global->N_THREADS; i++) {
         memmove(&halofield->halo_masses[count_total], &halofield->halo_masses[istart_threads[i]],
                 sizeof(float) * nhalo_threads[i]);
@@ -779,12 +779,12 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field,
     double Mmin = hs_constants->M_min;
     double growthf = hs_constants->growth_out;
 
-    unsigned long long int nhalo_in = halofield_large->n_halos;
-    unsigned long long int nhalo_threads[simulation_options_global->N_THREADS];
-    unsigned long long int istart_threads[simulation_options_global->N_THREADS];
+    index_t nhalo_in = halofield_large->n_halos;
+    index_t nhalo_threads[simulation_options_global->N_THREADS];
+    index_t istart_threads[simulation_options_global->N_THREADS];
 
-    unsigned long long int arraysize_total = halofield_out->buffer_size;
-    unsigned long long int arraysize_local = arraysize_total / simulation_options_global->N_THREADS;
+    index_t arraysize_total = halofield_out->buffer_size;
+    index_t arraysize_local = arraysize_total / simulation_options_global->N_THREADS;
 
     LOG_DEBUG("Beginning stochastic halo sampling on %d ^3 grid", lo_dim[0]);
     LOG_DEBUG("z = %f, Mmin = %e, Mmax = %e,volume = %.3e, D = %.3e", redshift, Mmin, Mcell,
@@ -804,7 +804,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field,
 
         // PRIVATE VARIABLES
         int x, y, z, i;
-        unsigned long long int halo_idx, cell_idx;
+        index_t halo_idx, cell_idx;
         int threadnum = omp_get_thread_num();
 
         int nh_buf;
@@ -817,8 +817,8 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field,
         // buffer per cell
         float hm_buf[MAX_HALO_CELL];
 
-        unsigned long long int count = 0;
-        unsigned long long int istart = threadnum * arraysize_local;
+        index_t count = 0;
+        index_t istart = threadnum * arraysize_local;
         // debug total
         double M_tot_cell = 0.;
 
@@ -918,7 +918,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field,
         nhalo_threads[threadnum] = count;
     }
     if (any_thread_overflowed) {
-        unsigned long long int max_halos_per_thread = nhalo_threads[0];
+        index_t max_halos_per_thread = nhalo_threads[0];
         LOG_ERROR("Halo buffer overflow (allocated %llu halos per thread)", arraysize_local);
         for (int n_t = 0; n_t < simulation_options_global->N_THREADS; n_t++) {
             LOG_ERROR("Thread %d: %llu halos", n_t, nhalo_threads[n_t]);
@@ -964,12 +964,12 @@ int sample_halo_progenitors(gsl_rng **rng_arr, double z_in, double z_out, HaloCa
     double Mmin = hs_constants->M_min;
     double delta = hs_constants->delta;
 
-    unsigned long long int nhalo_in = halofield_in->n_halos;
-    unsigned long long int nhalo_threads[simulation_options_global->N_THREADS];
-    unsigned long long int istart_threads[simulation_options_global->N_THREADS];
+    index_t nhalo_in = halofield_in->n_halos;
+    index_t nhalo_threads[simulation_options_global->N_THREADS];
+    index_t istart_threads[simulation_options_global->N_THREADS];
 
-    unsigned long long int arraysize_total = halofield_out->buffer_size;
-    unsigned long long int arraysize_local = arraysize_total / simulation_options_global->N_THREADS;
+    index_t arraysize_total = halofield_out->buffer_size;
+    index_t arraysize_local = arraysize_total / simulation_options_global->N_THREADS;
 
     LOG_DEBUG("Beginning stochastic halo sampling of progenitors on %llu halos", nhalo_in);
     LOG_DEBUG("z = %f, Mmin = %e, d = %.3e", z_out, Mmin, delta);
@@ -996,9 +996,9 @@ int sample_halo_progenitors(gsl_rng **rng_arr, double z_in, double z_out, HaloCa
         int threadnum = omp_get_thread_num();
         double M2, R2, R1;
         int jj;
-        unsigned long long int ii;
-        unsigned long long int count = 0;
-        unsigned long long int istart = threadnum * arraysize_local;
+        index_t ii;
+        index_t count = 0;
+        index_t istart = threadnum * arraysize_local;
         double pos_prog[3], pos_desc[3];
 
         // we need a private version
@@ -1094,7 +1094,7 @@ int sample_halo_progenitors(gsl_rng **rng_arr, double z_in, double z_out, HaloCa
         nhalo_threads[threadnum] = count;
     }
     if (any_thread_overflowed) {
-        unsigned long long int max_halos_per_thread = nhalo_threads[0];
+        index_t max_halos_per_thread = nhalo_threads[0];
         LOG_ERROR("Halo buffer overflow (allocated %llu halos per thread)", arraysize_local);
         for (int n_t = 0; n_t < simulation_options_global->N_THREADS; n_t++) {
             LOG_ERROR("Thread %d: %llu halos", n_t, nhalo_threads[n_t]);
@@ -1124,9 +1124,8 @@ int sample_halo_progenitors(gsl_rng **rng_arr, double z_in, double z_out, HaloCa
 }
 
 // function that talks between the structures (Python objects) and the sampling functions
-int stochastic_halofield(unsigned long long int seed, float redshift_desc, float redshift,
-                         float *dens_field, float *halo_overlap_box, HaloCatalog *halos_desc,
-                         HaloCatalog *halos) {
+int stochastic_halofield(index_t seed, float redshift_desc, float redshift, float *dens_field,
+                         float *halo_overlap_box, HaloCatalog *halos_desc, HaloCatalog *halos) {
     if (redshift_desc > 0 && halos_desc->n_halos == 0) {
         LOG_DEBUG("No halos to sample from redshifts %.2f to %.2f, continuing...", redshift_desc,
                   redshift);
@@ -1135,7 +1134,7 @@ int stochastic_halofield(unsigned long long int seed, float redshift_desc, float
 
     // set up the rng
     gsl_rng *rng_stoc[simulation_options_global->N_THREADS];
-    unsigned long long int seed_fac = (unsigned long long int)(redshift * 1000);
+    index_t seed_fac = (index_t)(redshift * 1000);
     seed_rng_threads_fast(rng_stoc, seed + seed_fac);
 
     struct HaloSamplingConstants hs_constants;
@@ -1180,8 +1179,8 @@ int stochastic_halofield(unsigned long long int seed, float redshift_desc, float
 // This is a test function which takes a list of conditions (cells or halos) and samples them to
 // produce a descendant list
 //       as well as per-condition number and mass counts
-int single_test_sample(unsigned long long int seed, int n_condition, float *conditions,
-                       float *cond_crd, double z_out, double z_in, int *out_n_tot, int *out_n_cell,
+int single_test_sample(index_t seed, int n_condition, float *conditions, float *cond_crd,
+                       double z_out, double z_in, int *out_n_tot, int *out_n_cell,
                        double *out_n_exp, double *out_m_cell, double *out_m_exp,
                        float *out_halo_masses, float *out_halo_coords) {
     int status;
@@ -1215,7 +1214,7 @@ int single_test_sample(unsigned long long int seed, int n_condition, float *cond
         // halo catalogues + cell sums from multiple conditions, given M as cell descendant
         // halos/cells the result mapping is n_halo_total (1) (exp_n,exp_m,n_prog,m_prog) (n_desc)
         // M_cat (n_prog_total)
-        unsigned long long int n_halo_tot = 0;
+        index_t n_halo_tot = 0;
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS) private(i, j)
         {
             float out_hm[MAX_HALO_CELL];

--- a/src/py21cmfast/src/Stochasticity.c
+++ b/src/py21cmfast/src/Stochasticity.c
@@ -242,7 +242,7 @@ void set_prop_rng(gsl_rng *rng, bool from_catalog, double *interp, double *input
 }
 
 // This is the function called to assign halo properties to an entire catalogue, used for DexM halos
-int add_properties_cat(index_t seed, float redshift, HaloCatalog *halos) {
+int add_properties_cat(random_huge seed, float redshift, HaloCatalog *halos) {
     // set up the rng
     gsl_rng *rng_stoc[simulation_options_global->N_THREADS];
     seed_rng_threads_fast(rng_stoc, seed);
@@ -250,7 +250,7 @@ int add_properties_cat(index_t seed, float redshift, HaloCatalog *halos) {
     LOG_DEBUG("computing rng for %llu halos", halos->n_halos);
 
     // loop through the halos and assign properties
-    index_t i;
+    index_huge i;
     double buf[3];
     double dummy[3];  // we don't need interpolation here
 #pragma omp parallel for private(i, buf)
@@ -731,10 +731,10 @@ int stoc_sample(struct HaloSamplingConstants *hs_constants, gsl_rng *rng, int *n
 // Halo lists are partitioned per thread for sampling
 //   so have trailing zeros in each thread.
 //   This function condenses the array
-void condense_sparse_halolist(HaloCatalog *halofield, index_t *istart_threads,
-                              index_t *nhalo_threads) {
+void condense_sparse_halolist(HaloCatalog *halofield, index_huge *istart_threads,
+                              size_huge *nhalo_threads) {
     int i = 0;
-    index_t count_total = 0;
+    size_huge count_total = 0;
     for (i = 0; i < simulation_options_global->N_THREADS; i++) {
         memmove(&halofield->halo_masses[count_total], &halofield->halo_masses[istart_threads[i]],
                 sizeof(float) * nhalo_threads[i]);
@@ -779,12 +779,12 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field,
     double Mmin = hs_constants->M_min;
     double growthf = hs_constants->growth_out;
 
-    index_t nhalo_in = halofield_large->n_halos;
-    index_t nhalo_threads[simulation_options_global->N_THREADS];
-    index_t istart_threads[simulation_options_global->N_THREADS];
+    size_huge nhalo_in = halofield_large->n_halos;
+    size_huge nhalo_threads[simulation_options_global->N_THREADS];
+    index_huge istart_threads[simulation_options_global->N_THREADS];
 
-    index_t arraysize_total = halofield_out->buffer_size;
-    index_t arraysize_local = arraysize_total / simulation_options_global->N_THREADS;
+    size_huge arraysize_total = halofield_out->buffer_size;
+    size_huge arraysize_local = arraysize_total / simulation_options_global->N_THREADS;
 
     LOG_DEBUG("Beginning stochastic halo sampling on %d ^3 grid", lo_dim[0]);
     LOG_DEBUG("z = %f, Mmin = %e, Mmax = %e,volume = %.3e, D = %.3e", redshift, Mmin, Mcell,
@@ -804,7 +804,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field,
 
         // PRIVATE VARIABLES
         int x, y, z, i;
-        index_t halo_idx, cell_idx;
+        index_huge halo_idx, cell_idx;
         int threadnum = omp_get_thread_num();
 
         int nh_buf;
@@ -817,8 +817,8 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field,
         // buffer per cell
         float hm_buf[MAX_HALO_CELL];
 
-        index_t count = 0;
-        index_t istart = threadnum * arraysize_local;
+        size_huge count = 0;
+        index_huge istart = threadnum * arraysize_local;
         // debug total
         double M_tot_cell = 0.;
 
@@ -918,7 +918,7 @@ int sample_halo_grids(gsl_rng **rng_arr, double redshift, float *dens_field,
         nhalo_threads[threadnum] = count;
     }
     if (any_thread_overflowed) {
-        index_t max_halos_per_thread = nhalo_threads[0];
+        size_huge max_halos_per_thread = nhalo_threads[0];
         LOG_ERROR("Halo buffer overflow (allocated %llu halos per thread)", arraysize_local);
         for (int n_t = 0; n_t < simulation_options_global->N_THREADS; n_t++) {
             LOG_ERROR("Thread %d: %llu halos", n_t, nhalo_threads[n_t]);
@@ -964,12 +964,12 @@ int sample_halo_progenitors(gsl_rng **rng_arr, double z_in, double z_out, HaloCa
     double Mmin = hs_constants->M_min;
     double delta = hs_constants->delta;
 
-    index_t nhalo_in = halofield_in->n_halos;
-    index_t nhalo_threads[simulation_options_global->N_THREADS];
-    index_t istart_threads[simulation_options_global->N_THREADS];
+    size_huge nhalo_in = halofield_in->n_halos;
+    size_huge nhalo_threads[simulation_options_global->N_THREADS];
+    index_huge istart_threads[simulation_options_global->N_THREADS];
 
-    index_t arraysize_total = halofield_out->buffer_size;
-    index_t arraysize_local = arraysize_total / simulation_options_global->N_THREADS;
+    size_huge arraysize_total = halofield_out->buffer_size;
+    size_huge arraysize_local = arraysize_total / simulation_options_global->N_THREADS;
 
     LOG_DEBUG("Beginning stochastic halo sampling of progenitors on %llu halos", nhalo_in);
     LOG_DEBUG("z = %f, Mmin = %e, d = %.3e", z_out, Mmin, delta);
@@ -996,9 +996,9 @@ int sample_halo_progenitors(gsl_rng **rng_arr, double z_in, double z_out, HaloCa
         int threadnum = omp_get_thread_num();
         double M2, R2, R1;
         int jj;
-        index_t ii;
-        index_t count = 0;
-        index_t istart = threadnum * arraysize_local;
+        index_huge ii;
+        size_huge count = 0;
+        index_huge istart = threadnum * arraysize_local;
         double pos_prog[3], pos_desc[3];
 
         // we need a private version
@@ -1094,7 +1094,7 @@ int sample_halo_progenitors(gsl_rng **rng_arr, double z_in, double z_out, HaloCa
         nhalo_threads[threadnum] = count;
     }
     if (any_thread_overflowed) {
-        index_t max_halos_per_thread = nhalo_threads[0];
+        size_huge max_halos_per_thread = nhalo_threads[0];
         LOG_ERROR("Halo buffer overflow (allocated %llu halos per thread)", arraysize_local);
         for (int n_t = 0; n_t < simulation_options_global->N_THREADS; n_t++) {
             LOG_ERROR("Thread %d: %llu halos", n_t, nhalo_threads[n_t]);
@@ -1124,7 +1124,7 @@ int sample_halo_progenitors(gsl_rng **rng_arr, double z_in, double z_out, HaloCa
 }
 
 // function that talks between the structures (Python objects) and the sampling functions
-int stochastic_halofield(index_t seed, float redshift_desc, float redshift, float *dens_field,
+int stochastic_halofield(random_huge seed, float redshift_desc, float redshift, float *dens_field,
                          float *halo_overlap_box, HaloCatalog *halos_desc, HaloCatalog *halos) {
     if (redshift_desc > 0 && halos_desc->n_halos == 0) {
         LOG_DEBUG("No halos to sample from redshifts %.2f to %.2f, continuing...", redshift_desc,
@@ -1134,7 +1134,7 @@ int stochastic_halofield(index_t seed, float redshift_desc, float redshift, floa
 
     // set up the rng
     gsl_rng *rng_stoc[simulation_options_global->N_THREADS];
-    index_t seed_fac = (index_t)(redshift * 1000);
+    random_huge seed_fac = (random_huge)(redshift * 1000);
     seed_rng_threads_fast(rng_stoc, seed + seed_fac);
 
     struct HaloSamplingConstants hs_constants;
@@ -1179,7 +1179,7 @@ int stochastic_halofield(index_t seed, float redshift_desc, float redshift, floa
 // This is a test function which takes a list of conditions (cells or halos) and samples them to
 // produce a descendant list
 //       as well as per-condition number and mass counts
-int single_test_sample(index_t seed, int n_condition, float *conditions, float *cond_crd,
+int single_test_sample(random_huge seed, int n_condition, float *conditions, float *cond_crd,
                        double z_out, double z_in, int *out_n_tot, int *out_n_cell,
                        double *out_n_exp, double *out_m_cell, double *out_m_exp,
                        float *out_halo_masses, float *out_halo_coords) {
@@ -1214,7 +1214,7 @@ int single_test_sample(index_t seed, int n_condition, float *conditions, float *
         // halo catalogues + cell sums from multiple conditions, given M as cell descendant
         // halos/cells the result mapping is n_halo_total (1) (exp_n,exp_m,n_prog,m_prog) (n_desc)
         // M_cat (n_prog_total)
-        index_t n_halo_tot = 0;
+        size_huge n_halo_tot = 0;
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS) private(i, j)
         {
             float out_hm[MAX_HALO_CELL];

--- a/src/py21cmfast/src/Stochasticity.c
+++ b/src/py21cmfast/src/Stochasticity.c
@@ -1215,7 +1215,7 @@ int single_test_sample(unsigned long long int seed, int n_condition, float *cond
         // halo catalogues + cell sums from multiple conditions, given M as cell descendant
         // halos/cells the result mapping is n_halo_total (1) (exp_n,exp_m,n_prog,m_prog) (n_desc)
         // M_cat (n_prog_total)
-        int n_halo_tot = 0;
+        unsigned long long int n_halo_tot = 0;
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS) private(i, j)
         {
             float out_hm[MAX_HALO_CELL];
@@ -1279,7 +1279,7 @@ int single_test_sample(unsigned long long int seed, int n_condition, float *cond
         }
 
         out_n_tot[0] = n_halo_tot;
-        LOG_DEBUG("Found %d halos", n_halo_tot);
+        LOG_DEBUG("Found %llu halos", n_halo_tot);
 
         // get expected values from the saved mass range
         if (hs_constants->from_catalog) {

--- a/src/py21cmfast/src/Stochasticity.h
+++ b/src/py21cmfast/src/Stochasticity.h
@@ -40,10 +40,10 @@ struct HaloSamplingConstants {
     double expected_M;
 };
 
-int stochastic_halofield(index_t seed, float redshift_desc, float redshift, float *dens_field,
+int stochastic_halofield(random_huge seed, float redshift_desc, float redshift, float *dens_field,
                          float *halo_overlap_box, HaloCatalog *halos_desc, HaloCatalog *halos);
 
-int single_test_sample(index_t seed, int n_condition, float *conditions, float *cond_crd,
+int single_test_sample(random_huge seed, int n_condition, float *conditions, float *cond_crd,
                        double z_out, double z_in, int *out_n_tot, int *out_n_cell,
                        double *out_n_exp, double *out_m_cell, double *out_m_exp,
                        float *out_halo_masses, float *out_halo_coords);
@@ -53,7 +53,7 @@ int single_test_sample(index_t seed, int n_condition, float *conditions, float *
 double expected_nhalo(double redshift);
 
 // used in HaloCatalog.c to assign rng to DexM halos
-int add_properties_cat(index_t seed, float redshift, HaloCatalog *halos);
+int add_properties_cat(random_huge seed, float redshift, HaloCatalog *halos);
 
 void stoc_set_consts_z(struct HaloSamplingConstants *const_struct, double redshift,
                        double redshift_desc);

--- a/src/py21cmfast/src/Stochasticity.h
+++ b/src/py21cmfast/src/Stochasticity.h
@@ -3,6 +3,7 @@
 
 #include "InputParameters.h"
 #include "OutputStructs.h"
+#include "indexing.h"
 
 // parameters for the halo mass->stars calculations
 // Note: ideally I would split this into constants set per snapshot and
@@ -39,12 +40,11 @@ struct HaloSamplingConstants {
     double expected_M;
 };
 
-int stochastic_halofield(unsigned long long int seed, float redshift_desc, float redshift,
-                         float *dens_field, float *halo_overlap_box, HaloCatalog *halos_desc,
-                         HaloCatalog *halos);
+int stochastic_halofield(index_t seed, float redshift_desc, float redshift, float *dens_field,
+                         float *halo_overlap_box, HaloCatalog *halos_desc, HaloCatalog *halos);
 
-int single_test_sample(unsigned long long int seed, int n_condition, float *conditions,
-                       float *cond_crd, double z_out, double z_in, int *out_n_tot, int *out_n_cell,
+int single_test_sample(index_t seed, int n_condition, float *conditions, float *cond_crd,
+                       double z_out, double z_in, int *out_n_tot, int *out_n_cell,
                        double *out_n_exp, double *out_m_cell, double *out_m_exp,
                        float *out_halo_masses, float *out_halo_coords);
 
@@ -53,7 +53,7 @@ int single_test_sample(unsigned long long int seed, int n_condition, float *cond
 double expected_nhalo(double redshift);
 
 // used in HaloCatalog.c to assign rng to DexM halos
-int add_properties_cat(unsigned long long int seed, float redshift, HaloCatalog *halos);
+int add_properties_cat(index_t seed, float redshift, HaloCatalog *halos);
 
 void stoc_set_consts_z(struct HaloSamplingConstants *const_struct, double redshift,
                        double redshift_desc);

--- a/src/py21cmfast/src/_functionprototypes_wrapper.h
+++ b/src/py21cmfast/src/_functionprototypes_wrapper.h
@@ -3,7 +3,7 @@
     are visible to the python wrapper */
 
 /* OutputStruct COMPUTE FUNCTIONS */
-int ComputeInitialConditions(unsigned long long random_seed, InitialConditions *boxes);
+int ComputeInitialConditions(unsigned long long int random_seed, InitialConditions *boxes);
 
 int ComputePerturbedField(float redshift, InitialConditions *boxes,
                           PerturbedField *perturbed_field);

--- a/src/py21cmfast/src/_outputstructs_wrapper.h
+++ b/src/py21cmfast/src/_outputstructs_wrapper.h
@@ -16,8 +16,8 @@ typedef struct PerturbedField {
 } PerturbedField;
 
 typedef struct HaloCatalog {
-    long long unsigned int n_halos;
-    long long unsigned int buffer_size;
+    unsigned long long int n_halos;
+    unsigned long long int buffer_size;
     float *halo_masses;
     float *halo_coords;
 
@@ -28,8 +28,8 @@ typedef struct HaloCatalog {
 } HaloCatalog;
 
 typedef struct PerturbedHaloCatalog {
-    long long unsigned int n_halos;
-    long long unsigned int buffer_size;
+    unsigned long long int n_halos;
+    unsigned long long int buffer_size;
     float *halo_masses;
     float *halo_coords;
 

--- a/src/py21cmfast/src/bubble_helper_progs.c
+++ b/src/py21cmfast/src/bubble_helper_progs.c
@@ -343,7 +343,8 @@ void update_in_sphere(float *box, int dimensions, int dimensions_ncf, float R, f
     int x_curr, y_curr, z_curr, xb_min, xb_max, yb_min, yb_max, zb_min, zb_max, R_index;
     int xl_min, xl_max, yl_min, yl_max, zl_min, zl_max;
     float Rsq_curr_index;
-    int x, y, z, index;
+    int x, y, z;
+    unsigned long long int index;
 
     int index_arr[3];
     int box_dim[3] = {dimensions, dimensions, dimensions_ncf};

--- a/src/py21cmfast/src/bubble_helper_progs.c
+++ b/src/py21cmfast/src/bubble_helper_progs.c
@@ -267,7 +267,7 @@ void check_region(float *box, int dimensions, int dimensions_ncf, float Rsq_curr
 
     int index_arr[3];
     int box_dim[3] = {dimensions, dimensions, dimensions_ncf};
-    index_t index;
+    index_huge index;
     for (x_curr = x_min; x_curr <= x_max; x_curr++) {
         for (y_curr = y_min; y_curr <= y_max; y_curr++) {
             for (z_curr = z_min; z_curr <= z_max; z_curr++) {
@@ -344,7 +344,7 @@ void update_in_sphere(float *box, int dimensions, int dimensions_ncf, float R, f
     int xl_min, xl_max, yl_min, yl_max, zl_min, zl_max;
     float Rsq_curr_index;
     int x, y, z;
-    index_t index;
+    index_huge index;
 
     int index_arr[3];
     int box_dim[3] = {dimensions, dimensions, dimensions_ncf};

--- a/src/py21cmfast/src/bubble_helper_progs.c
+++ b/src/py21cmfast/src/bubble_helper_progs.c
@@ -267,7 +267,7 @@ void check_region(float *box, int dimensions, int dimensions_ncf, float Rsq_curr
 
     int index_arr[3];
     int box_dim[3] = {dimensions, dimensions, dimensions_ncf};
-    unsigned long long int index;
+    index_t index;
     for (x_curr = x_min; x_curr <= x_max; x_curr++) {
         for (y_curr = y_min; y_curr <= y_max; y_curr++) {
             for (z_curr = z_min; z_curr <= z_max; z_curr++) {
@@ -344,7 +344,7 @@ void update_in_sphere(float *box, int dimensions, int dimensions_ncf, float R, f
     int xl_min, xl_max, yl_min, yl_max, zl_min, zl_max;
     float Rsq_curr_index;
     int x, y, z;
-    unsigned long long int index;
+    index_t index;
 
     int index_arr[3];
     int box_dim[3] = {dimensions, dimensions, dimensions_ncf};

--- a/src/py21cmfast/src/debugging.c
+++ b/src/py21cmfast/src/debugging.c
@@ -190,7 +190,7 @@ void writeAstroOptions(AstroOptions *p) {
 }
 
 // Wrapper function to select appropriate indexing function based on layout
-static index_t get_corner_index(int x, int y, int z, int dim[3], GridLayout layout) {
+static index_huge get_corner_index(int x, int y, int z, int dim[3], GridLayout layout) {
     if (layout == FFTW_REAL_LAYOUT) {
         return grid_index_fftw_r(x, y, z, dim);
     } else if (layout == FFTW_COMPLEX_LAYOUT) {
@@ -218,7 +218,8 @@ static void compute_layout_dims(int size_x, int size_y, int size_z, GridLayout l
     }
 }
 
-void get_corner_indices(int size_x, int size_y, int size_z, GridLayout layout, index_t indices[8]) {
+void get_corner_indices(int size_x, int size_y, int size_z, GridLayout layout,
+                        index_huge indices[8]) {
     int original_z;
     int dim[3];
 
@@ -239,8 +240,8 @@ void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, GridLayou
                        char *indent) {
 #if LOG_LEVEL >= SUPER_DEBUG_LEVEL
     float corners[8];
-    index_t indices[8];
-    index_t idx;
+    index_huge indices[8];
+    index_huge idx;
 
     get_corner_indices(size_x, size_y, size_z, layout, indices);
     for (idx = 0; idx < 8; idx++) {
@@ -264,7 +265,7 @@ void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, GridLayou
 
     // Uniform loop using wrapper function
     int i, j, k;
-    index_t grid_idx;
+    index_huge grid_idx;
 
     for (i = 0; i < size_x; i++) {
         for (j = 0; j < size_y; j++) {
@@ -276,7 +277,7 @@ void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, GridLayou
             }
         }
     }
-    index_t tot_size = (index_t)size_x * size_y * original_z;
+    size_huge tot_size = (size_huge)size_x * size_y * original_z;
     mean = sum / tot_size;
 
     LOG_SUPER_DEBUG("%sSum/Mean/Min/Max: %.4e, %.4e, %.4e, %.4e", indent, sum, mean, mn, mx);
@@ -287,8 +288,8 @@ void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, Gr
                              char *indent) {
 #if LOG_LEVEL >= SUPER_DEBUG_LEVEL
     double corners[8];
-    index_t indices[8];
-    index_t idx;
+    index_huge indices[8];
+    index_huge idx;
 
     get_corner_indices(size_x, size_y, size_z, layout, indices);
     for (idx = 0; idx < 8; idx++) {
@@ -312,7 +313,7 @@ void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, Gr
 
     // Uniform loop using wrapper function
     int i, j, k;
-    index_t grid_idx;
+    index_huge grid_idx;
 
     for (i = 0; i < size_x; i++) {
         for (j = 0; j < size_y; j++) {
@@ -324,7 +325,7 @@ void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, Gr
             }
         }
     }
-    index_t tot_size = (index_t)size_x * size_y * original_z;
+    size_huge tot_size = (size_huge)size_x * size_y * original_z;
     mean = sum / tot_size;
 
     LOG_SUPER_DEBUG("%sSum/Mean/Min/Max: %.4e, %.4e, %.4e, %.4e", indent, sum, mean, mn, mx);
@@ -336,8 +337,8 @@ void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int si
 #if LOG_LEVEL >= SUPER_DEBUG_LEVEL
     float corners_real[8];
     float corners_imag[8];
-    index_t indices[8];
-    index_t idx;
+    index_huge indices[8];
+    index_huge idx;
 
     get_corner_indices(size_x, size_y, size_z, layout, indices);
     for (idx = 0; idx < 8; idx++) {
@@ -367,7 +368,7 @@ void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int si
 
     // Uniform loop using wrapper function
     int i, j, k;
-    index_t grid_idx;
+    index_huge grid_idx;
 
     for (i = 0; i < size_x; i++) {
         for (j = 0; j < size_y; j++) {
@@ -379,7 +380,7 @@ void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int si
             }
         }
     }
-    index_t tot_size = (index_t)size_x * size_y * original_z;
+    size_huge tot_size = (size_huge)size_x * size_y * original_z;
     mean = sum / tot_size;
 
     LOG_SUPER_DEBUG("%sSum/Mean/Min/Max: %.4e+%.4ei, %.4e+%.4ei, %.4e+%.4ei, %.4e+%.4ei", indent,

--- a/src/py21cmfast/src/debugging.c
+++ b/src/py21cmfast/src/debugging.c
@@ -190,7 +190,7 @@ void writeAstroOptions(AstroOptions *p) {
 }
 
 // Wrapper function to select appropriate indexing function based on layout
-static unsigned long long get_corner_index(int x, int y, int z, int dim[3], GridLayout layout) {
+static index_t get_corner_index(int x, int y, int z, int dim[3], GridLayout layout) {
     if (layout == FFTW_REAL_LAYOUT) {
         return grid_index_fftw_r(x, y, z, dim);
     } else if (layout == FFTW_COMPLEX_LAYOUT) {
@@ -218,8 +218,7 @@ static void compute_layout_dims(int size_x, int size_y, int size_z, GridLayout l
     }
 }
 
-void get_corner_indices(int size_x, int size_y, int size_z, GridLayout layout,
-                        unsigned long long indices[8]) {
+void get_corner_indices(int size_x, int size_y, int size_z, GridLayout layout, index_t indices[8]) {
     int original_z;
     int dim[3];
 
@@ -240,8 +239,8 @@ void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, GridLayou
                        char *indent) {
 #if LOG_LEVEL >= SUPER_DEBUG_LEVEL
     float corners[8];
-    unsigned long long indices[8];
-    unsigned long long idx;
+    index_t indices[8];
+    index_t idx;
 
     get_corner_indices(size_x, size_y, size_z, layout, indices);
     for (idx = 0; idx < 8; idx++) {
@@ -265,7 +264,7 @@ void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, GridLayou
 
     // Uniform loop using wrapper function
     int i, j, k;
-    unsigned long long grid_idx;
+    index_t grid_idx;
 
     for (i = 0; i < size_x; i++) {
         for (j = 0; j < size_y; j++) {
@@ -277,7 +276,7 @@ void debugSummarizeBox(float *box, int size_x, int size_y, int size_z, GridLayou
             }
         }
     }
-    unsigned long long tot_size = (unsigned long long)size_x * size_y * original_z;
+    index_t tot_size = (index_t)size_x * size_y * original_z;
     mean = sum / tot_size;
 
     LOG_SUPER_DEBUG("%sSum/Mean/Min/Max: %.4e, %.4e, %.4e, %.4e", indent, sum, mean, mn, mx);
@@ -288,8 +287,8 @@ void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, Gr
                              char *indent) {
 #if LOG_LEVEL >= SUPER_DEBUG_LEVEL
     double corners[8];
-    unsigned long long indices[8];
-    unsigned long long idx;
+    index_t indices[8];
+    index_t idx;
 
     get_corner_indices(size_x, size_y, size_z, layout, indices);
     for (idx = 0; idx < 8; idx++) {
@@ -313,7 +312,7 @@ void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, Gr
 
     // Uniform loop using wrapper function
     int i, j, k;
-    unsigned long long grid_idx;
+    index_t grid_idx;
 
     for (i = 0; i < size_x; i++) {
         for (j = 0; j < size_y; j++) {
@@ -325,7 +324,7 @@ void debugSummarizeBoxDouble(double *box, int size_x, int size_y, int size_z, Gr
             }
         }
     }
-    unsigned long long tot_size = (unsigned long long)size_x * size_y * original_z;
+    index_t tot_size = (index_t)size_x * size_y * original_z;
     mean = sum / tot_size;
 
     LOG_SUPER_DEBUG("%sSum/Mean/Min/Max: %.4e, %.4e, %.4e, %.4e", indent, sum, mean, mn, mx);
@@ -337,8 +336,8 @@ void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int si
 #if LOG_LEVEL >= SUPER_DEBUG_LEVEL
     float corners_real[8];
     float corners_imag[8];
-    unsigned long long indices[8];
-    unsigned long long idx;
+    index_t indices[8];
+    index_t idx;
 
     get_corner_indices(size_x, size_y, size_z, layout, indices);
     for (idx = 0; idx < 8; idx++) {
@@ -368,7 +367,7 @@ void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int si
 
     // Uniform loop using wrapper function
     int i, j, k;
-    unsigned long long grid_idx;
+    index_t grid_idx;
 
     for (i = 0; i < size_x; i++) {
         for (j = 0; j < size_y; j++) {
@@ -380,7 +379,7 @@ void debugSummarizeBoxComplex(fftwf_complex *box, int size_x, int size_y, int si
             }
         }
     }
-    unsigned long long tot_size = (unsigned long long)size_x * size_y * original_z;
+    index_t tot_size = (index_t)size_x * size_y * original_z;
     mean = sum / tot_size;
 
     LOG_SUPER_DEBUG("%sSum/Mean/Min/Max: %.4e+%.4ei, %.4e+%.4ei, %.4e+%.4ei, %.4e+%.4ei", indent,

--- a/src/py21cmfast/src/filtering.c
+++ b/src/py21cmfast/src/filtering.c
@@ -133,7 +133,7 @@ void filter_box(fftwf_complex *box, int box_dim[3], int filter_type, float R, fl
     {
         int n_x, n_z, n_y;
         float k_x, k_y, k_z, k_mag_sq, kR;
-        unsigned long long int grid_index;
+        index_t grid_index;
 #pragma omp for
         for (n_x = 0; n_x < box_dim[0]; n_x++) {
             if (n_x > (box_dim[0] / 2)) {
@@ -197,7 +197,7 @@ void filter_box(fftwf_complex *box, int box_dim[3], int filter_type, float R, fl
 // Test function to filter a box without computing a whole output box
 int test_filter(float *input_box, double R, double R_param, int filter_flag, double *result) {
     int i, j, k;
-    unsigned long long int ii, jj;
+    index_t ii, jj;
     int box_dim[3] = {
         simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
         simulation_options_global->NON_CUBIC_FACTOR * simulation_options_global->HII_DIM};

--- a/src/py21cmfast/src/filtering.c
+++ b/src/py21cmfast/src/filtering.c
@@ -133,7 +133,7 @@ void filter_box(fftwf_complex *box, int box_dim[3], int filter_type, float R, fl
     {
         int n_x, n_z, n_y;
         float k_x, k_y, k_z, k_mag_sq, kR;
-        index_t grid_index;
+        index_huge grid_index;
 #pragma omp for
         for (n_x = 0; n_x < box_dim[0]; n_x++) {
             if (n_x > (box_dim[0] / 2)) {
@@ -197,7 +197,7 @@ void filter_box(fftwf_complex *box, int box_dim[3], int filter_type, float R, fl
 // Test function to filter a box without computing a whole output box
 int test_filter(float *input_box, double R, double R_param, int filter_flag, double *result) {
     int i, j, k;
-    index_t ii, jj;
+    index_huge ii, jj;
     int box_dim[3] = {
         simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
         simulation_options_global->NON_CUBIC_FACTOR * simulation_options_global->HII_DIM};

--- a/src/py21cmfast/src/filtering.c
+++ b/src/py21cmfast/src/filtering.c
@@ -133,7 +133,7 @@ void filter_box(fftwf_complex *box, int box_dim[3], int filter_type, float R, fl
     {
         int n_x, n_z, n_y;
         float k_x, k_y, k_z, k_mag_sq, kR;
-        unsigned long long grid_index;
+        unsigned long long int grid_index;
 #pragma omp for
         for (n_x = 0; n_x < box_dim[0]; n_x++) {
             if (n_x > (box_dim[0] / 2)) {

--- a/src/py21cmfast/src/indexing.h
+++ b/src/py21cmfast/src/indexing.h
@@ -24,7 +24,9 @@
 #ifndef _INDEXING_H
 #define _INDEXING_H
 
-typedef unsigned long long int index_t;
+typedef unsigned long long int index_huge;
+typedef unsigned long long int size_huge;
+typedef unsigned long long int random_huge;
 
 #include <gsl/gsl_rng.h>
 #include <math.h>
@@ -44,36 +46,34 @@ typedef unsigned long long int index_t;
 // -------------------------------------------------------------------------------------
 // Convenience Macros for hi-resolution boxes
 // -------------------------------------------------------------------------------------
-#define D_PARA                                              \
-    (index_t)(simulation_options_global->NON_CUBIC_FACTOR * \
-              simulation_options_global->DIM)  // the long long dimension
-#define TOT_NUM_PIXELS                                                          \
-    ((index_t)simulation_options_global->DIM * simulation_options_global->DIM * \
+#define D_PARA (int)(simulation_options_global->NON_CUBIC_FACTOR * simulation_options_global->DIM)
+#define TOT_NUM_PIXELS                                                            \
+    ((size_huge)simulation_options_global->DIM * simulation_options_global->DIM * \
      D_PARA)  // no padding
 
 // Fourier-Transform numbers
-#define TOT_FFT_NUM_PIXELS                                                             \
-    ((index_t)simulation_options_global->DIM * simulation_options_global->DIM * 2llu * \
-     (D_PARA / 2 + 1llu))
+#define TOT_FFT_NUM_PIXELS                                                            \
+    ((size_huge)simulation_options_global->DIM * simulation_options_global->DIM * 2 * \
+     (D_PARA / 2 + 1))
 #define KSPACE_NUM_PIXELS \
-    ((index_t)simulation_options_global->DIM * simulation_options_global->DIM * (D_PARA / 2 + 1llu))
+    ((size_huge)simulation_options_global->DIM * simulation_options_global->DIM * (D_PARA / 2 + 1))
 
 // -------------------------------------------------------------------------------------
 // Convenience Macros for low-resolution boxes
 // -------------------------------------------------------------------------------------
 #define HII_D_PARA \
-    (index_t)(simulation_options_global->NON_CUBIC_FACTOR * simulation_options_global->HII_DIM)
-#define HII_TOT_NUM_PIXELS                                                                       \
-    (index_t)((index_t)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * \
-              HII_D_PARA)
+    (int)(simulation_options_global->NON_CUBIC_FACTOR * simulation_options_global->HII_DIM)
+#define HII_TOT_NUM_PIXELS                                                                \
+    ((size_huge)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * \
+     HII_D_PARA)
 
 // Fourier-Transform numbers
-#define HII_TOT_FFT_NUM_PIXELS                                                                 \
-    ((index_t)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * 2llu * \
-     (HII_D_PARA / 2 + 1llu))
-#define HII_KSPACE_NUM_PIXELS                                                           \
-    ((index_t)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * \
-     (HII_D_PARA / 2 + 1llu))
+#define HII_TOT_FFT_NUM_PIXELS                                                                \
+    ((size_huge)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * 2 * \
+     (HII_D_PARA / 2 + 1))
+#define HII_KSPACE_NUM_PIXELS                                                             \
+    ((size_huge)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * \
+     (HII_D_PARA / 2 + 1))
 
 void wrap_position(double pos[3], double size[3]);
 void wrap_coord(int idx[3], int size[3]);
@@ -81,20 +81,20 @@ void random_point_in_sphere(double centre[3], double radius, gsl_rng *rng, doubl
 void random_point_in_cell(int idx[3], double cell_len, gsl_rng *rng, double *point);
 
 // Indexing a 3D array stored in a 1D array
-inline index_t grid_index_general(int x, int y, int z, int dim[3]) {
-    return (z) + (dim[2] + 0llu) * (y + (dim[1] + 0llu) * x);
+inline index_huge grid_index_general(int x, int y, int z, int dim[3]) {
+    return (index_huge)z + dim[2] * ((index_huge)y + dim[1] * (index_huge)x);
 }
 
 // Indexing a 3D array stored in a 1D array, where the 3D array is the real-space
 // representation of a Fourier Transform (with padding on the last axis)
-inline index_t grid_index_fftw_r(int x, int y, int z, int dim[3]) {
-    return (z) + 2llu * (dim[2] / 2 + 1llu) * (y + (dim[1] + 0llu) * x);
+inline index_huge grid_index_fftw_r(int x, int y, int z, int dim[3]) {
+    return (index_huge)z + 2 * (dim[2] / 2 + 1) * ((index_huge)y + dim[1] * (index_huge)x);
 }
 
 // Indexing a 3D array stored in a 1D array, where the 3D array is the complex-space
 // representation of a Fourier Transform (with padding on the last axis)
-inline index_t grid_index_fftw_c(int x, int y, int z, int dim[3]) {
-    return (z) + (dim[2] / 2 + 1llu) * (y + (dim[1] + 0llu) * x);
+inline index_huge grid_index_fftw_c(int x, int y, int z, int dim[3]) {
+    return (index_huge)z + (dim[2] / 2 + 1) * ((index_huge)y + dim[1] * (index_huge)x);
 }
 
 // Convert a position on [0,BOX_LEN] to an index for a particular cell size.

--- a/src/py21cmfast/src/indexing.h
+++ b/src/py21cmfast/src/indexing.h
@@ -21,6 +21,11 @@
         to do the FFT, the extra spaces don't actually get used, and the indexing
         macros (eg. R_FFT_INDEX) skip these extra bits to index the truly used array.
 */
+#ifndef _INDEXING_H
+#define _INDEXING_H
+
+typedef unsigned long long int index_t;
+
 #include <gsl/gsl_rng.h>
 #include <math.h>
 
@@ -39,37 +44,35 @@
 // -------------------------------------------------------------------------------------
 // Convenience Macros for hi-resolution boxes
 // -------------------------------------------------------------------------------------
-#define D_PARA                                                         \
-    (unsigned long long)(simulation_options_global->NON_CUBIC_FACTOR * \
-                         simulation_options_global->DIM)  // the long long dimension
-#define TOT_NUM_PIXELS                                                                     \
-    ((unsigned long long)simulation_options_global->DIM * simulation_options_global->DIM * \
+#define D_PARA                                              \
+    (index_t)(simulation_options_global->NON_CUBIC_FACTOR * \
+              simulation_options_global->DIM)  // the long long dimension
+#define TOT_NUM_PIXELS                                                          \
+    ((index_t)simulation_options_global->DIM * simulation_options_global->DIM * \
      D_PARA)  // no padding
 
 // Fourier-Transform numbers
-#define TOT_FFT_NUM_PIXELS                                                                        \
-    ((unsigned long long)simulation_options_global->DIM * simulation_options_global->DIM * 2llu * \
+#define TOT_FFT_NUM_PIXELS                                                             \
+    ((index_t)simulation_options_global->DIM * simulation_options_global->DIM * 2llu * \
      (D_PARA / 2 + 1llu))
-#define KSPACE_NUM_PIXELS                                                                  \
-    ((unsigned long long)simulation_options_global->DIM * simulation_options_global->DIM * \
-     (D_PARA / 2 + 1llu))
+#define KSPACE_NUM_PIXELS \
+    ((index_t)simulation_options_global->DIM * simulation_options_global->DIM * (D_PARA / 2 + 1llu))
 
 // -------------------------------------------------------------------------------------
 // Convenience Macros for low-resolution boxes
 // -------------------------------------------------------------------------------------
-#define HII_D_PARA                                                     \
-    (unsigned long long)(simulation_options_global->NON_CUBIC_FACTOR * \
-                         simulation_options_global->HII_DIM)
-#define HII_TOT_NUM_PIXELS                                                        \
-    (unsigned long long)((unsigned long long)simulation_options_global->HII_DIM * \
-                         simulation_options_global->HII_DIM * HII_D_PARA)
+#define HII_D_PARA \
+    (index_t)(simulation_options_global->NON_CUBIC_FACTOR * simulation_options_global->HII_DIM)
+#define HII_TOT_NUM_PIXELS                                                                       \
+    (index_t)((index_t)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * \
+              HII_D_PARA)
 
 // Fourier-Transform numbers
-#define HII_TOT_FFT_NUM_PIXELS                                                                     \
-    ((unsigned long long)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * \
-     2llu * (HII_D_PARA / 2 + 1llu))
-#define HII_KSPACE_NUM_PIXELS                                                                      \
-    ((unsigned long long)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * \
+#define HII_TOT_FFT_NUM_PIXELS                                                                 \
+    ((index_t)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * 2llu * \
+     (HII_D_PARA / 2 + 1llu))
+#define HII_KSPACE_NUM_PIXELS                                                           \
+    ((index_t)simulation_options_global->HII_DIM * simulation_options_global->HII_DIM * \
      (HII_D_PARA / 2 + 1llu))
 
 void wrap_position(double pos[3], double size[3]);
@@ -78,19 +81,19 @@ void random_point_in_sphere(double centre[3], double radius, gsl_rng *rng, doubl
 void random_point_in_cell(int idx[3], double cell_len, gsl_rng *rng, double *point);
 
 // Indexing a 3D array stored in a 1D array
-inline unsigned long long grid_index_general(int x, int y, int z, int dim[3]) {
+inline index_t grid_index_general(int x, int y, int z, int dim[3]) {
     return (z) + (dim[2] + 0llu) * (y + (dim[1] + 0llu) * x);
 }
 
 // Indexing a 3D array stored in a 1D array, where the 3D array is the real-space
 // representation of a Fourier Transform (with padding on the last axis)
-inline unsigned long long grid_index_fftw_r(int x, int y, int z, int dim[3]) {
+inline index_t grid_index_fftw_r(int x, int y, int z, int dim[3]) {
     return (z) + 2llu * (dim[2] / 2 + 1llu) * (y + (dim[1] + 0llu) * x);
 }
 
 // Indexing a 3D array stored in a 1D array, where the 3D array is the complex-space
 // representation of a Fourier Transform (with padding on the last axis)
-inline unsigned long long grid_index_fftw_c(int x, int y, int z, int dim[3]) {
+inline index_t grid_index_fftw_c(int x, int y, int z, int dim[3]) {
     return (z) + (dim[2] / 2 + 1llu) * (y + (dim[1] + 0llu) * x);
 }
 
@@ -115,3 +118,5 @@ inline double index_to_k(int idx, double len, int dim) {
     double buf = (idx <= dim / 2) ? idx : (idx - dim);
     return buf * 2. * M_PI / len;
 }
+
+#endif

--- a/src/py21cmfast/src/map_mass.c
+++ b/src/py21cmfast/src/map_mass.c
@@ -224,8 +224,8 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
     double box_size[3] = {boxlen, boxlen, boxlen_z};
     double dim_ratio_vel = (double)vel_dim[0] / (double)dens_dim[0];
     double dim_ratio_out = (double)out_dim[0] / (double)dens_dim[0];
-    double vol_ratio_out = (double)(out_dim[0] * out_dim[1] * out_dim[2]) /
-                           (double)(dens_dim[0] * dens_dim[1] * dens_dim[2]);
+    double vol_ratio_out = ((double)out_dim[0] * out_dim[1] * out_dim[2]) /
+                           ((double)dens_dim[0] * dens_dim[1] * dens_dim[2]);
 
     double prefactor_mass = RHOcrit * cosmo_params_global->OMm * vol_ratio_out;
     double prefactor_stars = RHOcrit * cosmo_params_global->OMb * consts->fstar_10 * vol_ratio_out;
@@ -340,7 +340,7 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
     // Without stochasticity, these grids are the same to a constant
     double prefactor_wsfr = 1 / consts->t_h / consts->t_star;
     if (astro_options_global->INHOMO_RECO) {
-        for (int i = 0; i < HII_TOT_NUM_PIXELS; i++) {
+        for (unsigned long long int i = 0; i < HII_TOT_NUM_PIXELS; i++) {
             boxes->whalo_sfr[i] = boxes->n_ion[i] * prefactor_wsfr;
         }
     }

--- a/src/py21cmfast/src/map_mass.c
+++ b/src/py21cmfast/src/map_mass.c
@@ -177,7 +177,7 @@ void move_grid_masses(double redshift, float *dens_pointer, int dens_dim[3], flo
         int i, j, k, axis;
         double pos[3], curr_dens;
         int ipos[3];
-        unsigned long long vel_index, dens_index;
+        unsigned long long int vel_index, dens_index;
 #pragma omp for
         for (i = 0; i < dens_dim[0]; i++) {
             for (j = 0; j < dens_dim[1]; j++) {
@@ -259,7 +259,7 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
         int i, j, k, axis;
         double pos[3], curr_dens;
         int ipos[3];
-        unsigned long long vel_index, dens_index, mturn_index;
+        unsigned long long int vel_index, dens_index, mturn_index;
         double l10_mturn_a = log10(consts->mturn_a_nofb);
         double l10_mturn_m = log10(consts->mturn_m_nofb);
         HaloProperties properties;
@@ -372,10 +372,10 @@ void move_halo_galprops(double redshift, HaloCatalog *halos, float *vel_pointers
         displacement_factor_2LPT - init_displacement_factor_2LPT;
 #pragma omp parallel num_threads(simulation_options_global->N_THREADS)
     {
-        int i, axis;
+        int axis;
         double pos[3];
         int ipos[3];
-        unsigned long long vel_index;
+        unsigned long long int i, vel_index;
         HaloProperties properties;
         double M_turn_a = consts->mturn_a_nofb;
         double M_turn_m = consts->mturn_m_nofb;

--- a/src/py21cmfast/src/map_mass.c
+++ b/src/py21cmfast/src/map_mass.c
@@ -35,15 +35,14 @@ static inline void do_cic_interpolation_double(double *resampled_box, double pos
     wrap_coord(ipos, box_dim);
     wrap_coord(iposp1, box_dim);
 
-    unsigned long long int cic_indices[8] = {
-        grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
-        grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
-        grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
-        grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
-        grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
-        grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
-        grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
-        grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
+    index_t cic_indices[8] = {grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
+                              grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
+                              grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
+                              grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
+                              grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
+                              grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
+                              grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
+                              grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
 
     double cic_weights[8] = {(1. - dist[0]) * (1. - dist[1]) * (1. - dist[2]),
                              dist[0] * (1. - dist[1]) * (1. - dist[2]),
@@ -76,15 +75,14 @@ static inline void do_cic_interpolation_float(float *resampled_box, double pos[3
     wrap_coord(ipos, box_dim);
     wrap_coord(iposp1, box_dim);
 
-    unsigned long long int cic_indices[8] = {
-        grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
-        grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
-        grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
-        grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
-        grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
-        grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
-        grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
-        grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
+    index_t cic_indices[8] = {grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
+                              grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
+                              grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
+                              grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
+                              grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
+                              grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
+                              grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
+                              grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
 
     double cic_weights[8] = {(1. - dist[0]) * (1. - dist[1]) * (1. - dist[2]),
                              dist[0] * (1. - dist[1]) * (1. - dist[2]),
@@ -116,15 +114,14 @@ static inline double cic_read_float(float *box, double pos[3], int box_dim[3]) {
     wrap_coord(ipos, box_dim);
     wrap_coord(iposp1, box_dim);
 
-    unsigned long long int cic_indices[8] = {
-        grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
-        grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
-        grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
-        grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
-        grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
-        grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
-        grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
-        grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
+    index_t cic_indices[8] = {grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
+                              grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
+                              grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
+                              grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
+                              grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
+                              grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
+                              grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
+                              grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
 
     double cic_weights[8] = {(1. - dist[0]) * (1. - dist[1]) * (1. - dist[2]),
                              dist[0] * (1. - dist[1]) * (1. - dist[2]),
@@ -177,7 +174,7 @@ void move_grid_masses(double redshift, float *dens_pointer, int dens_dim[3], flo
         int i, j, k, axis;
         double pos[3], curr_dens;
         int ipos[3];
-        unsigned long long int vel_index, dens_index;
+        index_t vel_index, dens_index;
 #pragma omp for
         for (i = 0; i < dens_dim[0]; i++) {
             for (j = 0; j < dens_dim[1]; j++) {
@@ -224,8 +221,8 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
     double box_size[3] = {boxlen, boxlen, boxlen_z};
     double dim_ratio_vel = (double)vel_dim[0] / (double)dens_dim[0];
     double dim_ratio_out = (double)out_dim[0] / (double)dens_dim[0];
-    double vol_ratio_out = ((double)out_dim[0] * out_dim[1] * out_dim[2]) /
-                           ((double)dens_dim[0] * dens_dim[1] * dens_dim[2]);
+    double vol_ratio_out = ((double)out_dim[0] * (double)out_dim[1] * (double)out_dim[2]) /
+                           ((double)dens_dim[0] * (double)dens_dim[1] * (double)dens_dim[2]);
 
     double prefactor_mass = RHOcrit * cosmo_params_global->OMm * vol_ratio_out;
     double prefactor_stars = RHOcrit * cosmo_params_global->OMb * consts->fstar_10 * vol_ratio_out;
@@ -259,7 +256,7 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
         int i, j, k, axis;
         double pos[3], curr_dens;
         int ipos[3];
-        unsigned long long int vel_index, dens_index, mturn_index;
+        index_t vel_index, dens_index, mturn_index;
         double l10_mturn_a = log10(consts->mturn_a_nofb);
         double l10_mturn_m = log10(consts->mturn_m_nofb);
         HaloProperties properties;
@@ -340,7 +337,7 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
     // Without stochasticity, these grids are the same to a constant
     double prefactor_wsfr = 1 / consts->t_h / consts->t_star;
     if (astro_options_global->INHOMO_RECO) {
-        for (unsigned long long int i = 0; i < HII_TOT_NUM_PIXELS; i++) {
+        for (index_t i = 0; i < HII_TOT_NUM_PIXELS; i++) {
             boxes->whalo_sfr[i] = boxes->n_ion[i] * prefactor_wsfr;
         }
     }
@@ -375,7 +372,7 @@ void move_halo_galprops(double redshift, HaloCatalog *halos, float *vel_pointers
         int axis;
         double pos[3];
         int ipos[3];
-        unsigned long long int i, vel_index;
+        index_t i, vel_index;
         HaloProperties properties;
         double M_turn_a = consts->mturn_a_nofb;
         double M_turn_m = consts->mturn_m_nofb;
@@ -455,7 +452,7 @@ void move_halo_galprops(double redshift, HaloCatalog *halos, float *vel_pointers
 #endif
         }
 #pragma omp for
-        for (unsigned long long int i_cell = 0; i_cell < HII_TOT_NUM_PIXELS; i_cell++) {
+        for (index_t i_cell = 0; i_cell < HII_TOT_NUM_PIXELS; i_cell++) {
             boxes->n_ion[i_cell] *= cell_vol_inv;
             boxes->halo_sfr[i_cell] *= cell_vol_inv;
             if (astro_options_global->USE_TS_FLUCT) {

--- a/src/py21cmfast/src/map_mass.c
+++ b/src/py21cmfast/src/map_mass.c
@@ -35,14 +35,14 @@ static inline void do_cic_interpolation_double(double *resampled_box, double pos
     wrap_coord(ipos, box_dim);
     wrap_coord(iposp1, box_dim);
 
-    index_t cic_indices[8] = {grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
-                              grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
-                              grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
-                              grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
-                              grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
-                              grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
-                              grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
-                              grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
+    index_huge cic_indices[8] = {grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
+                                 grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
+                                 grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
+                                 grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
+                                 grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
+                                 grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
+                                 grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
+                                 grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
 
     double cic_weights[8] = {(1. - dist[0]) * (1. - dist[1]) * (1. - dist[2]),
                              dist[0] * (1. - dist[1]) * (1. - dist[2]),
@@ -75,14 +75,14 @@ static inline void do_cic_interpolation_float(float *resampled_box, double pos[3
     wrap_coord(ipos, box_dim);
     wrap_coord(iposp1, box_dim);
 
-    index_t cic_indices[8] = {grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
-                              grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
-                              grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
-                              grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
-                              grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
-                              grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
-                              grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
-                              grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
+    index_huge cic_indices[8] = {grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
+                                 grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
+                                 grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
+                                 grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
+                                 grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
+                                 grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
+                                 grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
+                                 grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
 
     double cic_weights[8] = {(1. - dist[0]) * (1. - dist[1]) * (1. - dist[2]),
                              dist[0] * (1. - dist[1]) * (1. - dist[2]),
@@ -114,14 +114,14 @@ static inline double cic_read_float(float *box, double pos[3], int box_dim[3]) {
     wrap_coord(ipos, box_dim);
     wrap_coord(iposp1, box_dim);
 
-    index_t cic_indices[8] = {grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
-                              grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
-                              grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
-                              grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
-                              grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
-                              grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
-                              grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
-                              grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
+    index_huge cic_indices[8] = {grid_index_general(ipos[0], ipos[1], ipos[2], box_dim),
+                                 grid_index_general(iposp1[0], ipos[1], ipos[2], box_dim),
+                                 grid_index_general(ipos[0], iposp1[1], ipos[2], box_dim),
+                                 grid_index_general(iposp1[0], iposp1[1], ipos[2], box_dim),
+                                 grid_index_general(ipos[0], ipos[1], iposp1[2], box_dim),
+                                 grid_index_general(iposp1[0], ipos[1], iposp1[2], box_dim),
+                                 grid_index_general(ipos[0], iposp1[1], iposp1[2], box_dim),
+                                 grid_index_general(iposp1[0], iposp1[1], iposp1[2], box_dim)};
 
     double cic_weights[8] = {(1. - dist[0]) * (1. - dist[1]) * (1. - dist[2]),
                              dist[0] * (1. - dist[1]) * (1. - dist[2]),
@@ -174,7 +174,7 @@ void move_grid_masses(double redshift, float *dens_pointer, int dens_dim[3], flo
         int i, j, k, axis;
         double pos[3], curr_dens;
         int ipos[3];
-        index_t vel_index, dens_index;
+        index_huge vel_index, dens_index;
 #pragma omp for
         for (i = 0; i < dens_dim[0]; i++) {
             for (j = 0; j < dens_dim[1]; j++) {
@@ -256,7 +256,7 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
         int i, j, k, axis;
         double pos[3], curr_dens;
         int ipos[3];
-        index_t vel_index, dens_index, mturn_index;
+        index_huge vel_index, dens_index, mturn_index;
         double l10_mturn_a = log10(consts->mturn_a_nofb);
         double l10_mturn_m = log10(consts->mturn_m_nofb);
         HaloProperties properties;
@@ -337,7 +337,7 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
     // Without stochasticity, these grids are the same to a constant
     double prefactor_wsfr = 1 / consts->t_h / consts->t_star;
     if (astro_options_global->INHOMO_RECO) {
-        for (index_t i = 0; i < HII_TOT_NUM_PIXELS; i++) {
+        for (index_huge i = 0; i < HII_TOT_NUM_PIXELS; i++) {
             boxes->whalo_sfr[i] = boxes->n_ion[i] * prefactor_wsfr;
         }
     }
@@ -372,7 +372,7 @@ void move_halo_galprops(double redshift, HaloCatalog *halos, float *vel_pointers
         int axis;
         double pos[3];
         int ipos[3];
-        index_t i, vel_index;
+        index_huge i, vel_index;
         HaloProperties properties;
         double M_turn_a = consts->mturn_a_nofb;
         double M_turn_m = consts->mturn_m_nofb;
@@ -452,7 +452,7 @@ void move_halo_galprops(double redshift, HaloCatalog *halos, float *vel_pointers
 #endif
         }
 #pragma omp for
-        for (index_t i_cell = 0; i_cell < HII_TOT_NUM_PIXELS; i_cell++) {
+        for (index_huge i_cell = 0; i_cell < HII_TOT_NUM_PIXELS; i_cell++) {
             boxes->n_ion[i_cell] *= cell_vol_inv;
             boxes->halo_sfr[i_cell] *= cell_vol_inv;
             if (astro_options_global->USE_TS_FLUCT) {

--- a/src/py21cmfast/src/rng.c
+++ b/src/py21cmfast/src/rng.c
@@ -28,7 +28,7 @@
 //   used as a seed with a looping list of 5 different gsl initialisers.
 //   In order to keep consistency with master I'm leaving it as is for now, but I really want to
 //   understand why it was done this way.
-void seed_rng_threads(gsl_rng *rng_arr[], index_t seed) {
+void seed_rng_threads(gsl_rng *rng_arr[], random_huge seed) {
     // An RNG for generating seeds for multithreading
     gsl_rng *rseed = gsl_rng_alloc(gsl_rng_mt19937);
 
@@ -101,7 +101,7 @@ bool array_unique(unsigned int array[], int array_size) {
 }
 
 // Samples a number of integers, repeating the samples if any repeat
-void sample_n_unique_integers(unsigned int n, index_t seed, unsigned int array[]) {
+void sample_n_unique_integers(unsigned int n, random_huge seed, unsigned int array[]) {
     // An RNG for generating seeds for multithreading
     gsl_rng *rseed = gsl_rng_alloc(gsl_rng_mt19937);
     gsl_rng_set(rseed, seed);
@@ -124,7 +124,7 @@ void sample_n_unique_integers(unsigned int n, index_t seed, unsigned int array[]
 //   as well as be applied to different cells/halos, so I can't forsee any issues.
 // Just in case I'm not using it for the initial conditions, which is okay since the slower version
 // is only used once
-void seed_rng_threads_fast(gsl_rng *rng_arr[], index_t seed) {
+void seed_rng_threads_fast(gsl_rng *rng_arr[], random_huge seed) {
     unsigned int seed_thread;
     unsigned int st_arr[1000];  // surely nobody uses > 1000 threads
     int thread_num, checker;

--- a/src/py21cmfast/src/rng.c
+++ b/src/py21cmfast/src/rng.c
@@ -12,6 +12,7 @@
 #include "OutputStructs.h"
 #include "cexcept.h"
 #include "exceptions.h"
+#include "indexing.h"
 #include "logger.h"
 
 // TODO: seed_rng_threads is slow, and isn't great to use every snapshot in Stochasticity.c or
@@ -27,7 +28,7 @@
 //   used as a seed with a looping list of 5 different gsl initialisers.
 //   In order to keep consistency with master I'm leaving it as is for now, but I really want to
 //   understand why it was done this way.
-void seed_rng_threads(gsl_rng *rng_arr[], unsigned long long int seed) {
+void seed_rng_threads(gsl_rng *rng_arr[], index_t seed) {
     // An RNG for generating seeds for multithreading
     gsl_rng *rseed = gsl_rng_alloc(gsl_rng_mt19937);
 
@@ -100,7 +101,7 @@ bool array_unique(unsigned int array[], int array_size) {
 }
 
 // Samples a number of integers, repeating the samples if any repeat
-void sample_n_unique_integers(unsigned int n, unsigned long long int seed, unsigned int array[]) {
+void sample_n_unique_integers(unsigned int n, index_t seed, unsigned int array[]) {
     // An RNG for generating seeds for multithreading
     gsl_rng *rseed = gsl_rng_alloc(gsl_rng_mt19937);
     gsl_rng_set(rseed, seed);
@@ -123,7 +124,7 @@ void sample_n_unique_integers(unsigned int n, unsigned long long int seed, unsig
 //   as well as be applied to different cells/halos, so I can't forsee any issues.
 // Just in case I'm not using it for the initial conditions, which is okay since the slower version
 // is only used once
-void seed_rng_threads_fast(gsl_rng *rng_arr[], unsigned long long int seed) {
+void seed_rng_threads_fast(gsl_rng *rng_arr[], index_t seed) {
     unsigned int seed_thread;
     unsigned int st_arr[1000];  // surely nobody uses > 1000 threads
     int thread_num, checker;

--- a/src/py21cmfast/src/rng.h
+++ b/src/py21cmfast/src/rng.h
@@ -3,8 +3,10 @@
 
 #include <gsl/gsl_rng.h>
 
-void seed_rng_threads(gsl_rng *rng_arr[], unsigned long long int seed);
-void seed_rng_threads_fast(gsl_rng *rng_arr[], unsigned long long int seed);
+#include "indexing.h"
+
+void seed_rng_threads(gsl_rng *rng_arr[], index_t seed);
+void seed_rng_threads_fast(gsl_rng *rng_arr[], index_t seed);
 void free_rng_threads(gsl_rng *rng_arr[]);
 
 #endif

--- a/src/py21cmfast/src/rng.h
+++ b/src/py21cmfast/src/rng.h
@@ -5,8 +5,8 @@
 
 #include "indexing.h"
 
-void seed_rng_threads(gsl_rng *rng_arr[], index_t seed);
-void seed_rng_threads_fast(gsl_rng *rng_arr[], index_t seed);
+void seed_rng_threads(gsl_rng *rng_arr[], random_huge seed);
+void seed_rng_threads_fast(gsl_rng *rng_arr[], random_huge seed);
 void free_rng_threads(gsl_rng *rng_arr[]);
 
 #endif


### PR DESCRIPTION
This PR follows the work of #703.

I took the liberty to make another commit on top of their work. I used AI (mainly Claude) to audit all the C files in order to find other lines where potentially huge integers are defined in the code with `int`. According to a mapping I made, there are 10 types of integers that appear throughout the code. 
 
1.  Number of cells in each dimension (e.g. `HII_DIM`, `DIM`, `D_PARA`, etc).
2. Any dummy index that runs along a single dimension of the box (e.g. `i`, `j`, `k`, or `x`, `y`, `z`).
3. A multiplication of the integers above with themselves, to denote the total number of cells in the box (e.g. `TOT_NUM_PIXELS`, `HII_TOT_NUM_PIXELS`, etc).
4. Any dummy index that runs through all the cells in the box.
5. Size of halo catalog. This corresponds to either the buffer size of the halo catalog, or the actual number of halos that were found in the simulation.
6. Any dummy index that runs through the halo catalog. Again, this could mean running along the buffer size, or along the actual number of halos that were found in the simulation.
7. Random seed.
8. Integers that are set by the user, e.g. `N_THREADS`, `N_STEP_TS`, `N_COND_INTERP` and `N_PROB_INTERP`, as well as the corresponding running dummy indices in the code.
9. There are also fixed sizes of interpolation tables used in the code, and running indices along their grid.
10. Finally, there are also enums in the code, like `HMF`, `POWER_SPECTRUM`, `PERTURB_ALGORITHM`, and more.

Only integers of type 3-7 have the potential to be very large, above the upper limit of 2.1e9 that is supported by 32-bit `int`. (Note: apparently, we also allow users to run the code with very large random seeds!)

I asked the AI to scan other places where integers of type 3-7 are not defined as `unsigned long long int`. Apart of the work that was done in #703, the AI managed to find 4 more places where `int` was wrongly used (most importantly, in `map_mass.c` and `HaloCatalog.c`). I also made some stylistic changes, e.g. `unsigned long long -> unsigned long long int`.

## Summary by Sourcery

Update handling of potentially very large loop indices, grid indices, halo counts, and random seeds to use 64‑bit unsigned integers where needed to avoid overflow.

Bug Fixes:
- Use unsigned long long int for grid, velocity, and halo catalog indices that can exceed 32‑bit int limits, including in map_mass, halo catalog construction, perturbed field normalization, and filtering.
- Change counters and halo totals that may grow beyond 2.1e9 to unsigned long long int and fix corresponding logging format specifiers.
- Ensure allocation sizes and loop variables that depend on total pixel counts or halo numbers use 64‑bit unsigned integers to prevent overflow or truncation.

Enhancements:
- Align type usage and style across the codebase by consistently using unsigned long long int for large indices and random seeds and simplifying volume and mass factor computations.