### PR TITLE
Recombination model enum in C

### DIFF
--- a/src/py21cmfast/drivers/_global_initialization.py
+++ b/src/py21cmfast/drivers/_global_initialization.py
@@ -151,7 +151,7 @@ class GlobalInitializationManager:
         # NOTE: run_global_evolution at the moment does not do recombination calculations, so we only initialize if HII_DIM > 1.
         # If this is changed in the future, it will be necessary to remove the HII_DIM > 1 condition below, since it would cause a segfault!
         if (
-            self.inputs.astro_options.INHOMO_RECO
+            self.inputs.astro_options.RECOMB_MODEL != "none"
             and self.inputs.simulation_options.HII_DIM > 1
             and not self.recomb_inited
         ):

--- a/src/py21cmfast/src/HaloBox.c
+++ b/src/py21cmfast/src/HaloBox.c
@@ -176,7 +176,8 @@ HaloProperties get_halobox_averages(HaloBox *grids) {
         if (astro_options_global->USE_MINI_HALOS) {
             mean_sfr_mini += grids->halo_sfr_mini[i];
         }
-        if (astro_options_global->RECOMB_MODEL > 0) mean_wsfr += grids->whalo_sfr[i];
+        if (uses_recombination(astro_options_global->RECOMB_MODEL))
+            mean_wsfr += grids->whalo_sfr[i];
 
         if (config_settings.EXTRA_HALOBOX_FIELDS) {
             mean_count += grids->count[i];
@@ -223,7 +224,7 @@ void mean_fix_grids(double M_min, double M_max, HaloBox *grids, ScalingConstants
         if (astro_options_global->USE_TS_FLUCT) {
             grids->halo_xray[idx] *= averages_global.halo_xray / averages_hbox.halo_xray;
         }
-        if (astro_options_global->RECOMB_MODEL > 0) {
+        if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
             grids->whalo_sfr[idx] *=
                 averages_global.fescweighted_sfr / averages_hbox.fescweighted_sfr;
         }
@@ -417,7 +418,7 @@ int set_fixed_grids(double M_min, double M_max, InitialConditions *ini_boxes, fl
                        &integral_cond);
 
     LOG_ULTRA_DEBUG("Cell 0 Totals: SF: %.2e, NI: %.2e", grids->halo_sfr[0], grids->n_ion[0]);
-    if (astro_options_global->RECOMB_MODEL > 0) {
+    if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
         LOG_ULTRA_DEBUG("FESC * SF %.2e", grids->whalo_sfr[0]);
     }
     if (astro_options_global->USE_TS_FLUCT) {
@@ -548,7 +549,7 @@ void sum_halos_onto_grid(double redshift, InitialConditions *ini_boxes, HaloCata
                        mturn_m_grid, grids, out_dim, consts);
 
     LOG_SUPER_DEBUG("Cell 0 Totals: SF: %.2e NI: %.2e", grids->halo_sfr[0], grids->n_ion[0]);
-    if (astro_options_global->RECOMB_MODEL > 0) {
+    if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
         LOG_SUPER_DEBUG("FESC * SF %.2e", grids->whalo_sfr[0]);
     }
     if (astro_options_global->USE_TS_FLUCT) {
@@ -587,7 +588,7 @@ int ComputeHaloBox(double redshift, InitialConditions *ini_boxes, HaloCatalog *h
             if (astro_options_global->USE_MINI_HALOS) {
                 grids->halo_sfr_mini[idx] = 0.0;
             }
-            if (astro_options_global->RECOMB_MODEL > 0) {
+            if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
                 grids->whalo_sfr[idx] = 0.0;
             }
             if (config_settings.EXTRA_HALOBOX_FIELDS) {
@@ -854,7 +855,7 @@ int convert_halo_props(double redshift, InitialConditions *ics, TsBox *prev_ts,
                 halo_catalog_out->stellar_mini[i_halo] = out_props.stellar_mass_mini;
                 halo_catalog_out->sfr_mini[i_halo] = out_props.sfr_mini;
             }
-            if (astro_options_global->RECOMB_MODEL > 0) {
+            if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
                 halo_catalog_out->fesc_sfr[i_halo] = out_props.fescweighted_sfr;
             }
             if (astro_options_global->USE_TS_FLUCT) {

--- a/src/py21cmfast/src/InputParameters.h
+++ b/src/py21cmfast/src/InputParameters.h
@@ -52,6 +52,10 @@
 #define INTEGRATION_METHOD_GAUSS_LEGENDRE 1
 #define INTEGRATION_METHOD_GAMMA_APPROX 2
 
+#define RECOMB_MODEL_NO 0
+#define RECOMB_MODEL_HOMOGENEOUS 1
+#define RECOMB_MODEL_INHOMOGENEOUS 2
+
 static inline bool source_model_is_mass_dependent(int source_model) {
     return source_model != SOURCE_MODEL_CONST_ION_EFF;
 }
@@ -76,6 +80,8 @@ static inline bool uses_interpolation_tables(int interpolation_mode) {
 static inline bool uses_hmf_interpolation(int interpolation_mode) {
     return interpolation_mode == INTERPOLATION_HMF;
 }
+
+static inline bool uses_recombination(int recomb_model) { return recomb_model != RECOMB_MODEL_NO; }
 
 void Broadcast_struct_global_all(SimulationOptions *simulation_options,
                                  MatterOptions *matter_options, CosmoParams *cosmo_params,

--- a/src/py21cmfast/src/IonisationBox.c
+++ b/src/py21cmfast/src/IonisationBox.c
@@ -109,7 +109,7 @@ struct FilteredGrids {
     // Used when TS_FLUCT==True
     fftwf_complex *xe_unfiltered, *xe_filtered;
 
-    // Used when RECOMB_MODEL > 0 and CELL_RECOMB=False
+    // Used when using recombination and CELL_RECOMB=False
     fftwf_complex *N_rec_unfiltered, *N_rec_filtered;
 
     // Used when USE_MINI_HALOS==True and SOURCE_MODEL=='E-INTEGRAL'
@@ -153,8 +153,8 @@ void set_ionbox_constants(double redshift, double prev_redshift, struct IonBoxCo
     consts->fix_mean = !consts->lagrangian_source_grids;  // for now, opposite of above
     consts->need_minihalo_nion =
         !consts->lagrangian_source_grids && astro_options_global->USE_MINI_HALOS;
-    consts->filter_recombinations =
-        astro_options_global->RECOMB_MODEL > 0 && !astro_options_global->CELL_RECOMB;
+    consts->filter_recombinations = uses_recombination(astro_options_global->RECOMB_MODEL) &&
+                                    !astro_options_global->CELL_RECOMB;
 
     consts->hii_filter = astro_options_global->HII_FILTER;
     consts->T_re = astro_params_global->T_RE;
@@ -258,7 +258,8 @@ void allocate_fftw_grids(struct FilteredGrids **fg_struct) {
             (fftwf_complex *)fftwf_malloc(sizeof(fftwf_complex) * HII_KSPACE_NUM_PIXELS);
     }
 
-    if (astro_options_global->RECOMB_MODEL > 0 && !astro_options_global->CELL_RECOMB) {
+    if (uses_recombination(astro_options_global->RECOMB_MODEL) &&
+        !astro_options_global->CELL_RECOMB) {
         (*fg_struct)->N_rec_unfiltered = (fftwf_complex *)fftwf_malloc(
             sizeof(fftwf_complex) * HII_KSPACE_NUM_PIXELS);  // cumulative number of recombinations
         (*fg_struct)->N_rec_filtered =
@@ -271,7 +272,7 @@ void allocate_fftw_grids(struct FilteredGrids **fg_struct) {
         (*fg_struct)->stars_filtered =
             (fftwf_complex *)fftwf_malloc(sizeof(fftwf_complex) * HII_KSPACE_NUM_PIXELS);
 
-        if (astro_options_global->RECOMB_MODEL > 0) {
+        if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
             (*fg_struct)->sfr_unfiltered =
                 (fftwf_complex *)fftwf_malloc(sizeof(fftwf_complex) * HII_KSPACE_NUM_PIXELS);
             (*fg_struct)->sfr_filtered =
@@ -299,7 +300,8 @@ void free_fftw_grids(struct FilteredGrids *fg_struct) {
         fftwf_free(fg_struct->xe_unfiltered);
         fftwf_free(fg_struct->xe_filtered);
     }
-    if (astro_options_global->RECOMB_MODEL > 0 && !astro_options_global->CELL_RECOMB) {
+    if (uses_recombination(astro_options_global->RECOMB_MODEL) &&
+        !astro_options_global->CELL_RECOMB) {
         fftwf_free(fg_struct->N_rec_unfiltered);
         fftwf_free(fg_struct->N_rec_filtered);
     }
@@ -307,7 +309,7 @@ void free_fftw_grids(struct FilteredGrids *fg_struct) {
     if (source_model_uses_lagrangian_grids(matter_options_global->SOURCE_MODEL)) {
         fftwf_free(fg_struct->stars_unfiltered);
         fftwf_free(fg_struct->stars_filtered);
-        if (astro_options_global->RECOMB_MODEL > 0) {
+        if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
             fftwf_free(fg_struct->sfr_unfiltered);
             fftwf_free(fg_struct->sfr_filtered);
         }
@@ -586,7 +588,7 @@ void copy_filter_transform(struct FilteredGrids *fg_struct, struct IonBoxConstan
     if (consts->lagrangian_source_grids) {
         memcpy(fg_struct->stars_filtered, fg_struct->stars_unfiltered,
                sizeof(fftwf_complex) * HII_KSPACE_NUM_PIXELS);
-        if (astro_options_global->RECOMB_MODEL > 0) {
+        if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
             memcpy(fg_struct->sfr_filtered, fg_struct->sfr_unfiltered,
                    sizeof(fftwf_complex) * HII_KSPACE_NUM_PIXELS);
         }
@@ -614,7 +616,7 @@ void copy_filter_transform(struct FilteredGrids *fg_struct, struct IonBoxConstan
         if (consts->lagrangian_source_grids) {
             int filter_hf = astro_options_global->USE_EXP_FILTER ? 3 : consts->hii_filter;
             filter_box(fg_struct->stars_filtered, box_dim, filter_hf, R, consts->mfp_meandens, 0.);
-            if (astro_options_global->RECOMB_MODEL > 0) {
+            if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
                 filter_box(fg_struct->sfr_filtered, box_dim, filter_hf, R, consts->mfp_meandens,
                            0.);
             }
@@ -635,7 +637,7 @@ void copy_filter_transform(struct FilteredGrids *fg_struct, struct IonBoxConstan
     if (consts->lagrangian_source_grids) {
         dft_c2r_cube(matter_options_global->USE_FFTW_WISDOM, simulation_options_global->HII_DIM,
                      HII_D_PARA, simulation_options_global->N_THREADS, fg_struct->stars_filtered);
-        if (astro_options_global->RECOMB_MODEL > 0) {
+        if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
             dft_c2r_cube(matter_options_global->USE_FFTW_WISDOM, simulation_options_global->HII_DIM,
                          HII_D_PARA, simulation_options_global->N_THREADS, fg_struct->sfr_filtered);
         }
@@ -820,7 +822,7 @@ void calculate_fcoll_grid(IonizedBox *box, IonizedBox *previous_ionize_box,
                     if (consts->lagrangian_source_grids) {
                         *((float *)fg_struct->stars_filtered + index_f) =
                             fmaxf(*((float *)fg_struct->stars_filtered + index_f), 0.0);
-                        if (astro_options_global->RECOMB_MODEL > 0) {
+                        if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
                             *((float *)fg_struct->sfr_filtered + index_f) =
                                 fmaxf(*((float *)fg_struct->sfr_filtered + index_f), 0.0);
                         }
@@ -1080,10 +1082,13 @@ void find_ionised_regions(IonizedBox *box, IonizedBox *previous_ionize_box,
                         }
                     }
 
-                    if (astro_options_global->RECOMB_MODEL > 0) {
+                    if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
                         // number of recombinations per mean baryon
                         if (astro_options_global->CELL_RECOMB) {
-                            index_rec = (astro_options_global->RECOMB_MODEL == 2) ? index_r : 0;
+                            index_rec =
+                                (astro_options_global->RECOMB_MODEL == RECOMB_MODEL_INHOMOGENEOUS)
+                                    ? index_r
+                                    : 0;
                             rec = previous_ionize_box->cumulative_recombinations[index_rec];
                         } else
                             rec = (*((float *)fg_struct->N_rec_filtered + index_f));
@@ -1117,7 +1122,7 @@ void find_ionised_regions(IonizedBox *box, IonizedBox *previous_ionize_box,
                         // if this is the first crossing of the ionization barrier for this cell
                         // (largest R), record the gamma this assumes photon-starved growth of HII
                         // regions...  breaks down post EoR
-                        if (astro_options_global->RECOMB_MODEL > 0 &&
+                        if (uses_recombination(astro_options_global->RECOMB_MODEL) &&
                             (box->neutral_fraction[index_r] > FRACT_FLOAT_ERR)) {
                             if (consts->lagrangian_source_grids) {
                                 // since ION_EFF_FACTOR==1 here, gamma_prefactor is the same for ACG
@@ -1254,7 +1259,7 @@ void set_ionized_temperatures(IonizedBox *box, PerturbedField *perturbed_field, 
 void set_recombination_rates(IonizedBox *box, IonizedBox *previous_ionize_box,
                              PerturbedField *perturbed_field, struct IonBoxConstants *consts,
                              float global_xHI, float global_photionization_rate) {
-    if (astro_options_global->RECOMB_MODEL == 1) {
+    if (astro_options_global->RECOMB_MODEL == RECOMB_MODEL_HOMOGENEOUS) {
         // Homogeneous recombination rate
         double dNrec_global =
             splined_recombination_rate(consts->stored_redshift, global_photionization_rate) *
@@ -1270,7 +1275,7 @@ void set_recombination_rates(IonizedBox *box, IonizedBox *previous_ionize_box,
             Throw(InfinityorNaNError);
         }
         box->cumulative_recombinations[0] = cumulative_recomb_global;
-    } else if (astro_options_global->RECOMB_MODEL == 2) {
+    } else if (astro_options_global->RECOMB_MODEL == RECOMB_MODEL_INHOMOGENEOUS) {
         // Inhomogeneous recombination rate
         bool finite_error = false;
         int box_dim[3] = {simulation_options_global->HII_DIM, simulation_options_global->HII_DIM,
@@ -1478,7 +1483,7 @@ int ComputeIonizedBox(float redshift, float prev_redshift, PerturbedField *pertu
             if (ionbox_constants.lagrangian_source_grids) {
                 prepare_box_for_filtering(halos->n_ion, grid_struct->stars_unfiltered, 1., 0.,
                                           1e20);
-                if (astro_options_global->RECOMB_MODEL > 0) {
+                if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
                     prepare_box_for_filtering(halos->whalo_sfr, grid_struct->sfr_unfiltered, 1., 0.,
                                               1e20);
                 }
@@ -1595,7 +1600,7 @@ int ComputeIonizedBox(float redshift, float prev_redshift, PerturbedField *pertu
 #pragma omp for reduction(+ : global_xH, global_photoionization_rate)
                 for (ct = 0; ct < HII_TOT_NUM_PIXELS; ct++) {
                     global_xH += box->neutral_fraction[ct];
-                    if (astro_options_global->RECOMB_MODEL == 1) {
+                    if (astro_options_global->RECOMB_MODEL == RECOMB_MODEL_HOMOGENEOUS) {
                         global_photoionization_rate += box->ionisation_rate_G12[ct];
                     }
                 }
@@ -1611,7 +1616,7 @@ int ComputeIonizedBox(float redshift, float prev_redshift, PerturbedField *pertu
             }
 
             // update the N_rec field
-            if (astro_options_global->RECOMB_MODEL > 0) {
+            if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
                 set_recombination_rates(box, previous_ionize_box, perturbed_field,
                                         &ionbox_constants, global_xH, global_photoionization_rate);
             }

--- a/src/py21cmfast/src/map_mass.c
+++ b/src/py21cmfast/src/map_mass.c
@@ -336,7 +336,7 @@ void move_grid_galprops(double redshift, float *dens_pointer, int dens_dim[3],
     }
     // Without stochasticity, these grids are the same to a constant
     double prefactor_wsfr = 1 / consts->t_h / consts->t_star;
-    if (astro_options_global->RECOMB_MODEL > 0) {
+    if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
         for (index_huge i = 0; i < HII_TOT_NUM_PIXELS; i++) {
             boxes->whalo_sfr[i] = boxes->n_ion[i] * prefactor_wsfr;
         }
@@ -425,7 +425,7 @@ void move_halo_galprops(double redshift, HaloCatalog *halos, float *vel_pointers
             if (astro_options_global->USE_TS_FLUCT) {
                 do_cic_interpolation(boxes->halo_xray, pos, out_dim, properties.halo_xray);
             }
-            if (astro_options_global->RECOMB_MODEL > 0) {
+            if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
                 do_cic_interpolation(boxes->whalo_sfr, pos, out_dim, properties.fescweighted_sfr);
             }
             if (config_settings.EXTRA_HALOBOX_FIELDS) {
@@ -458,7 +458,7 @@ void move_halo_galprops(double redshift, HaloCatalog *halos, float *vel_pointers
             if (astro_options_global->USE_TS_FLUCT) {
                 boxes->halo_xray[i_cell] *= cell_vol_inv;
             }
-            if (astro_options_global->RECOMB_MODEL > 0) {
+            if (uses_recombination(astro_options_global->RECOMB_MODEL)) {
                 boxes->whalo_sfr[i_cell] *= cell_vol_inv;
             }
             if (astro_options_global->USE_MINI_HALOS) {

--- a/src/py21cmfast/utils.py
+++ b/src/py21cmfast/utils.py
@@ -58,7 +58,7 @@ def show_references(inputs: InputParameters, lightcone=True, print_to_stdout=Tru
         "https://ui.adsabs.harvard.edu/link_gateway/2011MNRAS.411..955M/doi:10.1111/j.1365-2966.2010.17731.x\n\n"
     )
 
-    if inputs.astro_options.INHOMO_RECO:
+    if inputs.astro_options.RECOMB_MODEL != "none":
         ref_string += (
             "Inhomogeneous recombination model introduced in:\n"
             "=============================================\n"

--- a/src/py21cmfast/utils.py
+++ b/src/py21cmfast/utils.py
@@ -60,7 +60,7 @@ def show_references(inputs: InputParameters, lightcone=True, print_to_stdout=Tru
 
     if inputs.astro_options.RECOMB_MODEL != "none":
         ref_string += (
-            "Inhomogeneous recombination model introduced in:\n"
+            "Recombination model introduced in:\n"
             "=============================================\n"
             "Sobacchi, E., Mesinger, A.,\n"
             "“Inhomogeneous recombinations during cosmic reionization”,\n"

--- a/tests/test_global_initialization.py
+++ b/tests/test_global_initialization.py
@@ -57,7 +57,7 @@ def test_initializations():
             SOURCE_MODEL="L-INTEGRAL",
             USE_UPPER_STELLAR_TURNOVER=False,
             USE_INTERPOLATION_TABLES="no-interpolation",
-            INHOMO_RECO=False,
+            RECOMB_MODEL="none",
         )
     )
 
@@ -75,7 +75,7 @@ def test_initializations():
 
     # Now let's change the inputs to ones that will allow the initialization of all tables, and check that it works as expected
     _GlobalInitManagerSingleton.inputs = _GlobalInitManagerSingleton.inputs.with_logspaced_redshifts().evolve_input_structs(
-        USE_INTERPOLATION_TABLES="sigma-interpolation", INHOMO_RECO=True
+        USE_INTERPOLATION_TABLES="sigma-interpolation", RECOMB_MODEL="inhomogeneous"
     )
 
     _GlobalInitManagerSingleton.broadcast_input_struct()
@@ -128,7 +128,7 @@ def test_direct_initializations_for_heat_and_recomb():
 
     # Now let's change the inputs to ones that will allow the initialization of the recombination rate, and check that it works as expected
     _GlobalInitManagerSingleton.inputs = _GlobalInitManagerSingleton.inputs.with_logspaced_redshifts().evolve_input_structs(
-        INHOMO_RECO=True
+        RECOMB_MODEL="inhomogeneous"
     )
     _GlobalInitManagerSingleton.initialize_recombination_rate()
     assert _GlobalInitManagerSingleton.inputs_are_broadcast

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ def test_ref_printing():
 
     assert "2011MNRAS.411..955M" in ref_str  # 21cmFAST first paper
     assert "10.21105/joss.02582" in ref_str  # v3 (wrapper)
-    assert "10.1093/mnras/stu377" in ref_str  # INHOMO_RECO
+    assert "10.1093/mnras/stu377" in ref_str  # inhomogeneous recombinations
     assert "10.1093/mnras/sty796" in ref_str  # LIGHTCONE + RSD
     assert "10.1093/mnras/stz032" in ref_str  # USE_MASS_DEPENDENT_ZETA
     assert "10.1093/mnras/staa1131" not in ref_str  # USE_MINI_HALOS
@@ -27,7 +27,7 @@ def test_ref_printing():
 
     assert "2011MNRAS.411..955M" in ref_str  # 21cmFAST first paper
     assert "10.21105/joss.02582" in ref_str  # v3 (wrapper)
-    assert "10.1093/mnras/stu377" in ref_str  # INHOMO_RECO
+    assert "10.1093/mnras/stu377" in ref_str  # inhomogeneous recombinations
     assert "10.1093/mnras/sty796" in ref_str  # LIGHTCONE + RSD
     assert "10.1093/mnras/stz032" in ref_str  # USE_MASS_DEPENDENT_ZETA
     assert "10.1093/mnras/staa1131" in ref_str  # USE_MINI_HALOS
@@ -41,7 +41,7 @@ def test_ref_printing():
 
     assert "2011MNRAS.411..955M" in ref_str  # 21cmFAST first paper
     assert "10.21105/joss.02582" in ref_str  # v3 (wrapper)
-    assert "10.1093/mnras/stu377" not in ref_str  # INHOMO_RECO
+    assert "10.1093/mnras/stu377" not in ref_str  # inhomogeneous recombinations
     assert "10.1093/mnras/sty796" in ref_str  # LIGHTCONE + RSD
     assert "10.1093/mnras/stz032" not in ref_str  # USE_MASS_DEPENDENT_ZETA
     assert "10.1093/mnras/staa1131" not in ref_str  # USE_MINI_HALOS
@@ -57,7 +57,7 @@ def test_ref_printing():
 
     assert "2011MNRAS.411..955M" in ref_str  # 21cmFAST first paper
     assert "10.21105/joss.02582" in ref_str  # v3 (wrapper)
-    assert "10.1093/mnras/stu377" in ref_str  # INHOMO_RECO
+    assert "10.1093/mnras/stu377" in ref_str  # inhomogeneous recombinations
     assert "10.1093/mnras/sty796" in ref_str  # LIGHTCONE + RSD
     assert "10.1093/mnras/stz032" in ref_str  # USE_MASS_DEPENDENT_ZETA
     assert "10.1093/mnras/staa1131" not in ref_str  # USE_MINI_HALOS
@@ -73,7 +73,7 @@ def test_ref_printing():
 
     assert "2011MNRAS.411..955M" in ref_str  # 21cmFAST first paper
     assert "10.21105/joss.02582" in ref_str  # v3 (wrapper)
-    assert "10.1093/mnras/stu377" in ref_str  # INHOMO_RECO
+    assert "10.1093/mnras/stu377" in ref_str  # inhomogeneous recombinations
     assert "10.1093/mnras/sty796" not in ref_str  # LIGHTCONE + RSD
     assert "10.1093/mnras/stz032" in ref_str  # USE_MASS_DEPENDENT_ZETA
     assert "10.1093/mnras/staa1131" not in ref_str  # USE_MINI_HALOS


### PR DESCRIPTION
In #681 we added a homogeneous recombination model, so we switched from the boolean flag `INHOMO_RECO` (which will become deprecated) to an enum-type variable called `RECOMB_MODEL`.

Meanwhile, in #698 we have introduced enums in the C code. In addition, in #624 we incorporated the `init_once` logic in the main branch (v4.1) which depends partially on the archaic flag `INHOMO_RECO`.

This PR does the following:
1. It replaces the remaining appearances of `INHOMO_RECO` in favor of `RECOMB_MODEL`.
2. It uses enums in the C code for `RECOMB_MODEL`.

## Summary by Sourcery

Switch recombination logic in the C and Python code to use the new RECOMB_MODEL enum and helper, removing remaining dependencies on the deprecated INHOMO_RECO flag.

Enhancements:
- Use RECOMB_MODEL enum constants and a uses_recombination helper throughout C recombination, ionization, halo, and mapping routines.
- Align global initialization and reference-printing utilities with the new RECOMB_MODEL API, including updated tests and comments.