### PR TITLE
added an update method to CacheConfig

### DIFF
--- a/src/py21cmfast/io/caching.py
+++ b/src/py21cmfast/io/caching.py
@@ -9,7 +9,7 @@ import logging
 import re
 from hashlib import md5
 from pathlib import Path
-from typing import ClassVar, Self
+from typing import ClassVar, Self, TypedDict, Unpack
 
 import attrs
 import numpy as np
@@ -537,6 +537,19 @@ class RunCache:
         return True
 
 
+class CacheConfigUpdate(TypedDict, total=False):
+    """A TypedDict for updating CacheConfig objects."""
+
+    initial_conditions: bool
+    perturbed_field: bool
+    spin_temp: bool
+    ionized_box: bool
+    brightness_temp: bool
+    halobox: bool
+    halo_catalog: bool
+    xray_source_box: bool
+
+
 @attrs.define
 class CacheConfig:
     """A configuration object that specifies whether a certain field should be cached."""
@@ -550,17 +563,17 @@ class CacheConfig:
     halo_catalog: bool = attrs.field(default=True, converter=bool)
     xray_source_box: bool = attrs.field(default=True, converter=bool)
 
-    def update(self, **kwargs) -> Self:
+    def update(self, **kwargs: Unpack[CacheConfigUpdate]) -> Self:
         """Return a new CacheConfig with the given fields updated."""
         return attrs.evolve(self, **kwargs)
 
     @classmethod
-    def on(cls, **kwargs) -> Self:
+    def on(cls, **kwargs: Unpack[CacheConfigUpdate]) -> Self:
         """Generate a CacheConfig where all boxes are cached."""
         return cls().update(**kwargs)
 
     @classmethod
-    def off(cls, **kwargs):
+    def off(cls, **kwargs: Unpack[CacheConfigUpdate]) -> Self:
         """Generate a CacheConfig where no boxes are cached."""
         return cls(
             initial_conditions=False,
@@ -574,7 +587,7 @@ class CacheConfig:
         ).update(**kwargs)
 
     @classmethod
-    def noloop(cls, **kwargs):
+    def noloop(cls, **kwargs: Unpack[CacheConfigUpdate]) -> Self:
         """Generate a CacheConfig where only boxes not requiring evolution are cached."""
         return cls(
             initial_conditions=True,
@@ -588,7 +601,7 @@ class CacheConfig:
         ).update(**kwargs)
 
     @classmethod
-    def last_step_only(cls, **kwargs):
+    def last_step_only(cls, **kwargs: Unpack[CacheConfigUpdate]) -> Self:
         """Generate a CacheConfig where only boxes needed from more than one step away are cached.
 
         This represents the minimum caching setup which will *never* store every redshift in memory.

--- a/src/py21cmfast/io/caching.py
+++ b/src/py21cmfast/io/caching.py
@@ -550,13 +550,17 @@ class CacheConfig:
     halo_catalog: bool = attrs.field(default=True, converter=bool)
     xray_source_box: bool = attrs.field(default=True, converter=bool)
 
-    @classmethod
-    def on(cls) -> Self:
-        """Generate a CacheConfig where all boxes are cached."""
-        return cls()
+    def update(self, **kwargs) -> Self:
+        """Return a new CacheConfig with the given fields updated."""
+        return attrs.evolve(self, **kwargs)
 
     @classmethod
-    def off(cls):
+    def on(cls, **kwargs) -> Self:
+        """Generate a CacheConfig where all boxes are cached."""
+        return cls().update(**kwargs)
+
+    @classmethod
+    def off(cls, **kwargs):
         """Generate a CacheConfig where no boxes are cached."""
         return cls(
             initial_conditions=False,
@@ -567,10 +571,10 @@ class CacheConfig:
             halobox=False,
             halo_catalog=False,
             xray_source_box=False,
-        )
+        ).update(**kwargs)
 
     @classmethod
-    def noloop(cls):
+    def noloop(cls, **kwargs):
         """Generate a CacheConfig where only boxes not requiring evolution are cached."""
         return cls(
             initial_conditions=True,
@@ -581,10 +585,10 @@ class CacheConfig:
             halobox=False,
             halo_catalog=True,
             xray_source_box=False,
-        )
+        ).update(**kwargs)
 
     @classmethod
-    def last_step_only(cls):
+    def last_step_only(cls, **kwargs):
         """Generate a CacheConfig where only boxes needed from more than one step away are cached.
 
         This represents the minimum caching setup which will *never* store every redshift in memory.
@@ -601,4 +605,4 @@ class CacheConfig:
             halobox=True,
             halo_catalog=True,
             xray_source_box=False,
-        )
+        ).update(**kwargs)

--- a/tests/io/test_caching.py
+++ b/tests/io/test_caching.py
@@ -63,6 +63,48 @@ def partial_run_cache(tmp_path_factory):
     return cache
 
 
+class TestCacheConfig:
+    """Tests of the CacheConfig class."""
+
+    def test_on_and_off(self):
+        """Test that the on and off classmethods produce the expected configs."""
+        config_on = caching.CacheConfig.on()
+        assert all(attrs.asdict(config_on).values())
+
+        config_off = caching.CacheConfig.off()
+        assert not any(attrs.asdict(config_off).values())
+
+    @pytest.mark.parametrize("config_method", ["on", "off", "noloop", "last_step_only"])
+    def test_update(self, config_method):
+        """Test that the update method produces the expected configs."""
+        config = getattr(caching.CacheConfig, config_method)()
+        fields = attrs.fields(caching.CacheConfig)
+
+        # Annoying fields that we don't want to cache
+        annoying_fields = ["xray_source_box", "initial_conditions"]
+        kwargs = dict.fromkeys(annoying_fields, False)
+
+        # First check that the update method works as expected
+        updated_config = config.update(**kwargs)
+        for field in fields:
+            if field.name in annoying_fields:
+                assert not getattr(updated_config, field.name)
+            else:
+                assert getattr(updated_config, field.name) == getattr(
+                    config, field.name
+                )
+
+        # Then check that the classmethod versions also work as expected
+        updated_config = getattr(caching.CacheConfig, config_method)(**kwargs)
+        for field in fields:
+            if field.name in annoying_fields:
+                assert not getattr(updated_config, field.name)
+            else:
+                assert getattr(updated_config, field.name) == getattr(
+                    config, field.name
+                )
+
+
 class TestRunCache:
     """Tests of the RunCache class."""
 


### PR DESCRIPTION
Fix #673

## Summary by Sourcery

Add an update method to CacheConfig and allow predefined cache configurations to be customized via keyword overrides.

New Features:
- Introduce a CacheConfig.update method to create modified cache configurations based on existing ones.

Enhancements:
- Allow CacheConfig.on, .off, .noloop, and .last_step_only to accept keyword overrides when constructing cache configurations.

Tests:
- Add unit tests for CacheConfig factory methods and the new update behavior to ensure configurations are correctly overridden.