### PR TITLE
Multiple scattering small updates after publication

### DIFF
--- a/docs/acknowledge.rst
+++ b/docs/acknowledge.rst
@@ -19,7 +19,8 @@ Lyman alpha multiple scattering
 
     Flitter, J., Munoz, J. B., Mesinger, A.,
     "Semi-analytical approach to Lyman-alpha multiple-scattering in 21-cm signal simulations",
-    eprint arXiv:2601.14360, 2026. https://doi.org/10.48550/arXiv.2601.14360.
+    Physical Review D, vol. 113, no. 10, 103552, 2026,
+    https://doi.org/10.1103/5r5v-nk5j.
 
 Discrete Halo Sampler / version 4:
 

--- a/src/py21cmfast/src/filtering.c
+++ b/src/py21cmfast/src/filtering.c
@@ -190,7 +190,7 @@ double asymptotic_2F3(double kR, double alpha, double beta) {
     // as given in
     // https://functions.wolfram.com/HypergeometricFunctions/Hypergeometric2F3/06/02/03/01/0003/. In
     // our case, z=-kR^2/4 and the parameters of the hypergeometric function are given below
-    // (see also Eq. D8 in arxiv: 2601.14360)
+    // (see also Eq. E8 in arxiv: 2601.14360)
     double a1 = (2. + alpha) / 2.;
     double a2 = (3. + alpha) / 2.;
     double b1 = 5. / 2.;
@@ -256,7 +256,7 @@ double hyper_2F3(double kR, double alpha, double beta) {
         return 3.0 / (pow(kR, 3)) * (sin(kR) - cos(kR) * kR);
     }
     // For a small argument, we compute the hypergeometric function through power-law expansion
-    // This is Eq. (D7) in arxiv: 2601.14360
+    // This is Eq. (E7) in arxiv: 2601.14360
     if (kR < 30.) {
         int n;
         int max_terms = 1000;

--- a/src/py21cmfast/utils.py
+++ b/src/py21cmfast/utils.py
@@ -144,7 +144,8 @@ def show_references(inputs: InputParameters, lightcone=True, print_to_stdout=Tru
             "========================================================\n"
             "Flitter, J., Munoz, J. B., Mesinger, A.,\n"
             '"Semi-analytical approach to Lyman-alpha multiple-scattering in 21-cm signal simulations",\n'
-            "eprint arXiv:2601.14360, 2026. https://doi.org/10.48550/arXiv.2601.14360.\n\n"
+            "Physical Review D, vol. 113, no. 10, 103552, 2026.\n"
+            "https://doi.org/10.1103/5r5v-nk5j.\n\n"
         )
 
     if print_to_stdout:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,7 @@ def test_ref_printing():
     assert "10.1093/mnras/stac185" not in ref_str  # USE_RELATIVE_VELOCITIES
     assert "10.1093/mnras/stac2756" not in ref_str  # PHOTON_CONS
     assert "10.1051/0004-6361/202554951" not in ref_str  # LAGRANGIAN_SOURCE_MODEL
-    assert "10.48550/arXiv.2601.14360" not in ref_str  # LYA_MULTIPLE_SCATTERING
+    assert "10.1103/5r5v-nk5j" not in ref_str  # LYA_MULTIPLE_SCATTERING
 
     inputs = InputParameters.from_template(
         "mini-dhalos", random_seed=1234, K_MAX_FOR_CLASS=1.0
@@ -36,7 +36,7 @@ def test_ref_printing():
     assert "10.1093/mnras/stac185" in ref_str  # USE_RELATIVE_VELOCITIES
     assert "10.1093/mnras/stac2756" not in ref_str  # PHOTON_CONS
     assert "10.1051/0004-6361/202554951" in ref_str  # LAGRANGIAN_SOURCE_MODEL
-    assert "10.48550/arXiv.2601.14360" not in ref_str  # LYA_MULTIPLE_SCATTERING
+    assert "10.1103/5r5v-nk5j" not in ref_str  # LYA_MULTIPLE_SCATTERING
 
     inputs = InputParameters.from_template("const-zeta", random_seed=1234)
     ref_str = show_references(inputs, lightcone=True, print_to_stdout=True)
@@ -50,7 +50,7 @@ def test_ref_printing():
     assert "10.1093/mnras/stac185" not in ref_str  # USE_RELATIVE_VELOCITIES
     assert "10.1093/mnras/stac2756" not in ref_str  # PHOTON_CONS
     assert "10.1051/0004-6361/202554951" not in ref_str  # LAGRANGIAN_SOURCE_MODEL
-    assert "10.48550/arXiv.2601.14360" not in ref_str  # LYA_MULTIPLE_SCATTERING
+    assert "10.1103/5r5v-nk5j" not in ref_str  # LYA_MULTIPLE_SCATTERING
 
     inputs = InputParameters.from_template(
         "fixed-halos", random_seed=1234, LYA_MULTIPLE_SCATTERING=True
@@ -66,7 +66,7 @@ def test_ref_printing():
     assert "10.1093/mnras/stac185" not in ref_str  # USE_RELATIVE_VELOCITIES
     assert "10.1093/mnras/stac2756" not in ref_str  # PHOTON_CONS
     assert "10.1051/0004-6361/202554951" in ref_str  # LAGRANGIAN_SOURCE_MODEL
-    assert "10.48550/arXiv.2601.14360" in ref_str  # LYA_MULTIPLE_SCATTERING
+    assert "10.1103/5r5v-nk5j" in ref_str  # LYA_MULTIPLE_SCATTERING
 
     inputs = InputParameters.from_template(
         "latest", random_seed=1234, PHOTON_CONS_TYPE="z-photoncons"
@@ -82,7 +82,7 @@ def test_ref_printing():
     assert "10.1093/mnras/stac185" not in ref_str  # USE_RELATIVE_VELOCITIES
     assert "10.1093/mnras/stac2756" in ref_str  # PHOTON_CONS
     assert "10.1051/0004-6361/202554951" not in ref_str  # LAGRANGIAN_SOURCE_MODEL
-    assert "10.48550/arXiv.2601.14360" not in ref_str  # LYA_MULTIPLE_SCATTERING
+    assert "10.1103/5r5v-nk5j" not in ref_str  # LYA_MULTIPLE_SCATTERING
 
 
 class TestRecursiveDifference:


### PR DESCRIPTION
Small adjustments, after multiple scattering paper was published :)

## Summary by Sourcery

Update multiple-scattering references from the arXiv preprint to the published Physical Review D article across code, utilities, and tests.

Enhancements:
- Refresh inline comments in the filtering implementation to point to the correct equation labels in the published paper rather than the preprint.

Tests:
- Adjust reference-printing tests to expect the DOI and citation details of the published Lyman-alpha multiple-scattering paper.