### PR TITLE
Turnover mass are computed or extracted automatically in `cfuncs.py`

### DIFF
--- a/src/py21cmfast/drivers/global_evolution.py
+++ b/src/py21cmfast/drivers/global_evolution.py
@@ -59,15 +59,7 @@ def compute_global_reionization_at_z(
         #       When that happens, note that the call below to evaluate_Nion_z calls run_global_evolution,
         #       so be careful to avoid infinite recursion!
         nion, _ = evaluate_Nion_z(inputs=inputs, redshifts=np.asarray(redshift))
-        if inputs.matter_options.SOURCE_MODEL == "CONST-ION-EFF":
-            ion_eff_factor = inputs.astro_params.HII_EFF_FACTOR
-        else:
-            ion_eff_factor = (
-                pow(10.0, inputs.astro_params.F_STAR10)
-                * pow(10.0, inputs.astro_params.F_ESC10)
-                * inputs.astro_params.POP2_ION
-            )
-        Q_HI = 1.0 - ion_eff_factor * nion
+        Q_HI = 1.0 - nion
         # We don't need J_LW_21 because we currently don't allow to have mini-halos when USE_TS_FLUCT=False.
         # TODO: this limitation will be relaxed in the future, see https://github.com/21cmfast/21cmFAST/issues/600
         J_LW_21 = 0.0

--- a/src/py21cmfast/drivers/global_evolution.py
+++ b/src/py21cmfast/drivers/global_evolution.py
@@ -323,6 +323,7 @@ def run_global_evolution(
 
     new_input_kwargs = {
         "HIRES_TO_LOWRES_FACTOR": None,  # we set below DIM=HII_DIM=1
+        "LOWRES_CELL_SIZE_MPC": None,  # we set below to be equal to BOX_LEN since we have only one cell
         "DIM": 1,  # we need only one cell
         "HII_DIM": 1,  # we need only one cell
         "BOX_LEN": 1e6,  # we need a huge box/cell in order to simulate the global evolution

--- a/src/py21cmfast/drivers/global_evolution.py
+++ b/src/py21cmfast/drivers/global_evolution.py
@@ -12,7 +12,6 @@ from .. import __version__
 from ..io import h5
 from ..io.caching import CacheConfig
 from ..wrapper.arrays import Array
-from ..wrapper.cfuncs import compute_mturns, evaluate_Nion_z
 from ..wrapper.inputs import InputParameters
 from ..wrapper.outputs import (
     BrightnessTemp,
@@ -50,6 +49,8 @@ def compute_global_reionization_at_z(
     :class:`~IonizedBox` :
         An object containing the ionized box data.
     """
+    from ..wrapper.cfuncs import compute_mturns, evaluate_Nion_z
+
     box = IonizedBox.new(inputs=inputs, redshift=redshift)
     shape = (1, 1, 1)
 

--- a/src/py21cmfast/drivers/global_evolution.py
+++ b/src/py21cmfast/drivers/global_evolution.py
@@ -54,13 +54,11 @@ def compute_global_reionization_at_z(
 
     if spin_temp is None:
         # We compute Q_HI very similarly as in SpinTemperatureBox.c.
-        nion, _ = evaluate_Nion_z(
-            inputs=inputs,
-            redshifts=np.asarray(redshift),
-            # I just put here an arbitrary number because we currently don't allow to have mini-halos when USE_TS_FLUCT=False.
-            # TODO: this limitation be relaxed in the future, see https://github.com/21cmfast/21cmFAST/issues/600
-            log10mturns=np.asarray(5.0),
-        )
+        # TODO: We currently don't allow to have mini-halos when USE_TS_FLUCT=False.
+        #       This limitation however should be relaxed in the future, see https://github.com/21cmfast/21cmFAST/issues/600.
+        #       When that happens, note that the call below to evaluate_Nion_z calls run_global_evolution,
+        #       so be careful to avoid infinite recursion!
+        nion, _ = evaluate_Nion_z(inputs=inputs, redshifts=np.asarray(redshift))
         if inputs.matter_options.SOURCE_MODEL == "CONST-ION-EFF":
             ion_eff_factor = inputs.astro_params.HII_EFF_FACTOR
         else:
@@ -71,7 +69,7 @@ def compute_global_reionization_at_z(
             )
         Q_HI = 1.0 - ion_eff_factor * nion
         # We don't need J_LW_21 because we currently don't allow to have mini-halos when USE_TS_FLUCT=False.
-        # TODO: this limitation be relaxed in the future, see https://github.com/21cmfast/21cmFAST/issues/600
+        # TODO: this limitation will be relaxed in the future, see https://github.com/21cmfast/21cmFAST/issues/600
         J_LW_21 = 0.0
     else:
         Q_HI = spin_temp.Q_HI

--- a/src/py21cmfast/drivers/global_evolution.py
+++ b/src/py21cmfast/drivers/global_evolution.py
@@ -75,7 +75,11 @@ def compute_global_reionization_at_z(
         J_LW_21 = 0.0
     else:
         Q_HI = spin_temp.Q_HI
-        J_LW_21 = spin_temp.J_21_LW.value
+        J_LW_21 = (
+            np.squeeze(spin_temp.J_21_LW.value)
+            if spin_temp.J_21_LW is not None
+            else 0.0
+        )
 
     # TODO: I think a more accurate global Q_HI can be achieved by solving an ODE that includes also the recombination rate
     Q_HI = Q_HI if Q_HI > 0.0 else 0.0
@@ -89,7 +93,7 @@ def compute_global_reionization_at_z(
         dQdz = 0.0
     dzdt = -(1.0 + redshift) * inputs.cosmo_params.cosmo.H(redshift)
     ionisation_rate_G12 = np.abs(dQdz * dzdt)
-    ionisation_rate_G12 = ionisation_rate_G12.to("1/s").value
+    ionisation_rate_G12 = np.squeeze(ionisation_rate_G12.to("1/s").value)
     # TODO: is there a more clever way to estimate global z_reion?
     z_reion = -1.0 if Q_HI > 0.0 else redshift
 

--- a/src/py21cmfast/drivers/global_evolution.py
+++ b/src/py21cmfast/drivers/global_evolution.py
@@ -12,7 +12,7 @@ from .. import __version__
 from ..io import h5
 from ..io.caching import CacheConfig
 from ..wrapper.arrays import Array
-from ..wrapper.cfuncs import evaluate_Nion_z
+from ..wrapper.cfuncs import compute_mturns, evaluate_Nion_z
 from ..wrapper.inputs import InputParameters
 from ..wrapper.outputs import (
     BrightnessTemp,
@@ -58,7 +58,7 @@ def compute_global_reionization_at_z(
             inputs=inputs,
             redshifts=np.asarray(redshift),
             # I just put here an arbitrary number because we currently don't allow to have mini-halos when USE_TS_FLUCT=False.
-            # TODO: should this limitation be relaxed in the future?
+            # TODO: this limitation be relaxed in the future, see https://github.com/21cmfast/21cmFAST/issues/600
             log10mturns=np.asarray(5.0),
         )
         if inputs.matter_options.SOURCE_MODEL == "CONST-ION-EFF":
@@ -70,8 +70,12 @@ def compute_global_reionization_at_z(
                 * inputs.astro_params.POP2_ION
             )
         Q_HI = 1.0 - ion_eff_factor * nion
+        # We don't need J_LW_21 because we currently don't allow to have mini-halos when USE_TS_FLUCT=False.
+        # TODO: this limitation be relaxed in the future, see https://github.com/21cmfast/21cmFAST/issues/600
+        J_LW_21 = 0.0
     else:
         Q_HI = spin_temp.Q_HI
+        J_LW_21 = spin_temp.J_21_LW.value
 
     # TODO: I think a more accurate global Q_HI can be achieved by solving an ODE that includes also the recombination rate
     Q_HI = Q_HI if Q_HI > 0.0 else 0.0
@@ -85,13 +89,26 @@ def compute_global_reionization_at_z(
         dQdz = 0.0
     dzdt = -(1.0 + redshift) * inputs.cosmo_params.cosmo.H(redshift)
     ionisation_rate_G12 = np.abs(dQdz * dzdt)
+    ionisation_rate_G12 = ionisation_rate_G12.to("1/s").value
     # TODO: is there a more clever way to estimate global z_reion?
     z_reion = -1.0 if Q_HI > 0.0 else redshift
+
+    # Global v_cb is determined according to the flag FIX_VCB_AVG
+    v_cb = inputs.astro_params.FIXED_VAVG if inputs.astro_options.FIX_VCB_AVG else 0.0
+
+    M_turn_a, M_turn_m = compute_mturns(
+        inputs=inputs,
+        redshifts=redshift,
+        J_LW_21=J_LW_21,
+        v_cb=v_cb,
+        ionisation_rate_G12=ionisation_rate_G12,
+        z_reion=z_reion,
+    )
 
     # Now initialize the output box with the global values!
     required_arrays = {
         "neutral_fraction": Q_HI,
-        "ionisation_rate_G12": ionisation_rate_G12.to("1/s"),
+        "ionisation_rate_G12": ionisation_rate_G12,
         "z_reion": z_reion,
     }
     for name, val in required_arrays.items():
@@ -102,6 +119,8 @@ def compute_global_reionization_at_z(
             .initialize()
             .with_value(val=val * np.ones(shape)),
         )
+    box.log10_Mturnover_ave = np.log10(M_turn_a)
+    box.log10_Mturnover_MINI_ave = np.log10(M_turn_m)
     return box
 
 
@@ -132,7 +151,13 @@ class GlobalEvolution:
             possible_outputs.append(TsBox.new(inputs, redshift=0))
         if inputs.matter_options.lagrangian_source_grid:
             possible_outputs.append(HaloBox.new(inputs, redshift=0))
-        field_names = ("density", "neutral_fraction", "ionisation_rate_G12")
+        field_names = (
+            "density",
+            "neutral_fraction",
+            "ionisation_rate_G12",
+            "log10_mturn_acg",
+            "log10_mturn_mcg",
+        )
         for output in possible_outputs:
             field_names += tuple(output.arrays.keys())
         return field_names
@@ -368,9 +393,18 @@ def run_global_evolution(
         iokw=iokw,
     ):
         for quantity in global_evolution.quantities:
-            global_evolution.quantities[quantity][iz] = np.mean(
-                getattr(coeval, quantity)
-            )
+            if quantity == "log10_mturn_acg":
+                global_evolution.quantities[quantity][iz] = (
+                    coeval.ionized_box.log10_Mturnover_ave
+                )
+            elif quantity == "log10_mturn_mcg":
+                global_evolution.quantities[quantity][iz] = (
+                    coeval.ionized_box.log10_Mturnover_MINI_ave
+                )
+            else:
+                global_evolution.quantities[quantity][iz] = np.mean(
+                    getattr(coeval, quantity)
+                )
 
         prev_coeval = coeval
 

--- a/src/py21cmfast/drivers/global_evolution.py
+++ b/src/py21cmfast/drivers/global_evolution.py
@@ -18,6 +18,7 @@ from ..wrapper.outputs import (
     BrightnessTemp,
     HaloBox,
     IonizedBox,
+    PerturbedField,
     TsBox,
 )
 from .coeval import _redshift_loop_generator, _setup_ics_and_pfs_for_scrolling
@@ -139,19 +140,15 @@ class GlobalEvolution:
     def get_fields(cls, inputs: InputParameters) -> tuple:
         """Get a list of the names of the available fields in the simulation."""
         possible_outputs = [
+            PerturbedField.new(inputs, redshift=0),
+            IonizedBox.new(inputs, redshift=0),
             BrightnessTemp.new(inputs, redshift=0),
         ]
         if inputs.astro_options.USE_TS_FLUCT:
             possible_outputs.append(TsBox.new(inputs, redshift=0))
         if inputs.matter_options.lagrangian_source_grid:
             possible_outputs.append(HaloBox.new(inputs, redshift=0))
-        field_names = (
-            "density",
-            "neutral_fraction",
-            "ionisation_rate_G12",
-            "log10_mturn_acg",
-            "log10_mturn_mcg",
-        )
+        field_names = ("log10_mturn_acg", "log10_mturn_mcg")
         for output in possible_outputs:
             field_names += tuple(output.arrays.keys())
         return field_names

--- a/src/py21cmfast/src/PerturbedField.c
+++ b/src/py21cmfast/src/PerturbedField.c
@@ -464,15 +464,17 @@ int ComputePerturbedField(float redshift, InitialConditions *boxes,
         }
 
         // ****  Convert to velocities ***** //
-        // We re-use fft_density_grid to hold the FFTW velocity field
-        if (matter_options_global->KEEP_3D_VELOCITIES) {
-            compute_perturbed_velocities(0, redshift, density_perturb_saved, fft_density_grid,
-                                         perturbed_field->velocity_x);
-            compute_perturbed_velocities(1, redshift, density_perturb_saved, fft_density_grid,
-                                         perturbed_field->velocity_y);
+        if (simulation_options_global->HII_DIM > 1) {
+            // We re-use fft_density_grid to hold the FFTW velocity field
+            if (matter_options_global->KEEP_3D_VELOCITIES) {
+                compute_perturbed_velocities(0, redshift, density_perturb_saved, fft_density_grid,
+                                             perturbed_field->velocity_x);
+                compute_perturbed_velocities(1, redshift, density_perturb_saved, fft_density_grid,
+                                             perturbed_field->velocity_y);
+            }
+            compute_perturbed_velocities(2, redshift, density_perturb_saved, fft_density_grid,
+                                         perturbed_field->velocity_z);
         }
-        compute_perturbed_velocities(2, redshift, density_perturb_saved, fft_density_grid,
-                                     perturbed_field->velocity_z);
 
         fftwf_cleanup_threads();
         fftwf_cleanup();

--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -983,7 +983,7 @@ int global_reion_properties(double zp, double x_e_ave, double *log10_Mcrit_LW_av
         ION_EFF_FACTOR_MINI = astro_params_global->F_STAR7_MINI * astro_params_global->F_ESC7_MINI *
                               astro_params_global->POP3_ION;
     } else {
-        // no mini-halos when SOURCE_MODEL=0 (constant ionization efficiency)
+        // no mini-halos when SOURCE_MODE is mass independent (constant ionization efficiency)
         ION_EFF_FACTOR = astro_params_global->HII_EFF_FACTOR;
     }
 

--- a/src/py21cmfast/src/_functionprototypes_wrapper.h
+++ b/src/py21cmfast/src/_functionprototypes_wrapper.h
@@ -105,7 +105,7 @@ void get_conditional_FgtrM(double redshift, double R, int n_densities, double *d
 void get_conditional_SFRD(double redshift, double R, int n_densities, double *densities,
                           double log10_mturns_mini, double *out_sfrd, double *out_sfrd_mini);
 void get_conditional_Nion(double redshift, double R, int n_densities, double *densities,
-                          double *log10_mturns_acg, double *log10_mturns_mcg, double *out_nion,
+                          double log10_mturn_acg, double log10_mturn_mcg, double *out_nion,
                           double *out_nion_mini);
 void get_conditional_Xray(double redshift, double R, int n_densities, double *densities,
                           double log10_mturns_mini, double *out_xray);

--- a/src/py21cmfast/src/_functionprototypes_wrapper.h
+++ b/src/py21cmfast/src/_functionprototypes_wrapper.h
@@ -108,7 +108,7 @@ void get_conditional_Nion(double redshift, double R, int n_densities, double *de
                           double *log10_mturns_acg, double *log10_mturns_mcg, double *out_nion,
                           double *out_nion_mini);
 void get_conditional_Xray(double redshift, double R, int n_densities, double *densities,
-                          double *log10_mturns, double *out_xray);
+                          double log10_mturns_mini, double *out_xray);
 /*--------------------------------*/
 
 /* Error framework testing */

--- a/src/py21cmfast/src/_functionprototypes_wrapper.h
+++ b/src/py21cmfast/src/_functionprototypes_wrapper.h
@@ -103,7 +103,7 @@ void get_global_Nion_z(int n_redshift, double *redshifts, double *log10_turnover
 void get_conditional_FgtrM(double redshift, double R, int n_densities, double *densities,
                            double *out_fcoll, double *out_dfcoll);
 void get_conditional_SFRD(double redshift, double R, int n_densities, double *densities,
-                          double *log10_mturns, double *out_sfrd, double *out_sfrd_mini);
+                          double log10_mturns_mini, double *out_sfrd, double *out_sfrd_mini);
 void get_conditional_Nion(double redshift, double R, int n_densities, double *densities,
                           double *log10_mturns_acg, double *log10_mturns_mcg, double *out_nion,
                           double *out_nion_mini);

--- a/src/py21cmfast/src/_functionprototypes_wrapper.h
+++ b/src/py21cmfast/src/_functionprototypes_wrapper.h
@@ -146,4 +146,6 @@ double atomic_cooling_threshold(float z);
 double unconditional_hmf(double growthf, double lnM, double z, int HMF);
 double conditional_hmf(double growthf, double lnM, double delta, double sigma, int HMF);
 double expected_nhalo(double redshift);
+void compute_mturns(float z, float J_21_LW, float vcb, float Gamma12, float z_reion,
+                    double *M_turn_a, double *M_turn_m);
 /*-----------------------*/

--- a/src/py21cmfast/src/integral_wrappers.c
+++ b/src/py21cmfast/src/integral_wrappers.c
@@ -323,10 +323,13 @@ void get_conditional_Xray(double redshift, double R, int n_densities, double *de
         if (dens > max_dens) max_dens = dens;
     }
 
+    double X_RAY_FACTOR = RHOcrit * cosmo_params_global->OMm * 1e38;
+
     if (uses_hmf_interpolation(matter_options_global->USE_INTERPOLATION_TABLES)) {
         initialise_Xray_Conditional_table(redshift, min_dens, max_dens, M_min, M_cond, M_cond, &sc);
     }
     for (i = 0; i < n_densities; i++)
-        out_xray[i] = EvaluateXray_Conditional(densities[i], log10_mturn_mini, redshift, growthf,
-                                               M_min, M_cond, M_cond, sigma_cond, &sc);
+        out_xray[i] = X_RAY_FACTOR * EvaluateXray_Conditional(densities[i], log10_mturn_mini,
+                                                              redshift, growthf, M_min, M_cond,
+                                                              M_cond, sigma_cond, &sc);
 }

--- a/src/py21cmfast/src/integral_wrappers.c
+++ b/src/py21cmfast/src/integral_wrappers.c
@@ -212,7 +212,7 @@ void get_conditional_SFRD(double redshift, double R, int n_densities, double *de
 }
 
 void get_conditional_Nion(double redshift, double R, int n_densities, double *densities,
-                          double *log10_mturns_acg, double *log10_mturns_mcg, double *out_nion,
+                          double log10_mturn_acg, double log10_mturn_mcg, double *out_nion,
                           double *out_nion_mini) {
     double M_min = minimum_source_mass(redshift, true);
     double M_cond = RtoM(R);
@@ -237,8 +237,8 @@ void get_conditional_Nion(double redshift, double R, int n_densities, double *de
     double dens, l10mturn_a, l10mturn_m;
     for (i = 0; i < n_densities; i++) {
         dens = densities[i];
-        l10mturn_a = log10_mturns_acg[i];
-        l10mturn_m = log10_mturns_mcg[i];
+        l10mturn_a = log10_mturn_acg;
+        l10mturn_m = log10_mturn_mcg;
         if (dens < min_dens) min_dens = dens;
         if (dens > max_dens) max_dens = dens;
         if (l10mturn_a < min_l10mturn_acg) min_l10mturn_acg = l10mturn_a;
@@ -253,13 +253,13 @@ void get_conditional_Nion(double redshift, double R, int n_densities, double *de
                                            max_l10mturn_mcg, &sc, false);
     }
     for (i = 0; i < n_densities; i++)
-        out_nion[i] = EvaluateNion_Conditional(densities[i], log10_mturns_acg[i], growthf, M_min,
+        out_nion[i] = EvaluateNion_Conditional(densities[i], log10_mturn_acg, growthf, M_min,
                                                M_cond, M_cond, sigma_cond, &sc, false);
     if (astro_options_global->USE_MINI_HALOS) {
         for (i = 0; i < n_densities; i++)
             out_nion_mini[i] =
-                EvaluateNion_Conditional_MINI(densities[i], log10_mturns_mcg[i], growthf, M_min,
-                                              M_cond, M_cond, sigma_cond, &sc, false);
+                EvaluateNion_Conditional_MINI(densities[i], log10_mturn_mcg, growthf, M_min, M_cond,
+                                              M_cond, sigma_cond, &sc, false);
     }
 }
 

--- a/src/py21cmfast/src/integral_wrappers.c
+++ b/src/py21cmfast/src/integral_wrappers.c
@@ -230,22 +230,18 @@ void get_conditional_Nion(double redshift, double R, int n_densities, double *de
     int i;
     double min_dens = -1;
     double max_dens = 10;
-    double min_l10mturn_acg = 10.;
-    double min_l10mturn_mcg = 10.;
-    double max_l10mturn_acg = 5.;
-    double max_l10mturn_mcg = 5.;
     double dens, l10mturn_a, l10mturn_m;
     for (i = 0; i < n_densities; i++) {
         dens = densities[i];
-        l10mturn_a = log10_mturn_acg;
-        l10mturn_m = log10_mturn_mcg;
         if (dens < min_dens) min_dens = dens;
         if (dens > max_dens) max_dens = dens;
-        if (l10mturn_a < min_l10mturn_acg) min_l10mturn_acg = l10mturn_a;
-        if (l10mturn_a > max_l10mturn_acg) max_l10mturn_acg = l10mturn_a;
-        if (l10mturn_m < min_l10mturn_mcg) min_l10mturn_mcg = l10mturn_m;
-        if (l10mturn_m > max_l10mturn_mcg) max_l10mturn_mcg = l10mturn_m;
     }
+
+    double eps = 0.01;
+    double min_l10mturn_acg = log10_mturn_acg - eps;
+    double max_l10mturn_acg = log10_mturn_acg + eps;
+    double min_l10mturn_mcg = log10_mturn_mcg - eps;
+    double max_l10mturn_mcg = log10_mturn_mcg + eps;
 
     if (uses_hmf_interpolation(matter_options_global->USE_INTERPOLATION_TABLES)) {
         initialise_Nion_Conditional_spline(redshift, min_dens, max_dens, M_min, M_cond, M_cond,

--- a/src/py21cmfast/src/integral_wrappers.c
+++ b/src/py21cmfast/src/integral_wrappers.c
@@ -174,7 +174,7 @@ void get_conditional_FgtrM(double redshift, double R, int n_densities, double *d
 }
 
 void get_conditional_SFRD(double redshift, double R, int n_densities, double *densities,
-                          double *log10_mturns, double *out_sfrd, double *out_sfrd_mini) {
+                          double log10_mturns_mini, double *out_sfrd, double *out_sfrd_mini) {
     double M_min = minimum_source_mass(redshift, true);
     double M_cond = RtoM(R);
     double sigma_cond = EvaluateSigma(log(M_cond));
@@ -207,7 +207,7 @@ void get_conditional_SFRD(double redshift, double R, int n_densities, double *de
     if (astro_options_global->USE_MINI_HALOS) {
         for (i = 0; i < n_densities; i++)
             out_sfrd_mini[i] = EvaluateSFRD_Conditional_MINI(
-                densities[i], log10_mturns[i], growthf, M_min, M_cond, M_cond, sigma_cond, &sc);
+                densities[i], log10_mturns_mini, growthf, M_min, M_cond, M_cond, sigma_cond, &sc);
     }
 }
 

--- a/src/py21cmfast/src/integral_wrappers.c
+++ b/src/py21cmfast/src/integral_wrappers.c
@@ -104,6 +104,8 @@ void get_global_SFRD_z(int n_redshift, double *redshifts, double *log10_turnover
     int i;
     double z_min = simulation_options_global->Z_HEAT_MAX;
     double z_max = 0.;
+    double SFRD_FACTOR, SFRD_FACTOR_MINI;
+
     for (i = 0; i < n_redshift; i++) {
         if (redshifts[i] < z_min) z_min = redshifts[i];
         if (redshifts[i] > z_max) z_max = redshifts[i];
@@ -114,9 +116,15 @@ void get_global_SFRD_z(int n_redshift, double *redshifts, double *log10_turnover
     }
 
     for (i = 0; i < n_redshift; i++) {
-        out_sfrd[i] = EvaluateSFRD(redshifts[i], &sc);
-        if (astro_options_global->USE_MINI_HALOS)
-            out_sfrd_mini[i] = EvaluateSFRD_MINI(redshifts[i], log10_turnovers_mcg[i], &sc);
+        SFRD_FACTOR = astro_params_global->F_STAR10 * cosmo_params_global->OMb * RHOcrit /
+                      astro_params_global->t_STAR / t_hubble(redshifts[i]);
+        out_sfrd[i] = SFRD_FACTOR * EvaluateSFRD(redshifts[i], &sc);
+        if (astro_options_global->USE_MINI_HALOS) {
+            SFRD_FACTOR_MINI = astro_params_global->F_STAR7_MINI * cosmo_params_global->OMb *
+                               RHOcrit / astro_params_global->t_STAR / t_hubble(redshifts[i]);
+            out_sfrd_mini[i] =
+                SFRD_FACTOR_MINI * EvaluateSFRD_MINI(redshifts[i], log10_turnovers_mcg[i], &sc);
+        }
     }
 }
 
@@ -204,6 +212,11 @@ void get_conditional_SFRD(double redshift, double R, int n_densities, double *de
     double min_dens = -1;
     double max_dens = 10;
     double dens;
+    double SFRD_FACTOR = astro_params_global->F_STAR10 * cosmo_params_global->OMb * RHOcrit /
+                         astro_params_global->t_STAR / t_hubble(redshift);
+    double SFRD_FACTOR_MINI = astro_params_global->F_STAR7_MINI * cosmo_params_global->OMb *
+                              RHOcrit / astro_params_global->t_STAR / t_hubble(redshift);
+
     for (i = 0; i < n_densities; i++) {
         dens = densities[i];
         if (dens < min_dens) min_dens = dens;
@@ -213,13 +226,14 @@ void get_conditional_SFRD(double redshift, double R, int n_densities, double *de
     if (uses_hmf_interpolation(matter_options_global->USE_INTERPOLATION_TABLES)) {
         initialise_SFRD_Conditional_table(redshift, min_dens, max_dens, M_min, M_cond, M_cond, &sc);
     }
-    for (i = 0; i < n_densities; i++)
-        out_sfrd[i] =
-            EvaluateSFRD_Conditional(densities[i], growthf, M_min, M_cond, M_cond, sigma_cond, &sc);
-    if (astro_options_global->USE_MINI_HALOS) {
-        for (i = 0; i < n_densities; i++)
-            out_sfrd_mini[i] = EvaluateSFRD_Conditional_MINI(
-                densities[i], log10_mturn_mini, growthf, M_min, M_cond, M_cond, sigma_cond, &sc);
+    for (i = 0; i < n_densities; i++) {
+        out_sfrd[i] = SFRD_FACTOR * EvaluateSFRD_Conditional(densities[i], growthf, M_min, M_cond,
+                                                             M_cond, sigma_cond, &sc);
+        if (astro_options_global->USE_MINI_HALOS) {
+            out_sfrd_mini[i] = SFRD_FACTOR_MINI * EvaluateSFRD_Conditional_MINI(
+                                                      densities[i], log10_mturn_mini, growthf,
+                                                      M_min, M_cond, M_cond, sigma_cond, &sc);
+        }
     }
 }
 

--- a/src/py21cmfast/src/integral_wrappers.c
+++ b/src/py21cmfast/src/integral_wrappers.c
@@ -174,7 +174,7 @@ void get_conditional_FgtrM(double redshift, double R, int n_densities, double *d
 }
 
 void get_conditional_SFRD(double redshift, double R, int n_densities, double *densities,
-                          double log10_mturns_mini, double *out_sfrd, double *out_sfrd_mini) {
+                          double log10_mturn_mini, double *out_sfrd, double *out_sfrd_mini) {
     double M_min = minimum_source_mass(redshift, true);
     double M_cond = RtoM(R);
     double sigma_cond = EvaluateSigma(log(M_cond));
@@ -207,7 +207,7 @@ void get_conditional_SFRD(double redshift, double R, int n_densities, double *de
     if (astro_options_global->USE_MINI_HALOS) {
         for (i = 0; i < n_densities; i++)
             out_sfrd_mini[i] = EvaluateSFRD_Conditional_MINI(
-                densities[i], log10_mturns_mini, growthf, M_min, M_cond, M_cond, sigma_cond, &sc);
+                densities[i], log10_mturn_mini, growthf, M_min, M_cond, M_cond, sigma_cond, &sc);
     }
 }
 
@@ -264,7 +264,7 @@ void get_conditional_Nion(double redshift, double R, int n_densities, double *de
 }
 
 void get_conditional_Xray(double redshift, double R, int n_densities, double *densities,
-                          double *log10_mturns, double *out_xray) {
+                          double log10_mturn_mini, double *out_xray) {
     double M_min = minimum_source_mass(redshift, true);
     double M_cond = RtoM(R);
     double sigma_cond = EvaluateSigma(log(M_cond));
@@ -292,6 +292,6 @@ void get_conditional_Xray(double redshift, double R, int n_densities, double *de
         initialise_Xray_Conditional_table(redshift, min_dens, max_dens, M_min, M_cond, M_cond, &sc);
     }
     for (i = 0; i < n_densities; i++)
-        out_xray[i] = EvaluateXray_Conditional(densities[i], log10_mturns[i], redshift, growthf,
+        out_xray[i] = EvaluateXray_Conditional(densities[i], log10_mturn_mini, redshift, growthf,
                                                M_min, M_cond, M_cond, sigma_cond, &sc);
 }

--- a/src/py21cmfast/src/integral_wrappers.c
+++ b/src/py21cmfast/src/integral_wrappers.c
@@ -133,13 +133,25 @@ void get_global_Nion_z(int n_redshift, double *redshifts, double *log10_turnover
         if (redshifts[i] > z_max) z_max = redshifts[i];
     }
 
+    double ION_EFF_FACTOR, ION_EFF_FACTOR_MINI;
+    if (source_model_is_mass_dependent(matter_options_global->SOURCE_MODEL)) {
+        ION_EFF_FACTOR = astro_params_global->F_STAR10 * astro_params_global->F_ESC10 *
+                         astro_params_global->POP2_ION;
+        ION_EFF_FACTOR_MINI = astro_params_global->F_STAR7_MINI * astro_params_global->F_ESC7_MINI *
+                              astro_params_global->POP3_ION;
+    } else {
+        // no mini-halos when SOURCE_MODE is mass independent (constant ionization efficiency)
+        ION_EFF_FACTOR = astro_params_global->HII_EFF_FACTOR;
+    }
+
     if (uses_hmf_interpolation(matter_options_global->USE_INTERPOLATION_TABLES)) {
         initialise_Nion_Ts_spline(zpp_interp_points_SFR, z_min, z_max + 0.01, &sc);
     }
     for (i = 0; i < n_redshift; i++) {
-        out_nion[i] = EvaluateNionTs(redshifts[i], &sc);
+        out_nion[i] = ION_EFF_FACTOR * EvaluateNionTs(redshifts[i], &sc);
         if (astro_options_global->USE_MINI_HALOS)
-            out_nion_mini[i] = EvaluateNionTs_MINI(redshifts[i], log10_turnovers_mcg[i], &sc);
+            out_nion_mini[i] = ION_EFF_FACTOR_MINI *
+                               EvaluateNionTs_MINI(redshifts[i], log10_turnovers_mcg[i], &sc);
     }
 }
 
@@ -243,19 +255,32 @@ void get_conditional_Nion(double redshift, double R, int n_densities, double *de
     double min_l10mturn_mcg = log10_mturn_mcg - eps;
     double max_l10mturn_mcg = log10_mturn_mcg + eps;
 
+    double ION_EFF_FACTOR, ION_EFF_FACTOR_MINI;
+    if (source_model_is_mass_dependent(matter_options_global->SOURCE_MODEL)) {
+        ION_EFF_FACTOR = astro_params_global->F_STAR10 * astro_params_global->F_ESC10 *
+                         astro_params_global->POP2_ION;
+        ION_EFF_FACTOR_MINI = astro_params_global->F_STAR7_MINI * astro_params_global->F_ESC7_MINI *
+                              astro_params_global->POP3_ION;
+    } else {
+        // no mini-halos when SOURCE_MODE is mass independent (constant ionization efficiency)
+        ION_EFF_FACTOR = astro_params_global->HII_EFF_FACTOR;
+    }
+
     if (uses_hmf_interpolation(matter_options_global->USE_INTERPOLATION_TABLES)) {
         initialise_Nion_Conditional_spline(redshift, min_dens, max_dens, M_min, M_cond, M_cond,
                                            min_l10mturn_acg, max_l10mturn_acg, min_l10mturn_mcg,
                                            max_l10mturn_mcg, &sc, false);
     }
     for (i = 0; i < n_densities; i++)
-        out_nion[i] = EvaluateNion_Conditional(densities[i], log10_mturn_acg, growthf, M_min,
-                                               M_cond, M_cond, sigma_cond, &sc, false);
+        out_nion[i] =
+            ION_EFF_FACTOR * EvaluateNion_Conditional(densities[i], log10_mturn_acg, growthf, M_min,
+                                                      M_cond, M_cond, sigma_cond, &sc, false);
     if (astro_options_global->USE_MINI_HALOS) {
         for (i = 0; i < n_densities; i++)
             out_nion_mini[i] =
-                EvaluateNion_Conditional_MINI(densities[i], log10_mturn_mcg, growthf, M_min, M_cond,
-                                              M_cond, sigma_cond, &sc, false);
+                ION_EFF_FACTOR_MINI * EvaluateNion_Conditional_MINI(densities[i], log10_mturn_mcg,
+                                                                    growthf, M_min, M_cond, M_cond,
+                                                                    sigma_cond, &sc, false);
     }
 }
 

--- a/src/py21cmfast/src/thermochem.c
+++ b/src/py21cmfast/src/thermochem.c
@@ -305,3 +305,13 @@ double reionization_feedback(float z, float Gamma_halo_HII, float z_IN) {
            pow((1. + z) / 10, REION_SM13_B) *
            pow(1 - pow((1. + z) / (1. + z_IN), REION_SM13_C), REION_SM13_D);
 }
+
+void compute_mturns(float z, float J_21_LW, float vcb, float Gamma12, float z_reion,
+                    double *M_turn_a, double *M_turn_m) {
+    double M_turn_r = reionization_feedback(z, Gamma12, z_reion);
+    *M_turn_a = atomic_cooling_threshold(z);
+    *M_turn_m = lyman_werner_threshold(z, J_21_LW, vcb);
+    *M_turn_a = fmax(*M_turn_a, fmax(M_turn_r, astro_params_global->M_TURN));
+    *M_turn_m = fmax(*M_turn_m, fmax(M_turn_r, astro_params_global->M_TURN));
+    return;
+}

--- a/src/py21cmfast/src/thermochem.h
+++ b/src/py21cmfast/src/thermochem.h
@@ -20,5 +20,7 @@ double HeI_ion_crosssec(double nu);
 double HeII_ion_crosssec(double nu);
 double HI_ion_crosssec(double nu);
 double neutral_fraction(double density, double T4, double gamma, int usecaseB);
+void compute_mturns(float z, float J_21_LW, float vcb, float Gamma12, float z_reion,
+                    double *M_turn_a, double *M_turn_m);
 
 #endif

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -114,26 +114,23 @@ def compute_mturns(
     Raises
     ------
     ValueError :
-        If the input arrays do not have the same length.
+        If the input arrays do not have the same shape.
     """
-    lengths = {
-        len(x)
-        for x in (redshifts, J_LW_21, v_cb, ionisation_rate_G12, z_reion)
-        if hasattr(x, "__len__")
+    inputs_to_check = {
+        "J_LW_21": J_LW_21,
+        "v_cb": v_cb,
+        "ionisation_rate_G12": ionisation_rate_G12,
+        "z_reion": z_reion,
     }
-    if len(lengths) > 1:
-        raise ValueError(
-            "All input arrays must have the same length, got lengths: "
-            + ", ".join(
-                f"{name}={len(x)}"
-                for name, x in zip(
-                    ("redshifts", "J_LW_21", "v_cb", "ionisation_rate_G12", "z_reion"),
-                    (redshifts, J_LW_21, v_cb, ionisation_rate_G12, z_reion),
-                    strict=False,
-                )
-                if hasattr(x, "__len__")
+
+    redshifts_shape = np.asarray(redshifts).shape
+    for name, value in inputs_to_check.items():
+        current_shape = np.asarray(value).shape
+        if current_shape != redshifts_shape:
+            raise ValueError(
+                f"The shapes of redshifts and {name} are not the same! "
+                f"Got {redshifts_shape} and {current_shape}."
             )
-        )
 
     M_turn_a_ffi = ffi.new("double *")
     M_turn_m_ffi = ffi.new("double *")
@@ -705,16 +702,50 @@ def evaluate_SFRD_cond(
     redshift: float,
     radius: float,
     densities: NDArray[np.floating],
-    log10mturns: NDArray[np.floating],
+    lightcone: LightCone | None = None,
 ):
-    """Evaluate the conditional star formation rate density expected at a range of densities."""
-    if densities.shape != log10mturns.shape:
-        raise ValueError(
-            "the shapes of the input arrays `densities` and `log10mturns` must be equal"
-        )
+    """
+    Evaluate the conditional star formation rate density expected at a range of densities.
+
+    For now, it returns a dimensionless SFRD. TODO: fix this!
+
+    Parameters
+    ----------
+    inputs: :class:`~InputParameters`
+        The input parameters defining the simulation run.
+    redshift : float
+        The redshift at which to compute the SFRD.
+    radius : float
+        The radius at which to compute the conditional SFRD.
+    densities : array-like
+        The densities at which to compute the conditional SFRD.
+    lightcone : :class:`~LightCone` or None, optional
+        The lightcone object to use for the computation.
+        If None, the function will estimate the global m_turnover values,
+        otherwise they will be extracted from the given lightcone.
+
+    Returns
+    -------
+    sfrd : np.ndarray
+        The conditional star formation rate density at the given redshift and radius for ACGs.
+    sfrd_mini : np.ndarray
+        The conditional star formation rate density at the given redshift and radius for MCGs.
+    """
+    if lightcone is not None:
+        log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+    else:
+        from ..drivers.global_evolution import run_global_evolution
+
+        # If lightcone is not provided, we estimate the turnover masses from the global evolution
+        global_evolution = run_global_evolution(inputs=inputs)
+        log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
+
+    log10mturns_mini = np.interp(
+        redshift, inputs.node_redshifts, log10mturns_mini_global
+    )
 
     densities = densities.astype("f8")
-    log10mturns = log10mturns.astype("f8")
+    log10mturns_mini = np.full_like(densities, log10mturns_mini, dtype="f8")
     sfrd = np.zeros_like(densities)
     sfrd_mini = np.zeros_like(densities)
 
@@ -723,7 +754,7 @@ def evaluate_SFRD_cond(
         radius,
         densities.size,
         ffi.cast("double *", ffi.from_buffer(densities)),
-        ffi.cast("double *", ffi.from_buffer(log10mturns)),
+        ffi.cast("double *", ffi.from_buffer(log10mturns_mini)),
         ffi.cast("double *", ffi.from_buffer(sfrd)),
         ffi.cast("double *", ffi.from_buffer(sfrd_mini)),
     )

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -716,7 +716,7 @@ def evaluate_SFRD_cond(
     redshift : float
         The redshift at which to compute the SFRD.
     radius : float
-        The radius at which to compute the conditional SFRD.
+        The radius of the region at which to compute the conditional SFRD.
     densities : array-like
         The densities at which to compute the conditional SFRD.
     lightcone : :class:`~LightCone` or None, optional
@@ -740,7 +740,7 @@ def evaluate_SFRD_cond(
         global_evolution = run_global_evolution(inputs=inputs)
         log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
-    log10mturns_mini = np.interp(
+    log10mturn_mini = np.interp(
         redshift, inputs.node_redshifts, log10mturns_mini_global
     )
 
@@ -753,7 +753,7 @@ def evaluate_SFRD_cond(
         radius,
         densities.size,
         ffi.cast("double *", ffi.from_buffer(densities)),
-        log10mturns_mini,
+        log10mturn_mini,
         ffi.cast("double *", ffi.from_buffer(sfrd)),
         ffi.cast("double *", ffi.from_buffer(sfrd_mini)),
     )
@@ -804,29 +804,59 @@ def evaluate_Xray_cond(
     redshift: float,
     radius: float,
     densities: NDArray[np.floating],
-    log10mturns: NDArray[np.floating],
+    lightcone: LightCone | None = None,
 ):
-    """Evaluate the conditional star formation rate density expected at a range of densities."""
-    if densities.shape != log10mturns.shape:
-        raise ValueError(
-            "the shapes of the input arrays `cond_array` and `probabilities"
-            " must be equal."
-        )
+    """
+    Evaluate the conditional X-ray luminosity expected at a range of densities.
+
+    For now, it returns X-ray luminosity in units of 1e-38 erg/s/rho_m. TODO: fix this!
+
+    Parameters
+    ----------
+    inputs: :class:`~InputParameters`
+        The input parameters defining the simulation run.
+    redshift : float
+        The redshift at which to compute the conditional X-ray luminosity.
+    radius : float
+        The radius of the region at which to compute the conditional X-ray luminosity.
+    densities : array-like
+        The densities at which to compute the conditional X-ray luminosity.
+    lightcone : :class:`~LightCone` or None, optional
+        The lightcone object to use for the computation.
+        If None, the function will estimate the global m_turnover values,
+        otherwise they will be extracted from the given lightcone.
+
+    Returns
+    -------
+    xray_luminosity : np.ndarray
+        The conditional X-ray luminosity at the given redshift and radius for ACGs and MCGs combined.
+    """
+    if lightcone is not None:
+        log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+    else:
+        from ..drivers.global_evolution import run_global_evolution
+
+        # If lightcone is not provided, we estimate the turnover masses from the global evolution
+        global_evolution = run_global_evolution(inputs=inputs)
+        log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
+
+    log10mturn_mini = np.interp(
+        redshift, inputs.node_redshifts, log10mturns_mini_global
+    )
 
     densities = densities.astype("f8")
-    log10mturns = log10mturns.astype("f8")
-    xray = np.zeros_like(densities)
+    xray_luminosity = np.zeros_like(densities)
 
     lib.get_conditional_Xray(
         redshift,
         radius,
         densities.size,
         ffi.cast("double *", ffi.from_buffer(densities)),
-        ffi.cast("double *", ffi.from_buffer(log10mturns)),
-        ffi.cast("double *", ffi.from_buffer(xray)),
+        log10mturn_mini,
+        ffi.cast("double *", ffi.from_buffer(xray_luminosity)),
     )
 
-    return xray
+    return xray_luminosity
 
 
 @init_c_state(sigma=True)

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -88,7 +88,7 @@ def compute_mturns(
     v_cb: float | Sequence[float],
     ionisation_rate_G12: float | Sequence[float],
     z_reion: float | Sequence[float],
-):
+) -> tuple[float, float]:
     """
     Compute the turnover masses for both ACGs and MCGs at a given redshift.
 
@@ -252,7 +252,8 @@ def compute_luminosity_function(
     if (mturnovers is not None) or (mturnovers_mini is not None):
         raise TypeError(
             "`mturnovers` and `mturnovers_mini` have been removed. "
-            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+            "Please use the `lightcone` or `global_evolution` arguments instead, "
+            "or leave unspecified and they will be estimated automatically."
         )
 
     if not astro_options.USE_MINI_HALOS and component != "acg":
@@ -659,7 +660,8 @@ def evaluate_SFRD_z(
     if log10mturns is not None:
         raise TypeError(
             "`log10mturns` has been removed. "
-            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+            "Please use the `lightcone` or `global_evolution` arguments instead, "
+            "or leave unspecified and they will be estimated automatically."
         )
 
     if inputs.astro_options.USE_MINI_HALOS:
@@ -733,7 +735,8 @@ def evaluate_Nion_z(
     if log10mturns is not None:
         raise TypeError(
             "`log10mturns` has been removed. "
-            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+            "Please use the `lightcone` or `global_evolution` arguments instead, "
+            "or leave unspecified and they will be estimated automatically."
         )
 
     if inputs.astro_options.USE_MINI_HALOS:
@@ -814,7 +817,8 @@ def evaluate_SFRD_cond(
     if log10mturns is not None:
         raise TypeError(
             "`log10mturns` has been removed. "
-            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+            "Please use the `lightcone` or `global_evolution` arguments instead, "
+            "or leave unspecified and they will be estimated automatically."
         )
 
     if inputs.astro_options.USE_MINI_HALOS:
@@ -897,7 +901,8 @@ def evaluate_Nion_cond(
     if (l10mturns_acg is not None) or (l10mturns_mcg is not None):
         raise TypeError(
             "`l10mturns_acg` and `l10mturns_mcg` have been removed. "
-            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+            "Please use the `lightcone` or `global_evolution` arguments instead, "
+            "or leave unspecified and they will be estimated automatically."
         )
 
     # TODO: Why this function is the only one that needs the global mturnover values for ACGs?
@@ -980,7 +985,8 @@ def evaluate_Xray_cond(
     if log10mturns is not None:
         raise TypeError(
             "`log10mturns` has been removed. "
-            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+            "Please use the `lightcone` or `global_evolution` arguments instead, "
+            "or leave unspecified and they will be estimated automatically."
         )
 
     if inputs.astro_options.USE_MINI_HALOS:

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -714,7 +714,7 @@ def evaluate_Nion_z(
     else:
         log10mturns_mini = np.zeros_like(redshifts)  # dummy value for no mini halos
 
-    redshifts = redshifts.astype("f8")
+    redshifts = np.asarray(redshifts).astype("f8")
     log10mturns_mini = log10mturns_mini.astype("f8")
     nion = np.zeros_like(redshifts)
     nion_mini = np.zeros_like(redshifts)
@@ -806,18 +806,51 @@ def evaluate_Nion_cond(
     redshift: float,
     radius: float,
     densities: NDArray[np.floating],
-    l10mturns_acg: NDArray[np.floating],
-    l10mturns_mcg: NDArray[np.floating],
+    lightcone: LightCone | None = None,
 ):
-    """Evaluate the conditional ionising emissivity expected at a range of densities."""
-    if not (densities.shape == l10mturns_mcg.shape == l10mturns_acg.shape):
-        raise ValueError(
-            "the shapes of the input arrays `densities` and `log10mturns_x` must be equal"
-        )
+    """
+    Evaluate the global number of ionising photons per baryon, expected at a range of densities.
+
+    For now, it returns a dimensionless Nion. TODO: fix this!
+
+    Parameters
+    ----------
+    inputs: :class:`~InputParameters`
+        The input parameters defining the simulation run.
+    redshift : float
+        The redshift at which to compute Nion.
+    radius : float
+        The radius of the region at which to compute the conditional Nion.
+    densities : array-like
+        The densities at which to compute the conditional Nion.
+    lightcone : :class:`~LightCone` or None, optional
+        The lightcone object to use for the computation.
+        If None, the function will estimate the global m_turnover values,
+        otherwise they will be extracted from the given lightcone.
+
+    Returns
+    -------
+    nion : np.ndarray
+        The conditional number of ionising photons per baryon at the given redshift and radius for ACGs.
+    nion_mini : np.ndarray
+        The conditional number of ionising photons per baryon at the given redshift and radius for MCGs.
+    """
+    # TODO: Why this function is the only one that needs the global mturnover values for ACGs?
+    if lightcone is not None:
+        log10mturns_global = lightcone.global_quantities["log10_mturn_acg"]
+        log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+    else:
+        from ..drivers.global_evolution import run_global_evolution
+
+        # If lightcone is not provided, we estimate the turnover masses from the global evolution
+        global_evolution = run_global_evolution(inputs=inputs)
+        log10mturns_global = global_evolution.quantities["log10_mturn_acg"]
+        log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
+
+    log10mturn_acg = np.interp(redshift, inputs.node_redshifts, log10mturns_global)
+    log10mturn_mcg = np.interp(redshift, inputs.node_redshifts, log10mturns_mini_global)
 
     densities = densities.astype("f8")
-    l10mturns_acg = l10mturns_acg.astype("f8")
-    l10mturns_mcg = l10mturns_mcg.astype("f8")
     nion = np.zeros_like(densities)
     nion_mini = np.zeros_like(densities)
 
@@ -826,8 +859,8 @@ def evaluate_Nion_cond(
         radius,
         densities.size,
         ffi.cast("double *", ffi.from_buffer(densities)),
-        ffi.cast("double *", ffi.from_buffer(l10mturns_acg)),
-        ffi.cast("double *", ffi.from_buffer(l10mturns_mcg)),
+        log10mturn_acg,
+        log10mturn_mcg,
         ffi.cast("double *", ffi.from_buffer(nion)),
         ffi.cast("double *", ffi.from_buffer(nion_mini)),
     )

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -614,24 +614,53 @@ def evaluate_SFRD_z(
     *,
     inputs: InputParameters,
     redshifts: NDArray[np.floating],
-    log10mturns: NDArray[np.floating],
+    lightcone: LightCone | None = None,
 ):
-    """Evaluate the global star formation rate density expected at a range of redshifts."""
-    if redshifts.shape != log10mturns.shape:
-        raise ValueError(
-            f"the shapes of the input arrays `redshifts` {redshifts.shape} and `log10mturns` {log10mturns.shape}"
-            " must be equal."
-        )
+    """
+    Evaluate the global star formation rate density expected at a range of redshifts.
 
-    redshifts = redshifts.astype("f8")
-    log10mturns = log10mturns.astype("f8")
+    For now, it returns a dimensionless SFRD. TODO: fix this!
+
+    Parameters
+    ----------
+    inputs: :class:`~InputParameters`
+        The input parameters defining the simulation run.
+    redshifts : array-like
+        The redshifts at which to compute the SFRD.
+    lightcone : :class:`~LightCone` or None, optional
+        The lightcone object to use for the computation.
+        If None, the function will estimate the global m_turnover values,
+        otherwise they will be extracted from the given lightcone.
+
+    Returns
+    -------
+    sfrd : np.ndarray
+        The global star formation rate density at the given redshifts for ACGs.
+    sfrd_mini : np.ndarray
+        The global star formation rate density at the given redshifts for MCGs.
+    """
+    if lightcone is not None:
+        log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+    else:
+        from ..drivers.global_evolution import run_global_evolution
+
+        # If lightcone is not provided, we estimate the turnover masses from the global evolution
+        global_evolution = run_global_evolution(inputs=inputs)
+        log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
+
+    log10mturns_mini = np.interp(
+        redshifts, inputs.node_redshifts, log10mturns_mini_global
+    )
+
+    redshifts = np.asarray(redshifts).astype("f8")
+    log10mturns_mini = log10mturns_mini.astype("f8")
     sfrd = np.zeros_like(redshifts)
     sfrd_mini = np.zeros_like(redshifts)
 
     lib.get_global_SFRD_z(
         redshifts.size,
         ffi.cast("double *", ffi.from_buffer(redshifts)),
-        ffi.cast("double *", ffi.from_buffer(log10mturns)),
+        ffi.cast("double *", ffi.from_buffer(log10mturns_mini)),
         ffi.cast("double *", ffi.from_buffer(sfrd)),
         ffi.cast("double *", ffi.from_buffer(sfrd_mini)),
     )

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -642,8 +642,9 @@ def evaluate_SFRD_z(
     -------
     sfrd : np.ndarray
         The global star formation rate density at the given redshifts for ACGs.
-    sfrd_mini : np.ndarray
+    sfrd_mini : np.ndarray or None
         The global star formation rate density at the given redshifts for MCGs.
+        Will be None if `USE_MINI_HALOS` is False.
     """
     if log10mturns is not None:
         raise TypeError(
@@ -679,6 +680,8 @@ def evaluate_SFRD_z(
         ffi.cast("double *", ffi.from_buffer(sfrd)),
         ffi.cast("double *", ffi.from_buffer(sfrd_mini)),
     )
+    if not inputs.astro_options.USE_MINI_HALOS:
+        sfrd_mini = None
 
     return sfrd, sfrd_mini
 
@@ -709,8 +712,9 @@ def evaluate_Nion_z(
     -------
     nion : np.ndarray
         The global number of ionising photons per baryon at the given redshifts for ACGs.
-    nion_mini : np.ndarray
+    nion_mini : np.ndarray or None
         The global number of ionising photons per baryon at the given redshifts for MCGs.
+        Will be None if `USE_MINI_HALOS` is False.
     """
     if log10mturns is not None:
         raise TypeError(
@@ -747,6 +751,9 @@ def evaluate_Nion_z(
         ffi.cast("double *", ffi.from_buffer(nion_mini)),
     )
 
+    if not inputs.astro_options.USE_MINI_HALOS:
+        nion_mini = None
+
     return nion, nion_mini
 
 
@@ -782,8 +789,9 @@ def evaluate_SFRD_cond(
     -------
     sfrd : np.ndarray
         The conditional star formation rate density at the given redshift and radius for ACGs.
-    sfrd_mini : np.ndarray
+    sfrd_mini : np.ndarray or None
         The conditional star formation rate density at the given redshift and radius for MCGs.
+        Will be None if `USE_MINI_HALOS` is False.
     """
     if log10mturns is not None:
         raise TypeError(
@@ -821,6 +829,9 @@ def evaluate_SFRD_cond(
         ffi.cast("double *", ffi.from_buffer(sfrd_mini)),
     )
 
+    if not inputs.astro_options.USE_MINI_HALOS:
+        sfrd_mini = None
+
     return sfrd, sfrd_mini
 
 
@@ -857,8 +868,9 @@ def evaluate_Nion_cond(
     -------
     nion : np.ndarray
         The conditional number of ionising photons per baryon at the given redshift and radius for ACGs.
-    nion_mini : np.ndarray
+    nion_mini : np.ndarray or None
         The conditional number of ionising photons per baryon at the given redshift and radius for MCGs.
+        Will be None if `USE_MINI_HALOS` is False.
     """
     if (l10mturns_acg is not None) or (l10mturns_mcg is not None):
         raise TypeError(
@@ -899,6 +911,9 @@ def evaluate_Nion_cond(
         ffi.cast("double *", ffi.from_buffer(nion)),
         ffi.cast("double *", ffi.from_buffer(nion_mini)),
     )
+
+    if not inputs.astro_options.USE_MINI_HALOS:
+        nion_mini = None
 
     return nion, nion_mini
 

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -678,8 +678,6 @@ def evaluate_Nion_z(
     """
     Evaluate the global number of ionising photons per baryon, expected at a range of redshifts.
 
-    For now, it returns a dimensionless Nion. TODO: fix this!
-
     Parameters
     ----------
     inputs: :class:`~InputParameters`
@@ -810,8 +808,6 @@ def evaluate_Nion_cond(
 ):
     """
     Evaluate the global number of ionising photons per baryon, expected at a range of densities.
-
-    For now, it returns a dimensionless Nion. TODO: fix this!
 
     Parameters
     ----------

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -745,7 +745,6 @@ def evaluate_SFRD_cond(
     )
 
     densities = densities.astype("f8")
-    log10mturns_mini = np.full_like(densities, log10mturns_mini, dtype="f8")
     sfrd = np.zeros_like(densities)
     sfrd_mini = np.zeros_like(densities)
 
@@ -754,7 +753,7 @@ def evaluate_SFRD_cond(
         radius,
         densities.size,
         ffi.cast("double *", ffi.from_buffer(densities)),
-        ffi.cast("double *", ffi.from_buffer(log10mturns_mini)),
+        log10mturns_mini,
         ffi.cast("double *", ffi.from_buffer(sfrd)),
         ffi.cast("double *", ffi.from_buffer(sfrd_mini)),
     )

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -227,7 +227,7 @@ def compute_luminosity_function(
         If not provided, the function will estimate the global m_turnover values,
         otherwise they will be extracted from the given lightcone.
     component : str, {'both', 'acg', 'mcg}
-        The component of the LF to be calculated.
+        The component of the LF to be calculated. Forced to be 'acg' if USE_MINI_HALOS is False.
 
     Returns
     -------
@@ -249,7 +249,7 @@ def compute_luminosity_function(
             "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
         )
 
-    if not astro_options.USE_MINI_HALOS:
+    if not astro_options.USE_MINI_HALOS and component != "acg":
         warnings.warn(
             "USE_MINI_HALOS is False, so only ACG LFs are computed.",
             stacklevel=2,
@@ -272,9 +272,11 @@ def compute_luminosity_function(
         )
 
     # Interpolate the mturnover arrays at the input redshifts
-    mturnovers = np.interp(redshifts, inputs.node_redshifts, mturnovers_global)
+    mturnovers = np.interp(
+        redshifts, inputs.node_redshifts[::-1], mturnovers_global[::-1]
+    )
     mturnovers_mini = np.interp(
-        redshifts, inputs.node_redshifts, mturnovers_mini_global
+        redshifts, inputs.node_redshifts[::-1], mturnovers_mini_global[::-1]
     )
 
     lfunc = np.zeros(len(redshifts) * nbins)
@@ -660,7 +662,7 @@ def evaluate_SFRD_z(
             log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
         log10mturns_mini = np.interp(
-            redshifts, inputs.node_redshifts, log10mturns_mini_global
+            redshifts, inputs.node_redshifts[::-1], log10mturns_mini_global[::-1]
         )
     else:
         log10mturns_mini = np.zeros_like(redshifts)  # dummy value for no mini halos
@@ -727,7 +729,7 @@ def evaluate_Nion_z(
             log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
         log10mturns_mini = np.interp(
-            redshifts, inputs.node_redshifts, log10mturns_mini_global
+            redshifts, inputs.node_redshifts[::-1], log10mturns_mini_global[::-1]
         )
     else:
         log10mturns_mini = np.zeros_like(redshifts)  # dummy value for no mini halos
@@ -800,7 +802,7 @@ def evaluate_SFRD_cond(
             log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
         log10mturn_mini = np.interp(
-            redshift, inputs.node_redshifts, log10mturns_mini_global
+            redshift, inputs.node_redshifts[::-1], log10mturns_mini_global[::-1]
         )
     else:
         log10mturn_mini = 0.0  # dummy value for no mini halos
@@ -876,8 +878,12 @@ def evaluate_Nion_cond(
         log10mturns_global = global_evolution.quantities["log10_mturn_acg"]
         log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
-    log10mturn_acg = np.interp(redshift, inputs.node_redshifts, log10mturns_global)
-    log10mturn_mcg = np.interp(redshift, inputs.node_redshifts, log10mturns_mini_global)
+    log10mturn_acg = np.interp(
+        redshift, inputs.node_redshifts[::-1], log10mturns_global[::-1]
+    )
+    log10mturn_mcg = np.interp(
+        redshift, inputs.node_redshifts[::-1], log10mturns_mini_global[::-1]
+    )
 
     densities = densities.astype("f8")
     nion = np.zeros_like(densities)
@@ -947,7 +953,7 @@ def evaluate_Xray_cond(
             log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
         log10mturn_mini = np.interp(
-            redshift, inputs.node_redshifts, log10mturns_mini_global
+            redshift, inputs.node_redshifts[::-1], log10mturns_mini_global[::-1]
         )
     else:
         log10mturn_mini = 0.0  # dummy value for no mini halos

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -252,15 +252,25 @@ def compute_luminosity_function(
         component = "acg"
 
     if lightcone is not None:
-        mturnovers = pow(10.0, lightcone.global_quantities["log10_mturn_acg"])
-        mturnovers_mini = pow(10.0, lightcone.global_quantities["log10_mturn_mcg"])
+        mturnovers_global = pow(10.0, lightcone.global_quantities["log10_mturn_acg"])
+        mturnovers_mini_global = pow(
+            10.0, lightcone.global_quantities["log10_mturn_mcg"]
+        )
     else:
         from ..drivers.global_evolution import run_global_evolution
 
         # If lightcone is not provided, we estimate the turnover masses from the global evolution
         global_evolution = run_global_evolution(inputs=inputs)
-        mturnovers = pow(10.0, global_evolution.quantities["log10_mturn_acg"])
-        mturnovers_mini = pow(10.0, global_evolution.quantities["log10_mturn_mcg"])
+        mturnovers_global = pow(10.0, global_evolution.quantities["log10_mturn_acg"])
+        mturnovers_mini_global = pow(
+            10.0, global_evolution.quantities["log10_mturn_mcg"]
+        )
+
+    # Interpolate the mturnover arrays at the input redshifts
+    mturnovers = np.interp(redshifts, inputs.node_redshifts, mturnovers_global)
+    mturnovers_mini = np.interp(
+        redshifts, inputs.node_redshifts, mturnovers_mini_global
+    )
 
     lfunc = np.zeros(len(redshifts) * nbins)
     Muvfunc = np.zeros(len(redshifts) * nbins)

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -1,6 +1,7 @@
 """Low-level python wrappers of C functions."""
 
 import logging
+import warnings
 from collections.abc import Sequence
 from typing import Literal
 
@@ -11,6 +12,7 @@ from scipy.interpolate import interp1d
 from .._cfg import config
 from ..c_21cmfast import ffi, lib
 from ..drivers._global_initialization import init_c_state
+from ..drivers.lightcone import LightCone
 from ._utils import _process_exitcode
 from .inputs import InputParameters
 
@@ -208,8 +210,7 @@ def compute_luminosity_function(
     redshifts: Sequence[float],
     inputs: InputParameters,
     nbins: int = 100,
-    mturnovers: np.ndarray | None = None,
-    mturnovers_mini: np.ndarray | None = None,
+    lightcone: LightCone | None = None,
     component: Literal["both", "acg", "mcg"] = "both",
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Compute a the luminosity function over a given number of bins and redshifts.
@@ -222,12 +223,10 @@ def compute_luminosity_function(
         The input parameters defining the simulation run.
     nbins : int, optional
         The number of luminosity bins to produce for the luminosity function.
-    mturnovers : array-like, optional
-        The turnover mass at each redshift for massive halos (ACGs).
-        Only required when USE_MINI_HALOS is True.
-    mturnovers_mini : array-like, optional
-        The turnover mass at each redshift for minihalos (MCGs).
-        Only required when USE_MINI_HALOS is True.
+    lightcone : :class:`~LightCone`, optional
+        The lightcone object containing the necessary data for the computation.
+        If not provided, the function will estimate the global m_turnover values,
+        otherwise they will be extracted from the given lightcone.
     component : str, {'both', 'acg', 'mcg}
         The component of the LF to be calculated.
 
@@ -242,42 +241,26 @@ def compute_luminosity_function(
         Shape [nredshifts, nbins].
     """
     astro_options = inputs.astro_options
-    astro_params = inputs.astro_params
 
     redshifts = np.array(redshifts, dtype="float32")
-    if astro_options.USE_MINI_HALOS:
-        if component in ["both", "acg"]:
-            if mturnovers is None:
-                raise ValueError(
-                    "calculating ACG LFs with mini-halo feature requires users to "
-                    "specify mturnovers!"
-                )
 
-            mturnovers = np.array(mturnovers, dtype=np.float32)
-            if len(mturnovers) != len(redshifts):
-                raise ValueError(
-                    f"mturnovers ({len(mturnovers)}) does not match the length of "
-                    f"redshifts ({len(redshifts)})"
-                )
-        if component in ["both", "mcg"]:
-            if mturnovers_mini is None:
-                raise ValueError(
-                    "calculating MCG LFs with mini-halo feature requires users to "
-                    "specify mturnovers_MINI!"
-                )
-
-            mturnovers_mini = np.array(mturnovers_mini, dtype="float32")
-            if len(mturnovers_mini) != len(redshifts):
-                raise ValueError(
-                    f"mturnovers_MINI ({len(mturnovers)}) does not match the length of "
-                    f"redshifts ({len(redshifts)})"
-                )
-
-    else:
-        mturnovers = (
-            np.zeros(len(redshifts), dtype=np.float32) + 10**astro_params.M_TURN
+    if not astro_options.USE_MINI_HALOS:
+        warnings.warn(
+            "USE_MINI_HALOS is False, so only ACG LFs are computed.",
+            stacklevel=2,
         )
         component = "acg"
+
+    if lightcone is not None:
+        mturnovers = pow(10.0, lightcone.global_quantities["log10_mturn_acg"])
+        mturnovers_mini = pow(10.0, lightcone.global_quantities["log10_mturn_mcg"])
+    else:
+        from ..drivers.global_evolution import run_global_evolution
+
+        # If lightcone is not provided, we estimate the turnover masses from the global evolution
+        global_evolution = run_global_evolution(inputs=inputs)
+        mturnovers = pow(10.0, global_evolution.quantities["log10_mturn_acg"])
+        mturnovers_mini = pow(10.0, global_evolution.quantities["log10_mturn_mcg"])
 
     lfunc = np.zeros(len(redshifts) * nbins)
     Muvfunc = np.zeros(len(redshifts) * nbins)

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -614,9 +614,7 @@ def evaluate_SFRD_z(
     lightcone: LightCone | None = None,
 ):
     """
-    Evaluate the global star formation rate density expected at a range of redshifts.
-
-    For now, it returns a dimensionless SFRD. TODO: fix this!
+    Evaluate the global star formation rate density (in units of M_sun/s/Mpc^3) expected at a range of redshifts.
 
     Parameters
     ----------
@@ -738,9 +736,7 @@ def evaluate_SFRD_cond(
     lightcone: LightCone | None = None,
 ):
     """
-    Evaluate the conditional star formation rate density expected at a range of densities.
-
-    For now, it returns a dimensionless SFRD. TODO: fix this!
+    Evaluate the conditional star formation rate density (in units of M_sun/s/Mpc^3) expected at a range of densities.
 
     Parameters
     ----------

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -77,6 +77,78 @@ def get_halo_catalog_buffer_size(
 
 
 @init_c_state(broadcast_inputs=True)
+def compute_mturns(
+    *,
+    inputs: InputParameters,
+    redshifts: float | Sequence[float],
+    J_LW_21: float | Sequence[float],
+    v_cb: float | Sequence[float],
+    ionisation_rate_G12: float | Sequence[float],
+    z_reion: float | Sequence[float],
+):
+    """
+    Compute the turnover masses for both ACGs and MCGs at a given redshift.
+
+    Parameters
+    ----------
+    redshifts : array-like
+        The redshifts at which to compute the turnover masses.
+    J_LW_21 : array-like
+        The Lyman-Werner flux in units of 1e-21 erg/s/Hz/cm^2/sr at the given redshifts.
+    v_cb : array-like
+        The amplitude of the relative velocity between dark matter and baryons in units of km/s at the given redshifts.
+    ionisation_rate_G12 : array-like
+        The ionisation rate in units of 1e-12 s^-1 at the given redshifts.
+    z_reion : array-like
+        The reionisation redshift at the given redshifts.
+
+    Returns
+    -------
+    M_turn_a : array-like
+        The turnover mass for atomic cooling halos at the given redshifts.
+    M_turn_m : array-like
+        The turnover mass for molecular cooling halos at the given redshifts.
+
+    Raises
+    ------
+    ValueError :
+        If the input arrays do not have the same length.
+    """
+    lengths = {
+        len(x)
+        for x in (redshifts, J_LW_21, v_cb, ionisation_rate_G12, z_reion)
+        if hasattr(x, "__len__")
+    }
+    if len(lengths) > 1:
+        raise ValueError(
+            "All input arrays must have the same length, got lengths: "
+            + ", ".join(
+                f"{name}={len(x)}"
+                for name, x in zip(
+                    ("redshifts", "J_LW_21", "v_cb", "ionisation_rate_G12", "z_reion"),
+                    (redshifts, J_LW_21, v_cb, ionisation_rate_G12, z_reion),
+                    strict=False,
+                )
+                if hasattr(x, "__len__")
+            )
+        )
+
+    M_turn_a_ffi = ffi.new("double *")
+    M_turn_m_ffi = ffi.new("double *")
+
+    def _scalar_call(z, j, v, g, zr):
+        lib.compute_mturns(z, j, v, g, zr, M_turn_a_ffi, M_turn_m_ffi)
+        return M_turn_a_ffi[0], M_turn_m_ffi[0]
+
+    vfunc = np.vectorize(_scalar_call, otypes=[np.float64, np.float64])
+    M_turn_a, M_turn_m = vfunc(redshifts, J_LW_21, v_cb, ionisation_rate_G12, z_reion)
+
+    if M_turn_a.ndim == 0:  # scalar input case
+        return float(M_turn_a), float(M_turn_m)
+    return M_turn_a, M_turn_m
+
+
+@init_c_state(broadcast_inputs=True)
 def compute_tau(
     *,
     redshifts: Sequence[float],

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -813,6 +813,14 @@ def evaluate_SFRD_cond(
     sfrd_mini : np.ndarray or None
         The conditional star formation rate density at the given redshift and radius for MCGs.
         Will be None if `USE_MINI_HALOS` is False.
+
+    Notes
+    -----
+    This function estimates the conditional SFRD by using the global turnover masses.
+    In reality, these turnover masses do not depend solely on redshift, but also on the local
+    density field, as well on its environment and history. Since it is impossible to well-define
+    the conditional SFRD in given region by only providing redshift and density, we approximate
+    the used turnover masses in this calculation to be the global ones.
     """
     if log10mturns is not None:
         raise TypeError(
@@ -897,6 +905,14 @@ def evaluate_Nion_cond(
     nion_mini : np.ndarray or None
         The conditional number of ionising photons per baryon at the given redshift and radius for MCGs.
         Will be None if `USE_MINI_HALOS` is False.
+
+    Notes
+    -----
+    This function estimates the conditional N_ion by using the global turnover masses.
+    In reality, these turnover masses do not depend solely on redshift, but also on the local
+    density field, as well on its environment and history. Since it is impossible to well-define
+    the conditional N_ion in given region by only providing redshift and density, we approximate
+    the used turnover masses in this calculation to be the global ones.
     """
     if (l10mturns_acg is not None) or (l10mturns_mcg is not None):
         raise TypeError(
@@ -981,6 +997,15 @@ def evaluate_Xray_cond(
     -------
     xray_emissivity : np.ndarray
         The conditional X-ray emissivity at the given redshift and radius for ACGs and MCGs combined.
+
+    Notes
+    -----
+    This function estimates the conditional X-ray emissivity by using the global turnover masses.
+    In reality, these turnover masses do not depend solely on redshift, but also on the local
+    density field, as well on its environment and history. Since it is impossible to well-define
+    the conditional X-ray emissivity in given region by only providing redshift and density, we approximate
+    the used turnover masses in this calculation to be the global ones.
+
     """
     if log10mturns is not None:
         raise TypeError(

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -12,6 +12,7 @@ from scipy.interpolate import interp1d
 from .._cfg import config
 from ..c_21cmfast import ffi, lib
 from ..drivers._global_initialization import init_c_state
+from ..drivers.global_evolution import GlobalEvolution, run_global_evolution
 from ..drivers.lightcone import LightCone
 from ._utils import _process_exitcode
 from .inputs import InputParameters
@@ -210,6 +211,7 @@ def compute_luminosity_function(
     mturnovers: np.ndarray | None = None,
     mturnovers_mini: np.ndarray | None = None,
     lightcone: LightCone | None = None,
+    global_evolution: GlobalEvolution | None = None,
     component: Literal["both", "acg", "mcg"] = "both",
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Compute a the luminosity function over a given number of bins and redshifts.
@@ -222,10 +224,14 @@ def compute_luminosity_function(
         The input parameters defining the simulation run.
     nbins : int, optional
         The number of luminosity bins to produce for the luminosity function.
-    lightcone : :class:`~LightCone`, optional
-        The lightcone object containing the necessary data for the computation.
-        If not provided, the function will estimate the global m_turnover values,
+    lightcone : :class:`~LightCone` or None, optional
+        The lightcone object to use for the computation.
+        If None, the function will consider `global_evolution` for the global m_turnover values,
         otherwise they will be extracted from the given lightcone.
+    global_evolution : :class:`~GlobalEvolution` or None, optional
+        The global evolution object to use for the computation.
+        If None, the function will run a global evolution to estimate the global m_turnover values,
+        otherwise they will be extracted from the given global evolution.
     component : str, {'both', 'acg', 'mcg}
         The component of the LF to be calculated. Forced to be 'acg' if USE_MINI_HALOS is False.
 
@@ -262,10 +268,9 @@ def compute_luminosity_function(
             10.0, lightcone.global_quantities["log10_mturn_mcg"]
         )
     else:
-        from ..drivers.global_evolution import run_global_evolution
-
         # If lightcone is not provided, we estimate the turnover masses from the global evolution
-        global_evolution = run_global_evolution(inputs=inputs)
+        if global_evolution is None:
+            global_evolution = run_global_evolution(inputs=inputs)
         mturnovers_global = pow(10.0, global_evolution.quantities["log10_mturn_acg"])
         mturnovers_mini_global = pow(
             10.0, global_evolution.quantities["log10_mturn_mcg"]
@@ -623,6 +628,7 @@ def evaluate_SFRD_z(
     redshifts: NDArray[np.floating],
     log10mturns: NDArray[np.floating] | None = None,
     lightcone: LightCone | None = None,
+    global_evolution: GlobalEvolution | None = None,
 ):
     """
     Evaluate the global star formation rate density (in units of M_sun/s/Mpc^3) expected at a range of redshifts.
@@ -635,8 +641,12 @@ def evaluate_SFRD_z(
         The redshifts at which to compute the SFRD.
     lightcone : :class:`~LightCone` or None, optional
         The lightcone object to use for the computation.
-        If None, the function will estimate the global m_turnover values,
+        If None, the function will consider `global_evolution` for the global m_turnover values,
         otherwise they will be extracted from the given lightcone.
+    global_evolution : :class:`~GlobalEvolution` or None, optional
+        The global evolution object to use for the computation.
+        If None, the function will run a global evolution to estimate the global m_turnover values,
+        otherwise they will be extracted from the given global evolution.
 
     Returns
     -------
@@ -656,10 +666,9 @@ def evaluate_SFRD_z(
         if lightcone is not None:
             log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
         else:
-            from ..drivers.global_evolution import run_global_evolution
-
             # If lightcone is not provided, we estimate the turnover masses from the global evolution
-            global_evolution = run_global_evolution(inputs=inputs)
+            if global_evolution is None:
+                global_evolution = run_global_evolution(inputs=inputs)
             log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
         log10mturns_mini = np.interp(
@@ -693,6 +702,7 @@ def evaluate_Nion_z(
     redshifts: NDArray[np.floating],
     log10mturns: NDArray[np.floating] | None = None,
     lightcone: LightCone | None = None,
+    global_evolution: GlobalEvolution | None = None,
 ):
     """
     Evaluate the global number of ionising photons per baryon, expected at a range of redshifts.
@@ -705,8 +715,12 @@ def evaluate_Nion_z(
         The redshifts at which to compute Nion.
     lightcone : :class:`~LightCone` or None, optional
         The lightcone object to use for the computation.
-        If None, the function will estimate the global m_turnover values,
+        If None, the function will consider `global_evolution` for the global m_turnover values,
         otherwise they will be extracted from the given lightcone.
+    global_evolution : :class:`~GlobalEvolution` or None, optional
+        The global evolution object to use for the computation.
+        If None, the function will run a global evolution to estimate the global m_turnover values,
+        otherwise they will be extracted from the given global evolution.
 
     Returns
     -------
@@ -726,10 +740,9 @@ def evaluate_Nion_z(
         if lightcone is not None:
             log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
         else:
-            from ..drivers.global_evolution import run_global_evolution
-
             # If lightcone is not provided, we estimate the turnover masses from the global evolution
-            global_evolution = run_global_evolution(inputs=inputs)
+            if global_evolution is None:
+                global_evolution = run_global_evolution(inputs=inputs)
             log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
         log10mturns_mini = np.interp(
@@ -766,6 +779,7 @@ def evaluate_SFRD_cond(
     densities: NDArray[np.floating],
     log10mturns: NDArray[np.floating] | None = None,
     lightcone: LightCone | None = None,
+    global_evolution: GlobalEvolution | None = None,
 ):
     """
     Evaluate the conditional star formation rate density (in units of M_sun/s/Mpc^3) expected at a range of densities.
@@ -782,8 +796,12 @@ def evaluate_SFRD_cond(
         The densities at which to compute the conditional SFRD.
     lightcone : :class:`~LightCone` or None, optional
         The lightcone object to use for the computation.
-        If None, the function will estimate the global m_turnover values,
+        If None, the function will consider `global_evolution` for the global m_turnover values,
         otherwise they will be extracted from the given lightcone.
+    global_evolution : :class:`~GlobalEvolution` or None, optional
+        The global evolution object to use for the computation.
+        If None, the function will run a global evolution to estimate the global m_turnover values,
+        otherwise they will be extracted from the given global evolution.
 
     Returns
     -------
@@ -803,10 +821,9 @@ def evaluate_SFRD_cond(
         if lightcone is not None:
             log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
         else:
-            from ..drivers.global_evolution import run_global_evolution
-
             # If lightcone is not provided, we estimate the turnover masses from the global evolution
-            global_evolution = run_global_evolution(inputs=inputs)
+            if global_evolution is None:
+                global_evolution = run_global_evolution(inputs=inputs)
             log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
         log10mturn_mini = np.interp(
@@ -845,6 +862,7 @@ def evaluate_Nion_cond(
     l10mturns_acg: NDArray[np.floating] | None = None,
     l10mturns_mcg: NDArray[np.floating] | None = None,
     lightcone: LightCone | None = None,
+    global_evolution: GlobalEvolution | None = None,
 ):
     """
     Evaluate the global number of ionising photons per baryon, expected at a range of densities.
@@ -861,8 +879,12 @@ def evaluate_Nion_cond(
         The densities at which to compute the conditional Nion.
     lightcone : :class:`~LightCone` or None, optional
         The lightcone object to use for the computation.
-        If None, the function will estimate the global m_turnover values,
+        If None, the function will consider `global_evolution` for the global m_turnover values,
         otherwise they will be extracted from the given lightcone.
+    global_evolution : :class:`~GlobalEvolution` or None, optional
+        The global evolution object to use for the computation.
+        If None, the function will run a global evolution to estimate the global m_turnover values,
+        otherwise they will be extracted from the given global evolution.
 
     Returns
     -------
@@ -883,10 +905,9 @@ def evaluate_Nion_cond(
         log10mturns_global = lightcone.global_quantities["log10_mturn_acg"]
         log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
     else:
-        from ..drivers.global_evolution import run_global_evolution
-
         # If lightcone is not provided, we estimate the turnover masses from the global evolution
-        global_evolution = run_global_evolution(inputs=inputs)
+        if global_evolution is None:
+            global_evolution = run_global_evolution(inputs=inputs)
         log10mturns_global = global_evolution.quantities["log10_mturn_acg"]
         log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
@@ -927,6 +948,7 @@ def evaluate_Xray_cond(
     densities: NDArray[np.floating],
     log10mturns: NDArray[np.floating] | None = None,
     lightcone: LightCone | None = None,
+    global_evolution: GlobalEvolution | None = None,
 ):
     """
     Evaluate the conditional X-ray emissivity (in units of erg/s/Mpc^3) expected at a range of densities.
@@ -943,8 +965,12 @@ def evaluate_Xray_cond(
         The densities at which to compute the conditional X-ray emissivity.
     lightcone : :class:`~LightCone` or None, optional
         The lightcone object to use for the computation.
-        If None, the function will estimate the global m_turnover values,
+        If None, the function will consider `global_evolution` for the global m_turnover values,
         otherwise they will be extracted from the given lightcone.
+    global_evolution : :class:`~GlobalEvolution` or None, optional
+        The global evolution object to use for the computation.
+        If None, the function will run a global evolution to estimate the global m_turnover values,
+        otherwise they will be extracted from the given global evolution.
 
     Returns
     -------
@@ -961,10 +987,9 @@ def evaluate_Xray_cond(
         if lightcone is not None:
             log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
         else:
-            from ..drivers.global_evolution import run_global_evolution
-
             # If lightcone is not provided, we estimate the turnover masses from the global evolution
-            global_evolution = run_global_evolution(inputs=inputs)
+            if global_evolution is None:
+                global_evolution = run_global_evolution(inputs=inputs)
             log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
 
         log10mturn_mini = np.interp(

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -207,6 +207,8 @@ def compute_luminosity_function(
     redshifts: Sequence[float],
     inputs: InputParameters,
     nbins: int = 100,
+    mturnovers: np.ndarray | None = None,
+    mturnovers_mini: np.ndarray | None = None,
     lightcone: LightCone | None = None,
     component: Literal["both", "acg", "mcg"] = "both",
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -240,6 +242,12 @@ def compute_luminosity_function(
     astro_options = inputs.astro_options
 
     redshifts = np.array(redshifts, dtype="float32")
+
+    if (mturnovers is not None) or (mturnovers_mini is not None):
+        raise TypeError(
+            "`mturnovers` and `mturnovers_mini` have been removed. "
+            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+        )
 
     if not astro_options.USE_MINI_HALOS:
         warnings.warn(
@@ -611,6 +619,7 @@ def evaluate_SFRD_z(
     *,
     inputs: InputParameters,
     redshifts: NDArray[np.floating],
+    log10mturns: NDArray[np.floating] | None = None,
     lightcone: LightCone | None = None,
 ):
     """
@@ -634,6 +643,12 @@ def evaluate_SFRD_z(
     sfrd_mini : np.ndarray
         The global star formation rate density at the given redshifts for MCGs.
     """
+    if log10mturns is not None:
+        raise TypeError(
+            "`log10mturns` has been removed. "
+            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+        )
+
     if inputs.astro_options.USE_MINI_HALOS:
         if lightcone is not None:
             log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
@@ -671,6 +686,7 @@ def evaluate_Nion_z(
     *,
     inputs: InputParameters,
     redshifts: NDArray[np.floating],
+    log10mturns: NDArray[np.floating] | None = None,
     lightcone: LightCone | None = None,
 ):
     """
@@ -694,6 +710,12 @@ def evaluate_Nion_z(
     nion_mini : np.ndarray
         The global number of ionising photons per baryon at the given redshifts for MCGs.
     """
+    if log10mturns is not None:
+        raise TypeError(
+            "`log10mturns` has been removed. "
+            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+        )
+
     if inputs.astro_options.USE_MINI_HALOS:
         if lightcone is not None:
             log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
@@ -733,6 +755,7 @@ def evaluate_SFRD_cond(
     redshift: float,
     radius: float,
     densities: NDArray[np.floating],
+    log10mturns: NDArray[np.floating] | None = None,
     lightcone: LightCone | None = None,
 ):
     """
@@ -760,6 +783,12 @@ def evaluate_SFRD_cond(
     sfrd_mini : np.ndarray
         The conditional star formation rate density at the given redshift and radius for MCGs.
     """
+    if log10mturns is not None:
+        raise TypeError(
+            "`log10mturns` has been removed. "
+            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+        )
+
     if inputs.astro_options.USE_MINI_HALOS:
         if lightcone is not None:
             log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
@@ -800,6 +829,8 @@ def evaluate_Nion_cond(
     redshift: float,
     radius: float,
     densities: NDArray[np.floating],
+    l10mturns_acg: NDArray[np.floating] | None = None,
+    l10mturns_mcg: NDArray[np.floating] | None = None,
     lightcone: LightCone | None = None,
 ):
     """
@@ -827,6 +858,12 @@ def evaluate_Nion_cond(
     nion_mini : np.ndarray
         The conditional number of ionising photons per baryon at the given redshift and radius for MCGs.
     """
+    if (l10mturns_acg is not None) or (l10mturns_mcg is not None):
+        raise TypeError(
+            "`l10mturns_acg` and `l10mturns_mcg` have been removed. "
+            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+        )
+
     # TODO: Why this function is the only one that needs the global mturnover values for ACGs?
     if lightcone is not None:
         log10mturns_global = lightcone.global_quantities["log10_mturn_acg"]
@@ -867,6 +904,7 @@ def evaluate_Xray_cond(
     redshift: float,
     radius: float,
     densities: NDArray[np.floating],
+    log10mturns: NDArray[np.floating] | None = None,
     lightcone: LightCone | None = None,
 ):
     """
@@ -892,6 +930,12 @@ def evaluate_Xray_cond(
     xray_emissivity : np.ndarray
         The conditional X-ray emissivity at the given redshift and radius for ACGs and MCGs combined.
     """
+    if log10mturns is not None:
+        raise TypeError(
+            "`log10mturns` has been removed. "
+            "Please use the `lightcone` argument instead, or don't use it to estimate the turnover masses."
+        )
+
     if inputs.astro_options.USE_MINI_HALOS:
         if lightcone is not None:
             log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -870,20 +870,18 @@ def evaluate_Xray_cond(
     lightcone: LightCone | None = None,
 ):
     """
-    Evaluate the conditional X-ray luminosity expected at a range of densities.
-
-    For now, it returns X-ray luminosity in units of 1e-38 erg/s/rho_m. TODO: fix this!
+    Evaluate the conditional X-ray emissivity (in units of erg/s/Mpc^3) expected at a range of densities.
 
     Parameters
     ----------
     inputs: :class:`~InputParameters`
         The input parameters defining the simulation run.
     redshift : float
-        The redshift at which to compute the conditional X-ray luminosity.
+        The redshift at which to compute the conditional X-ray emissivity.
     radius : float
-        The radius of the region at which to compute the conditional X-ray luminosity.
+        The radius of the region at which to compute the conditional X-ray emissivity.
     densities : array-like
-        The densities at which to compute the conditional X-ray luminosity.
+        The densities at which to compute the conditional X-ray emissivity.
     lightcone : :class:`~LightCone` or None, optional
         The lightcone object to use for the computation.
         If None, the function will estimate the global m_turnover values,
@@ -891,8 +889,8 @@ def evaluate_Xray_cond(
 
     Returns
     -------
-    xray_luminosity : np.ndarray
-        The conditional X-ray luminosity at the given redshift and radius for ACGs and MCGs combined.
+    xray_emissivity : np.ndarray
+        The conditional X-ray emissivity at the given redshift and radius for ACGs and MCGs combined.
     """
     if inputs.astro_options.USE_MINI_HALOS:
         if lightcone is not None:
@@ -911,7 +909,7 @@ def evaluate_Xray_cond(
         log10mturn_mini = 0.0  # dummy value for no mini halos
 
     densities = densities.astype("f8")
-    xray_luminosity = np.zeros_like(densities)
+    xray_emissivity = np.zeros_like(densities)
 
     lib.get_conditional_Xray(
         redshift,
@@ -919,10 +917,10 @@ def evaluate_Xray_cond(
         densities.size,
         ffi.cast("double *", ffi.from_buffer(densities)),
         log10mturn_mini,
-        ffi.cast("double *", ffi.from_buffer(xray_luminosity)),
+        ffi.cast("double *", ffi.from_buffer(xray_emissivity)),
     )
 
-    return xray_luminosity
+    return xray_emissivity
 
 
 @init_c_state(sigma=True)

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -636,18 +636,21 @@ def evaluate_SFRD_z(
     sfrd_mini : np.ndarray
         The global star formation rate density at the given redshifts for MCGs.
     """
-    if lightcone is not None:
-        log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+    if inputs.astro_options.USE_MINI_HALOS:
+        if lightcone is not None:
+            log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+        else:
+            from ..drivers.global_evolution import run_global_evolution
+
+            # If lightcone is not provided, we estimate the turnover masses from the global evolution
+            global_evolution = run_global_evolution(inputs=inputs)
+            log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
+
+        log10mturns_mini = np.interp(
+            redshifts, inputs.node_redshifts, log10mturns_mini_global
+        )
     else:
-        from ..drivers.global_evolution import run_global_evolution
-
-        # If lightcone is not provided, we estimate the turnover masses from the global evolution
-        global_evolution = run_global_evolution(inputs=inputs)
-        log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
-
-    log10mturns_mini = np.interp(
-        redshifts, inputs.node_redshifts, log10mturns_mini_global
-    )
+        log10mturns_mini = np.zeros_like(redshifts)  # dummy value for no mini halos
 
     redshifts = np.asarray(redshifts).astype("f8")
     log10mturns_mini = log10mturns_mini.astype("f8")
@@ -670,24 +673,56 @@ def evaluate_Nion_z(
     *,
     inputs: InputParameters,
     redshifts: NDArray[np.floating],
-    log10mturns: NDArray[np.floating],
+    lightcone: LightCone | None = None,
 ):
-    """Evaluate the global ionising emissivity expected at a range of redshifts."""
-    if redshifts.shape != log10mturns.shape:
-        raise ValueError(
-            "the shapes of the input arrays `redshifts` and `log10mturns`"
-            " must be equal."
+    """
+    Evaluate the global number of ionising photons per baryon, expected at a range of redshifts.
+
+    For now, it returns a dimensionless Nion. TODO: fix this!
+
+    Parameters
+    ----------
+    inputs: :class:`~InputParameters`
+        The input parameters defining the simulation run.
+    redshifts : array-like
+        The redshifts at which to compute Nion.
+    lightcone : :class:`~LightCone` or None, optional
+        The lightcone object to use for the computation.
+        If None, the function will estimate the global m_turnover values,
+        otherwise they will be extracted from the given lightcone.
+
+    Returns
+    -------
+    nion : np.ndarray
+        The global number of ionising photons per baryon at the given redshifts for ACGs.
+    nion_mini : np.ndarray
+        The global number of ionising photons per baryon at the given redshifts for MCGs.
+    """
+    if inputs.astro_options.USE_MINI_HALOS:
+        if lightcone is not None:
+            log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+        else:
+            from ..drivers.global_evolution import run_global_evolution
+
+            # If lightcone is not provided, we estimate the turnover masses from the global evolution
+            global_evolution = run_global_evolution(inputs=inputs)
+            log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
+
+        log10mturns_mini = np.interp(
+            redshifts, inputs.node_redshifts, log10mturns_mini_global
         )
+    else:
+        log10mturns_mini = np.zeros_like(redshifts)  # dummy value for no mini halos
 
     redshifts = redshifts.astype("f8")
-    log10mturns = log10mturns.astype("f8")
+    log10mturns_mini = log10mturns_mini.astype("f8")
     nion = np.zeros_like(redshifts)
     nion_mini = np.zeros_like(redshifts)
 
     lib.get_global_Nion_z(
         redshifts.size,
         ffi.cast("double *", ffi.from_buffer(redshifts)),
-        ffi.cast("double *", ffi.from_buffer(log10mturns)),
+        ffi.cast("double *", ffi.from_buffer(log10mturns_mini)),
         ffi.cast("double *", ffi.from_buffer(nion)),
         ffi.cast("double *", ffi.from_buffer(nion_mini)),
     )
@@ -731,18 +766,21 @@ def evaluate_SFRD_cond(
     sfrd_mini : np.ndarray
         The conditional star formation rate density at the given redshift and radius for MCGs.
     """
-    if lightcone is not None:
-        log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+    if inputs.astro_options.USE_MINI_HALOS:
+        if lightcone is not None:
+            log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+        else:
+            from ..drivers.global_evolution import run_global_evolution
+
+            # If lightcone is not provided, we estimate the turnover masses from the global evolution
+            global_evolution = run_global_evolution(inputs=inputs)
+            log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
+
+        log10mturn_mini = np.interp(
+            redshift, inputs.node_redshifts, log10mturns_mini_global
+        )
     else:
-        from ..drivers.global_evolution import run_global_evolution
-
-        # If lightcone is not provided, we estimate the turnover masses from the global evolution
-        global_evolution = run_global_evolution(inputs=inputs)
-        log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
-
-    log10mturn_mini = np.interp(
-        redshift, inputs.node_redshifts, log10mturns_mini_global
-    )
+        log10mturn_mini = 0.0  # dummy value for no mini halos
 
     densities = densities.astype("f8")
     sfrd = np.zeros_like(densities)
@@ -831,18 +869,21 @@ def evaluate_Xray_cond(
     xray_luminosity : np.ndarray
         The conditional X-ray luminosity at the given redshift and radius for ACGs and MCGs combined.
     """
-    if lightcone is not None:
-        log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+    if inputs.astro_options.USE_MINI_HALOS:
+        if lightcone is not None:
+            log10mturns_mini_global = lightcone.global_quantities["log10_mturn_mcg"]
+        else:
+            from ..drivers.global_evolution import run_global_evolution
+
+            # If lightcone is not provided, we estimate the turnover masses from the global evolution
+            global_evolution = run_global_evolution(inputs=inputs)
+            log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
+
+        log10mturn_mini = np.interp(
+            redshift, inputs.node_redshifts, log10mturns_mini_global
+        )
     else:
-        from ..drivers.global_evolution import run_global_evolution
-
-        # If lightcone is not provided, we estimate the turnover masses from the global evolution
-        global_evolution = run_global_evolution(inputs=inputs)
-        log10mturns_mini_global = global_evolution.quantities["log10_mturn_mcg"]
-
-    log10mturn_mini = np.interp(
-        redshift, inputs.node_redshifts, log10mturns_mini_global
-    )
+        log10mturn_mini = 0.0  # dummy value for no mini halos
 
     densities = densities.astype("f8")
     xray_luminosity = np.zeros_like(densities)

--- a/src/py21cmfast/wrapper/inputs.py
+++ b/src/py21cmfast/wrapper/inputs.py
@@ -999,7 +999,7 @@ class SimulationOptions(InputStruct):
         if self._BOX_LEN is not None:
             return self._BOX_LEN
         else:
-            return int(self.HII_DIM * self.LOWRES_CELL_SIZE_MPC)
+            return np.round(self.HII_DIM * self.LOWRES_CELL_SIZE_MPC, 3)
 
     @_HIRES_TO_LOWRES_FACTOR.validator
     def _hires_to_lowres_vld(self, att, val):

--- a/src/py21cmfast/wrapper/outputs.py
+++ b/src/py21cmfast/wrapper/outputs.py
@@ -681,7 +681,7 @@ class PerturbedField(OutputStructZ):
     _compat_hash = _HashType.zgrid
 
     density = _arrayfield()
-    velocity_z = _arrayfield()
+    velocity_z = _arrayfield(optional=True)
     velocity_x = _arrayfield(optional=True)
     velocity_y = _arrayfield(optional=True)
 
@@ -707,11 +707,14 @@ class PerturbedField(OutputStructZ):
 
         out = {
             "density": Array(shape, dtype=np.float32),
-            "velocity_z": Array(shape, dtype=np.float32),
         }
-        if inputs.matter_options.KEEP_3D_VELOCITIES:
-            out["velocity_x"] = Array(shape, dtype=np.float32)
-            out["velocity_y"] = Array(shape, dtype=np.float32)
+
+        # No need for velocities in a homogeneous universe!
+        if dim > 1:
+            out["velocity_z"] = Array(shape, dtype=np.float32)
+            if inputs.matter_options.KEEP_3D_VELOCITIES:
+                out["velocity_x"] = Array(shape, dtype=np.float32)
+                out["velocity_y"] = Array(shape, dtype=np.float32)
 
         return cls(inputs=inputs, redshift=redshift, **out, **kw)
 

--- a/tests/test_c_interpolation_tables.py
+++ b/tests/test_c_interpolation_tables.py
@@ -4,6 +4,7 @@ import matplotlib as mpl
 import numpy as np
 import pytest
 
+import py21cmfast as p21c
 from py21cmfast.wrapper import cfuncs as cf
 
 from .produce_integration_test_data import get_all_options_struct, print_failure_stats
@@ -28,8 +29,8 @@ OPTIONS_PS = {
 }
 
 OPTIONS_HMF = {
-    "PS": [10, {"HMF": "PS"}],
-    "ST": [10, {"HMF": "ST"}],
+    "PS": [10, {"HMF": "PS", "ZPRIME_STEP_FACTOR": 1.2}],
+    "ST": [10, {"HMF": "ST", "ZPRIME_STEP_FACTOR": 1.2}],
 }
 
 OPTIONS_INTMETHOD = {
@@ -66,6 +67,25 @@ def mass_range():
 @pytest.fixture(scope="module")
 def z_range():
     return np.linspace(6, 35, num=100)
+
+
+@pytest.fixture(scope="module")
+def default_input_struct_lc_mini(default_input_struct_lc):
+    """A default input struct with mini halos turned on."""
+    return default_input_struct_lc.evolve_input_structs(
+        USE_MINI_HALOS=True,
+        RECOMB_MODEL="inhomogeneous",
+        USE_TS_FLUCT=True,
+        K_MAX_FOR_CLASS=1.0,
+    ).with_logspaced_redshifts(
+        zmin=OPTIONS_HMF["PS"][0], step=OPTIONS_HMF["PS"][1]["ZPRIME_STEP_FACTOR"]
+    )
+
+
+@pytest.fixture(scope="module")
+def default_global_evolution(default_input_struct_lc_mini):
+    """A default global signal (with mini halos)."""
+    return p21c.run_global_evolution(inputs=default_input_struct_lc_mini)
 
 
 def get_delta_subset(inputs, redshift, R, delta_range):
@@ -356,14 +376,13 @@ def test_FgtrM_conditional_tables(R, delta_range, plt):
 
 
 @pytest.mark.parametrize("name", options_hmf)
-def test_SFRD_z_tables(name, z_range, plt):
+def test_SFRD_z_tables(name, z_range, default_global_evolution, plt):
     redshift, kwargs = OPTIONS_HMF[name]
     inputs = get_all_options_struct(
         redshift,
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
-        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
 
@@ -372,12 +391,14 @@ def test_SFRD_z_tables(name, z_range, plt):
             USE_INTERPOLATION_TABLES="hmf-interpolation"
         ),
         redshifts=z_range,
+        global_evolution=default_global_evolution,
     )
     SFRD_integrals, SFRD_integrals_mini = cf.evaluate_SFRD_z(
         inputs=inputs.evolve_input_structs(
             USE_INTERPOLATION_TABLES="sigma-interpolation"
         ),
         redshifts=z_range,
+        global_evolution=default_global_evolution,
     )
 
     abs_tol = 1e-5
@@ -421,14 +442,13 @@ def test_SFRD_z_tables(name, z_range, plt):
 
 
 @pytest.mark.parametrize("name", options_hmf)
-def test_Nion_z_tables(name, z_range, plt):
+def test_Nion_z_tables(name, z_range, default_global_evolution, plt):
     redshift, kwargs = OPTIONS_HMF[name]
     inputs = get_all_options_struct(
         redshift,
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
-        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
 
@@ -437,12 +457,14 @@ def test_Nion_z_tables(name, z_range, plt):
             USE_INTERPOLATION_TABLES="hmf-interpolation"
         ),
         redshifts=z_range,
+        global_evolution=default_global_evolution,
     )
     nion_integrals, nion_integrals_mini = cf.evaluate_Nion_z(
         inputs=inputs.evolve_input_structs(
             USE_INTERPOLATION_TABLES="sigma-interpolation"
         ),
         redshifts=z_range,
+        global_evolution=default_global_evolution,
     )
 
     abs_tol = 2e-6
@@ -498,7 +520,9 @@ def test_Nion_z_tables(name, z_range, plt):
 @pytest.mark.parametrize("R", R_PARAM_LIST)
 @pytest.mark.parametrize("name", options_hmf)
 @pytest.mark.parametrize("intmethod", options_intmethod)
-def test_Nion_conditional_tables(name, delta_range, R, mini, intmethod, plt):
+def test_Nion_conditional_tables(
+    name, delta_range, R, mini, intmethod, default_global_evolution, plt
+):
     if intmethod == "FFCOLL":
         if name != "PS":
             pytest.skip("FAST FFCOLL INTEGRALS WORK ONLY WITH EPS")
@@ -514,7 +538,6 @@ def test_Nion_conditional_tables(name, delta_range, R, mini, intmethod, plt):
         USE_MINI_HALOS=mini_flag,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
-        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
 
@@ -525,6 +548,7 @@ def test_Nion_conditional_tables(name, delta_range, R, mini, intmethod, plt):
         redshift=redshift,
         radius=R,
         densities=delta_range,
+        global_evolution=default_global_evolution,
     )
 
     Nion_integrals, Nion_integrals_mini = cf.evaluate_Nion_cond(
@@ -534,6 +558,7 @@ def test_Nion_conditional_tables(name, delta_range, R, mini, intmethod, plt):
         redshift=redshift,
         radius=R,
         densities=delta_range,
+        global_evolution=default_global_evolution,
     )
 
     # The bilinear interpolation we use underperforms at high mturn due to the sharp
@@ -611,7 +636,9 @@ def test_Nion_conditional_tables(name, delta_range, R, mini, intmethod, plt):
 @pytest.mark.parametrize("R", R_PARAM_LIST)
 @pytest.mark.parametrize("name", options_hmf)
 @pytest.mark.parametrize("intmethod", options_intmethod)
-def test_Xray_conditional_tables(name, delta_range, R, mini, intmethod, plt):
+def test_Xray_conditional_tables(
+    name, delta_range, R, mini, intmethod, default_global_evolution, plt
+):
     if intmethod == "FFCOLL":
         if name != "PS":
             pytest.skip("FAST FFCOLL INTEGRALS WORK ONLY WITH EPS")
@@ -628,7 +655,6 @@ def test_Xray_conditional_tables(name, delta_range, R, mini, intmethod, plt):
         USE_MINI_HALOS=mini_flag,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
-        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
 
@@ -641,6 +667,7 @@ def test_Xray_conditional_tables(name, delta_range, R, mini, intmethod, plt):
         redshift=redshift,
         radius=R,
         densities=delta_range,
+        global_evolution=default_global_evolution,
     )
 
     Xray_integrals = cf.evaluate_Xray_cond(
@@ -652,6 +679,7 @@ def test_Xray_conditional_tables(name, delta_range, R, mini, intmethod, plt):
         redshift=redshift,
         radius=R,
         densities=delta_range,
+        global_evolution=default_global_evolution,
     )
 
     abs_tol = 0.0
@@ -691,7 +719,9 @@ def test_Xray_conditional_tables(name, delta_range, R, mini, intmethod, plt):
 @pytest.mark.parametrize("R", R_PARAM_LIST)
 @pytest.mark.parametrize("name", options_hmf)
 @pytest.mark.parametrize("intmethod", options_intmethod)
-def test_SFRD_conditional_table(name, delta_range, R, intmethod, plt):
+def test_SFRD_conditional_table(
+    name, delta_range, R, intmethod, default_global_evolution, plt
+):
     if intmethod == "FFCOLL":
         if name != "PS":
             pytest.skip("FAST FFCOLL INTEGRALS WORK ONLY WITH EPS")
@@ -704,7 +734,6 @@ def test_SFRD_conditional_table(name, delta_range, R, intmethod, plt):
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
-        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
 
@@ -717,6 +746,7 @@ def test_SFRD_conditional_table(name, delta_range, R, intmethod, plt):
         radius=R,
         redshift=redshift,
         densities=delta_range,
+        global_evolution=default_global_evolution,
     )
 
     SFRD_integrals, SFRD_integrals_mini = cf.evaluate_SFRD_cond(
@@ -728,6 +758,7 @@ def test_SFRD_conditional_table(name, delta_range, R, intmethod, plt):
         radius=R,
         redshift=redshift,
         densities=delta_range,
+        global_evolution=default_global_evolution,
     )
 
     # The bilinear interpolation we use underperforms at high mturn due to the sharp
@@ -788,14 +819,15 @@ INTEGRAND_OPTIONS = ["sfrd", "n_ion"]
 @pytest.mark.parametrize("R", R_PARAM_LIST)
 @pytest.mark.parametrize("name", options_hmf)
 @pytest.mark.parametrize("integrand", INTEGRAND_OPTIONS)
-def test_conditional_integral_methods(R, delta_range, name, integrand, plt):
+def test_conditional_integral_methods(
+    R, delta_range, name, integrand, default_global_evolution, plt
+):
     redshift, kwargs = OPTIONS_HMF[name]
     inputs = get_all_options_struct(
         redshift,
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
-        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
 
@@ -817,6 +849,7 @@ def test_conditional_integral_methods(R, delta_range, name, integrand, plt):
                 redshift=redshift,
                 radius=R,
                 densities=delta_range,
+                global_evolution=default_global_evolution,
             )
         else:
             buf, buf_mini = cf.evaluate_Nion_cond(
@@ -824,6 +857,7 @@ def test_conditional_integral_methods(R, delta_range, name, integrand, plt):
                 redshift=redshift,
                 radius=R,
                 densities=delta_range,
+                global_evolution=default_global_evolution,
             )
         integrals.append(buf)
         integrals_mini.append(buf_mini)

--- a/tests/test_c_interpolation_tables.py
+++ b/tests/test_c_interpolation_tables.py
@@ -29,8 +29,8 @@ OPTIONS_PS = {
 }
 
 OPTIONS_HMF = {
-    "PS": [10, {"HMF": "PS", "ZPRIME_STEP_FACTOR": 1.2}],
-    "ST": [10, {"HMF": "ST", "ZPRIME_STEP_FACTOR": 1.2}],
+    "PS": [10, {"HMF": "PS"}],
+    "ST": [10, {"HMF": "ST"}],
 }
 
 OPTIONS_INTMETHOD = {
@@ -77,9 +77,7 @@ def default_input_struct_lc_mini(default_input_struct_lc):
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
         K_MAX_FOR_CLASS=1.0,
-    ).with_logspaced_redshifts(
-        zmin=OPTIONS_HMF["PS"][0], step=OPTIONS_HMF["PS"][1]["ZPRIME_STEP_FACTOR"]
-    )
+    ).with_logspaced_redshifts(zmin=OPTIONS_HMF["PS"][0], step=1.2)
 
 
 @pytest.fixture(scope="module")
@@ -383,6 +381,7 @@ def test_SFRD_z_tables(name, z_range, default_global_evolution, plt):
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # needed because we need inputs.node_redshifts == default_global_evolution.node_redshifts
         **kwargs,
     )["inputs"]
 
@@ -449,6 +448,7 @@ def test_Nion_z_tables(name, z_range, default_global_evolution, plt):
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # needed because we need inputs.node_redshifts == default_global_evolution.node_redshifts
         **kwargs,
     )["inputs"]
 
@@ -538,6 +538,7 @@ def test_Nion_conditional_tables(
         USE_MINI_HALOS=mini_flag,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # needed because we need inputs.node_redshifts == default_global_evolution.node_redshifts
         **kwargs,
     )["inputs"]
 
@@ -655,6 +656,7 @@ def test_Xray_conditional_tables(
         USE_MINI_HALOS=mini_flag,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # needed because we need inputs.node_redshifts == default_global_evolution.node_redshifts
         **kwargs,
     )["inputs"]
 
@@ -734,6 +736,7 @@ def test_SFRD_conditional_table(
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # needed because we need inputs.node_redshifts == default_global_evolution.node_redshifts
         **kwargs,
     )["inputs"]
 
@@ -828,6 +831,7 @@ def test_conditional_integral_methods(
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # needed because we need inputs.node_redshifts == default_global_evolution.node_redshifts
         **kwargs,
     )["inputs"]
 

--- a/tests/test_c_interpolation_tables.py
+++ b/tests/test_c_interpolation_tables.py
@@ -620,9 +620,7 @@ def test_Nion_conditional_tables(
 @pytest.mark.parametrize("R", R_PARAM_LIST)
 @pytest.mark.parametrize("name", options_hmf)
 @pytest.mark.parametrize("intmethod", options_intmethod)
-def test_Xray_conditional_tables(
-    name, log10_mturn_range, delta_range, R, mini, intmethod, plt
-):
+def test_Xray_conditional_tables(name, delta_range, R, mini, intmethod, plt):
     if intmethod == "FFCOLL":
         if name != "PS":
             pytest.skip("FAST FFCOLL INTEGRALS WORK ONLY WITH EPS")
@@ -639,10 +637,9 @@ def test_Xray_conditional_tables(
         USE_MINI_HALOS=mini_flag,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
-
-    d_input, mt_input = np.meshgrid(delta_range, log10_mturn_range, indexing="ij")
 
     Xray_tables = cf.evaluate_Xray_cond(
         inputs=inputs.evolve_input_structs(
@@ -652,8 +649,7 @@ def test_Xray_conditional_tables(
         ),
         redshift=redshift,
         radius=R,
-        densities=d_input,
-        log10mturns=mt_input,
+        densities=delta_range,
     )
 
     Xray_integrals = cf.evaluate_Xray_cond(
@@ -664,21 +660,16 @@ def test_Xray_conditional_tables(
         ),
         redshift=redshift,
         radius=R,
-        densities=d_input,
-        log10mturns=mt_input,
+        densities=delta_range,
     )
 
     abs_tol = 0.0
     if plt == mpl.pyplot:
-        xl = log10_mturn_range.size - 1
-        sel_m = np.linspace(0, xl, num=5).astype(int)
-        Xray_tb_plot = Xray_tables[..., sel_m]
-        Xray_il_plot = Xray_integrals[..., sel_m]
         make_table_comparison_plot(
             [delta_range],
-            [10 ** log10_mturn_range[sel_m]],
-            [Xray_tb_plot],
-            [Xray_il_plot],
+            [None],
+            [Xray_tables],
+            [Xray_integrals],
             plt,
             abstol=abs_tol,
             reltol=RELATIVE_TOLERANCE,
@@ -692,7 +683,7 @@ def test_Xray_conditional_tables(
     print_failure_stats(
         Xray_tables[sel_delta],
         Xray_integrals[sel_delta],
-        [delta_range[sel_delta], 10**log10_mturn_range],
+        [delta_range[sel_delta]],
         abs_tol,
         RELATIVE_TOLERANCE,
         "Xray_c",

--- a/tests/test_c_interpolation_tables.py
+++ b/tests/test_c_interpolation_tables.py
@@ -369,6 +369,7 @@ def test_SFRD_z_tables(name, z_range, plt):
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
 
@@ -426,41 +427,37 @@ def test_SFRD_z_tables(name, z_range, plt):
 
 
 @pytest.mark.parametrize("name", options_hmf)
-def test_Nion_z_tables(name, z_range, log10_mturn_range, plt):
+def test_Nion_z_tables(name, z_range, plt):
     redshift, kwargs = OPTIONS_HMF[name]
     inputs = get_all_options_struct(
         redshift,
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
 
-    z_input, mt_input = np.meshgrid(z_range, log10_mturn_range, indexing="ij")
     nion_tables, nion_tables_mini = cf.evaluate_Nion_z(
         inputs=inputs.evolve_input_structs(
             USE_INTERPOLATION_TABLES="hmf-interpolation"
         ),
-        redshifts=z_input,
-        log10mturns=mt_input,
+        redshifts=z_range,
     )
     nion_integrals, nion_integrals_mini = cf.evaluate_Nion_z(
         inputs=inputs.evolve_input_structs(
             USE_INTERPOLATION_TABLES="sigma-interpolation"
         ),
-        redshifts=z_input,
-        log10mturns=mt_input,
+        redshifts=z_range,
     )
 
     abs_tol = 2e-6
     if plt == mpl.pyplot:
-        xl = log10_mturn_range.size - 1
-        sel_m = np.linspace(0, xl, num=5).astype(int)
         make_table_comparison_plot(
             [z_range, z_range],
-            [np.array([0]), 10 ** log10_mturn_range[sel_m]],
-            [nion_tables[..., 0], nion_tables_mini[..., sel_m]],
-            [nion_integrals[..., 0], nion_integrals_mini[..., sel_m]],
+            [None, None],
+            [nion_tables, nion_tables_mini],
+            [nion_integrals, nion_integrals_mini],
             plt,
             abstol=abs_tol,
             reltol=RELATIVE_TOLERANCE,
@@ -480,7 +477,7 @@ def test_Nion_z_tables(name, z_range, log10_mturn_range, plt):
     print_failure_stats(
         nion_tables_mini,
         nion_integrals_mini,
-        [z_range, 10**log10_mturn_range],
+        [z_range],
         abs_tol,
         RELATIVE_TOLERANCE,
         "SFRD_z_mini",

--- a/tests/test_c_interpolation_tables.py
+++ b/tests/test_c_interpolation_tables.py
@@ -543,18 +543,32 @@ def test_Nion_conditional_tables(name, delta_range, R, mini, intmethod, plt):
     abs_tol = 1e-8
 
     if plt == mpl.pyplot:
-        make_table_comparison_plot(
-            [delta_range, delta_range],
-            [None, None],
-            [Nion_tables, Nion_tables_mini],
-            [Nion_integrals, Nion_integrals_mini],
-            plt,
-            abstol=abs_tol,
-            reltol=RELATIVE_TOLERANCE,
-            label_test=[True, False],
-            xlabels=["delta", "delta"],
-            ylabels=["Nion", "Nion_mini"],
-        )
+        if mini_flag:
+            make_table_comparison_plot(
+                [delta_range, delta_range],
+                [None, None],
+                [Nion_tables, Nion_tables_mini],
+                [Nion_integrals, Nion_integrals_mini],
+                plt,
+                abstol=abs_tol,
+                reltol=RELATIVE_TOLERANCE,
+                label_test=[True, False],
+                xlabels=["delta", "delta"],
+                ylabels=["Nion", "Nion_mini"],
+            )
+        else:
+            make_table_comparison_plot(
+                [delta_range],
+                [None],
+                [Nion_tables],
+                [Nion_integrals],
+                plt,
+                abstol=abs_tol,
+                reltol=RELATIVE_TOLERANCE,
+                label_test=[True],
+                xlabels=["delta"],
+                ylabels=["Nion"],
+            )
 
     sel_delta = get_delta_subset(inputs, redshift, R, delta_range)
 
@@ -584,12 +598,13 @@ def test_Nion_conditional_tables(name, delta_range, R, mini, intmethod, plt):
         rtol=RELATIVE_TOLERANCE,
     )
 
-    np.testing.assert_allclose(
-        Nion_tables_mini[sel_delta],
-        Nion_integrals_mini[sel_delta],
-        atol=abs_tol,
-        rtol=RELATIVE_TOLERANCE,
-    )
+    if mini_flag:
+        np.testing.assert_allclose(
+            Nion_tables_mini[sel_delta],
+            Nion_integrals_mini[sel_delta],
+            atol=abs_tol,
+            rtol=RELATIVE_TOLERANCE,
+        )
 
 
 @pytest.mark.parametrize("mini", ["mini", "acg"])

--- a/tests/test_c_interpolation_tables.py
+++ b/tests/test_c_interpolation_tables.py
@@ -362,7 +362,7 @@ def test_FgtrM_conditional_tables(R, delta_range, plt):
 
 
 @pytest.mark.parametrize("name", options_hmf)
-def test_SFRD_z_tables(name, z_range, log10_mturn_range, plt):
+def test_SFRD_z_tables(name, z_range, plt):
     redshift, kwargs = OPTIONS_HMF[name]
     inputs = get_all_options_struct(
         redshift,
@@ -372,31 +372,26 @@ def test_SFRD_z_tables(name, z_range, log10_mturn_range, plt):
         **kwargs,
     )["inputs"]
 
-    z_input, mt_input = np.meshgrid(z_range, log10_mturn_range, indexing="ij")
     SFRD_tables, SFRD_tables_mini = cf.evaluate_SFRD_z(
         inputs=inputs.evolve_input_structs(
             USE_INTERPOLATION_TABLES="hmf-interpolation"
         ),
-        redshifts=z_input,
-        log10mturns=mt_input,
+        redshifts=z_range,
     )
     SFRD_integrals, SFRD_integrals_mini = cf.evaluate_SFRD_z(
         inputs=inputs.evolve_input_structs(
             USE_INTERPOLATION_TABLES="sigma-interpolation"
         ),
-        redshifts=z_input,
-        log10mturns=mt_input,
+        redshifts=z_range,
     )
 
     abs_tol = 1e-5
     if plt == mpl.pyplot:
-        xl = log10_mturn_range.size - 1
-        sel_m = np.linspace(0, xl, num=5).astype(int)
         make_table_comparison_plot(
             [z_range, z_range],
-            [np.array([0]), 10 ** log10_mturn_range[sel_m]],
-            [SFRD_tables[..., 0], SFRD_tables_mini[..., sel_m]],
-            [SFRD_integrals[..., 0], SFRD_integrals_mini[..., sel_m]],
+            [None, None],
+            [SFRD_tables, SFRD_tables_mini],
+            [SFRD_integrals, SFRD_integrals_mini],
             plt,
             abstol=abs_tol,
             reltol=RELATIVE_TOLERANCE,
@@ -416,7 +411,7 @@ def test_SFRD_z_tables(name, z_range, log10_mturn_range, plt):
     print_failure_stats(
         SFRD_tables_mini,
         SFRD_integrals_mini,
-        [z_range, 10**log10_mturn_range],
+        [z_range],
         abs_tol,
         RELATIVE_TOLERANCE,
         "SFRD_z_mini",

--- a/tests/test_c_interpolation_tables.py
+++ b/tests/test_c_interpolation_tables.py
@@ -709,9 +709,7 @@ def test_Xray_conditional_tables(
 @pytest.mark.parametrize("R", R_PARAM_LIST)
 @pytest.mark.parametrize("name", options_hmf)
 @pytest.mark.parametrize("intmethod", options_intmethod)
-def test_SFRD_conditional_table(
-    name, log10_mturn_range, delta_range, R, intmethod, plt
-):
+def test_SFRD_conditional_table(name, delta_range, R, intmethod, plt):
     if intmethod == "FFCOLL":
         if name != "PS":
             pytest.skip("FAST FFCOLL INTEGRALS WORK ONLY WITH EPS")
@@ -724,10 +722,9 @@ def test_SFRD_conditional_table(
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
-
-    d_input, mt_input = np.meshgrid(delta_range, log10_mturn_range, indexing="ij")
 
     SFRD_tables, SFRD_tables_mini = cf.evaluate_SFRD_cond(
         inputs=inputs.evolve_input_structs(
@@ -737,8 +734,7 @@ def test_SFRD_conditional_table(
         ),
         radius=R,
         redshift=redshift,
-        densities=d_input,
-        log10mturns=mt_input,
+        densities=delta_range,
     )
 
     SFRD_integrals, SFRD_integrals_mini = cf.evaluate_SFRD_cond(
@@ -749,8 +745,7 @@ def test_SFRD_conditional_table(
         ),
         radius=R,
         redshift=redshift,
-        densities=d_input,
-        log10mturns=mt_input,
+        densities=delta_range,
     )
 
     # The bilinear interpolation we use underperforms at high mturn due to the sharp
@@ -759,13 +754,11 @@ def test_SFRD_conditional_table(
     # TODO: In future we should investigate cubic splines etc.
     abs_tol = 1e-8
     if plt == mpl.pyplot:
-        xl = log10_mturn_range.size - 1
-        sel_m = np.linspace(0, xl, num=5).astype(int)
         make_table_comparison_plot(
             [delta_range, delta_range],
-            [np.array([0]), 10 ** log10_mturn_range[sel_m]],
-            [SFRD_tables[:, 0], SFRD_tables_mini[..., sel_m]],
-            [SFRD_integrals[:, 0], SFRD_integrals_mini[..., sel_m]],
+            [None, None],
+            [SFRD_tables, SFRD_tables_mini],
+            [SFRD_integrals, SFRD_integrals_mini],
             plt,
             abstol=abs_tol,
             reltol=RELATIVE_TOLERANCE,
@@ -787,7 +780,7 @@ def test_SFRD_conditional_table(
     print_failure_stats(
         SFRD_tables_mini[sel_delta],
         SFRD_integrals_mini[sel_delta],
-        [delta_range[sel_delta], 10**log10_mturn_range],
+        [delta_range[sel_delta]],
         abs_tol,
         RELATIVE_TOLERANCE,
         "SFRD_c_mini",
@@ -822,6 +815,7 @@ def test_conditional_integral_methods(
         USE_MINI_HALOS=True,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
 
@@ -845,7 +839,6 @@ def test_conditional_integral_methods(
                 redshift=redshift,
                 radius=R,
                 densities=d_input,
-                log10mturns=mt_input,
             )
         else:
             buf, buf_mini = cf.evaluate_Nion_cond(

--- a/tests/test_c_interpolation_tables.py
+++ b/tests/test_c_interpolation_tables.py
@@ -62,12 +62,6 @@ def mass_range():
     return np.logspace(7, 13, num=200)
 
 
-# Mass turnover range for testing CMF/UMF integrals
-@pytest.fixture(scope="module")
-def log10_mturn_range():
-    return np.linspace(5, 8.5, num=40)
-
-
 # redshift range for testing UMF integrals
 @pytest.fixture(scope="module")
 def z_range():
@@ -504,9 +498,7 @@ def test_Nion_z_tables(name, z_range, plt):
 @pytest.mark.parametrize("R", R_PARAM_LIST)
 @pytest.mark.parametrize("name", options_hmf)
 @pytest.mark.parametrize("intmethod", options_intmethod)
-def test_Nion_conditional_tables(
-    name, log10_mturn_range, delta_range, R, mini, intmethod, plt
-):
+def test_Nion_conditional_tables(name, delta_range, R, mini, intmethod, plt):
     if intmethod == "FFCOLL":
         if name != "PS":
             pytest.skip("FAST FFCOLL INTEGRALS WORK ONLY WITH EPS")
@@ -522,13 +514,9 @@ def test_Nion_conditional_tables(
         USE_MINI_HALOS=mini_flag,
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
+        ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
-
-    # NOTE: we still pass a 2D array when minihalos are off.
-    #   part of the test is that passing different mturns *doesn't* change
-    #   the integral without minihalos
-    d_input, mt_input = np.meshgrid(delta_range, log10_mturn_range, indexing="ij")
 
     Nion_tables, Nion_tables_mini = cf.evaluate_Nion_cond(
         inputs=inputs.evolve_input_structs(
@@ -536,9 +524,7 @@ def test_Nion_conditional_tables(
         ),
         redshift=redshift,
         radius=R,
-        densities=d_input,
-        l10mturns_mcg=mt_input,
-        l10mturns_acg=mt_input,
+        densities=delta_range,
     )
 
     Nion_integrals, Nion_integrals_mini = cf.evaluate_Nion_cond(
@@ -547,9 +533,7 @@ def test_Nion_conditional_tables(
         ),
         redshift=redshift,
         radius=R,
-        densities=d_input,
-        l10mturns_mcg=mt_input,
-        l10mturns_acg=mt_input,
+        densities=delta_range,
     )
 
     # The bilinear interpolation we use underperforms at high mturn due to the sharp
@@ -559,16 +543,11 @@ def test_Nion_conditional_tables(
     abs_tol = 1e-8
 
     if plt == mpl.pyplot:
-        xl = log10_mturn_range.size - 1
-        sel_m = np.linspace(0, xl, num=5).astype(int)
-        Nion_tb_plot = Nion_tables[..., sel_m]
-        Nion_il_plot = Nion_integrals[..., sel_m]
-
         make_table_comparison_plot(
             [delta_range, delta_range],
-            [np.array([0]), 10 ** log10_mturn_range[sel_m]],
-            [Nion_tb_plot[..., 0], Nion_tables_mini[..., sel_m]],
-            [Nion_il_plot[..., 0], Nion_integrals_mini[..., sel_m]],
+            [None, None],
+            [Nion_tables, Nion_tables_mini],
+            [Nion_integrals, Nion_integrals_mini],
             plt,
             abstol=abs_tol,
             reltol=RELATIVE_TOLERANCE,
@@ -582,7 +561,7 @@ def test_Nion_conditional_tables(
     print_failure_stats(
         Nion_tables[sel_delta],
         Nion_integrals[sel_delta],
-        [delta_range[sel_delta], 10**log10_mturn_range],
+        [delta_range[sel_delta]],
         abs_tol,
         RELATIVE_TOLERANCE,
         "Nion_c",
@@ -592,7 +571,7 @@ def test_Nion_conditional_tables(
         print_failure_stats(
             Nion_tables_mini[sel_delta],
             Nion_integrals_mini[sel_delta],
-            [delta_range[sel_delta], 10**log10_mturn_range],
+            [delta_range[sel_delta]],
             abs_tol,
             RELATIVE_TOLERANCE,
             "Nion_c_mini",
@@ -794,9 +773,7 @@ INTEGRAND_OPTIONS = ["sfrd", "n_ion"]
 @pytest.mark.parametrize("R", R_PARAM_LIST)
 @pytest.mark.parametrize("name", options_hmf)
 @pytest.mark.parametrize("integrand", INTEGRAND_OPTIONS)
-def test_conditional_integral_methods(
-    R, log10_mturn_range, delta_range, name, integrand, plt
-):
+def test_conditional_integral_methods(R, delta_range, name, integrand, plt):
     redshift, kwargs = OPTIONS_HMF[name]
     inputs = get_all_options_struct(
         redshift,
@@ -806,8 +783,6 @@ def test_conditional_integral_methods(
         ZPRIME_STEP_FACTOR=1.2,  # speed it up a bit because the functions below call run_global_evolution
         **kwargs,
     )["inputs"]
-
-    d_input, mt_input = np.meshgrid(delta_range, log10_mturn_range, indexing="ij")
 
     integrals = []
     integrals_mini = []
@@ -826,29 +801,25 @@ def test_conditional_integral_methods(
                 inputs=inputs,
                 redshift=redshift,
                 radius=R,
-                densities=d_input,
+                densities=delta_range,
             )
         else:
             buf, buf_mini = cf.evaluate_Nion_cond(
                 inputs=inputs,
                 redshift=redshift,
                 radius=R,
-                densities=d_input,
-                l10mturns_acg=mt_input,
-                l10mturns_mcg=mt_input,
+                densities=delta_range,
             )
         integrals.append(buf)
         integrals_mini.append(buf_mini)
 
     abs_tol = 1e-6  # minimum = exp(-40) ~1e-18
     if plt == mpl.pyplot:
-        xl = log10_mturn_range.size - 1
-        sel_m = np.linspace(0, xl, num=5).astype(int)
-        iplot = [i[..., sel_m] if i.ndim == 2 else i for i in integrals]
-        iplot_mini = [i[..., sel_m] for i in integrals_mini]
+        iplot = [i[:, None] if i.ndim == 1 else i for i in integrals]
+        iplot_mini = [i[:, None] if i.ndim == 1 else i for i in integrals_mini]
         make_integral_comparison_plot(
             delta_range,
-            10 ** log10_mturn_range[sel_m],
+            None,
             iplot,
             iplot_mini,
             plt,
@@ -914,6 +885,8 @@ def make_integral_comparison_plot(x1, x2, integral_list, integral_list_second, p
         if len(i_first.shape) == 1:
             i_first = i_first[:, None]
             comparison = integral_list[0][:, None]
+        if len(i_second.shape) == 1:
+            i_second = i_second[:, None]
         for j in range(i_first.shape[1]):
             axs[0, 0].semilogy(
                 x1, i_first[:, j], color=f"C{j:d}", linestyle=styles[i], linewidth=2

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -594,10 +594,20 @@ def test_functions_with_and_without_lightcone(
     output = func(inputs=inputs, **kwargs[func], lightcone=lightcone)
     if func in [cf.evaluate_SFRD_z, cf.evaluate_Nion_z]:
         assert len(output[0]) == len(redshifts)
-        assert len(output[1]) == len(redshifts)  # output_mini
+        if use_mini_halos:
+            assert len(output[1]) == len(redshifts)
+        else:
+            assert (
+                output[1] is None
+            )  # output_mini should be None if not using mini halos
     elif func in [cf.evaluate_SFRD_cond, cf.evaluate_Nion_cond]:
         assert len(output[0]) == len(densities)
-        assert len(output[1]) == len(densities)  # output_mini
+        if use_mini_halos:
+            assert len(output[1]) == len(densities)
+        else:
+            assert (
+                output[1] is None
+            )  # output_mini should be None if not using mini halos
     elif func == cf.evaluate_Xray_cond:
         assert len(output) == len(densities)
 

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -26,7 +26,7 @@ YUNG24_PHYSICAL_PARAMS = {
 
 
 @pytest.mark.parametrize("use_lightcone", [True, False])
-def test_run_lf(default_input_struct_lc, lc, use_lightcone):
+def test_run_lf(default_input_struct_lc, lc, use_lightcone, cache):
     inputs = default_input_struct_lc
     lightcone = lc if use_lightcone else None
     *_, lf = p21c.compute_luminosity_function(
@@ -48,12 +48,28 @@ def test_run_lf(default_input_struct_lc, lc, use_lightcone):
     assert lf2.shape == (3, 100)
     assert np.allclose(lf2[~np.isnan(lf2)], lf[~np.isnan(lf)])
 
-    inputs = inputs.from_template("mini", random_seed=9)
+    inputs = inputs.from_template(["mini", "tiny"], random_seed=9)
+    if use_lightcone:
+        pytest.skip("run_lightcone + mini-halo LF too time consuming (about 4 minutes)")
+        lightcone_mini = p21c.run_lightcone(
+            lightconer=p21c.RectilinearLightconer.between_redshifts(
+                min_redshift=inputs.node_redshifts[-1] + 0.5,
+                max_redshift=inputs.node_redshifts[0] - 0.5,
+                resolution=inputs.simulation_options.cell_size,
+                cosmo=inputs.cosmo_params.cosmo,
+            ),
+            inputs=inputs,
+            write=p21c.CacheConfig(),
+            cache=cache,
+            include_dvdr_in_tau21=False,
+        )
+    else:
+        lightcone_mini = None
 
     _muv_minih, _mhalo_minih, lf_minih = p21c.compute_luminosity_function(
         redshifts=[7, 8, 9],
         nbins=100,
-        lightcone=lightcone,
+        lightcone=lightcone_mini,
         component="mcg",
         inputs=inputs,
     )

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -128,15 +128,6 @@ def test_bad_integral_inputs(default_input_struct):
         )
 
     with pytest.raises(ValueError, match="the shapes of"):
-        cf.evaluate_SFRD_cond(
-            inputs=default_input_struct,
-            redshift=redshifts[0],
-            densities=densities,
-            log10mturns=lnM_base,
-            radius=10.0,
-        )
-
-    with pytest.raises(ValueError, match="the shapes of"):
         cf.evaluate_Nion_cond(
             inputs=default_input_struct,
             redshift=redshifts[0],
@@ -555,9 +546,21 @@ def test_functions_with_and_without_lightcone(
     lightcone = lc if use_lightcone else None
 
     redshifts = [7, 8, 9]
+    densities = np.linspace(-0.98, 1.7, num=800)
+    radius = 5  # Mpc
 
     sfrd, sfrd_mini = cf.evaluate_SFRD_z(
         inputs=inputs, redshifts=redshifts, lightcone=lightcone
     )
     assert len(sfrd) == len(redshifts)
     assert len(sfrd_mini) == len(redshifts)
+
+    sfrd, sfrd_mini = cf.evaluate_SFRD_cond(
+        inputs=inputs,
+        redshift=redshifts[0],
+        radius=radius,
+        densities=densities,
+        lightcone=lightcone,
+    )
+    assert len(sfrd) == len(densities)
+    assert len(sfrd_mini) == len(densities)

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -137,15 +137,6 @@ def test_bad_integral_inputs(default_input_struct):
             radius=10.0,
         )
 
-    with pytest.raises(ValueError, match="the shapes of"):
-        cf.evaluate_Xray_cond(
-            inputs=default_input_struct,
-            redshift=redshifts[0],
-            densities=densities,
-            log10mturns=lnM_base,
-            radius=10.0,
-        )
-
     with pytest.raises(
         ValueError, match="Halo masses and rng shapes must be identical"
     ):
@@ -564,3 +555,12 @@ def test_functions_with_and_without_lightcone(
     )
     assert len(sfrd) == len(densities)
     assert len(sfrd_mini) == len(densities)
+
+    xray_luminosity = cf.evaluate_Xray_cond(
+        inputs=inputs,
+        redshift=redshifts[0],
+        radius=radius,
+        densities=densities,
+        lightcone=lightcone,
+    )
+    assert len(xray_luminosity) == len(densities)

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -1,5 +1,7 @@
 """Test the wrapper functions which access the C-backend, but not though an OutputStruct compute() method."""
 
+from collections.abc import Callable
+
 import matplotlib as mpl
 import numpy as np
 import pytest
@@ -33,10 +35,12 @@ def default_input_struct_lc_mini(default_input_struct_lc):
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
         K_MAX_FOR_CLASS=1.0,
-        N_THREADS=4.0,  # To speed it up
+        N_THREADS=4,  # To speed it up
         HII_DIM=2,  # it's a mini lightcone!
-        DIM=2 * 3,
-        BOX_LEN=2 * 1.5,
+        DIM=None,
+        BOX_LEN=None,
+        HIRES_TO_LOWRES_FACTOR=3,
+        LOWRES_CELL_SIZE_MPC=1.5,
         R_BUBBLE_MAX=2,
     )
 
@@ -537,6 +541,16 @@ def make_matterfield_comparison_plot(
 
 @pytest.mark.parametrize("use_lightcone", [True, False])
 @pytest.mark.parametrize("use_mini_halos", [True, False])
+@pytest.mark.parametrize(
+    "func",
+    [
+        cf.evaluate_SFRD_z,
+        cf.evaluate_Nion_z,
+        cf.evaluate_SFRD_cond,
+        cf.evaluate_Nion_cond,
+        cf.evaluate_Xray_cond,
+    ],
+)
 def test_functions_with_and_without_lightcone(
     default_input_struct_lc,
     lc,
@@ -544,6 +558,7 @@ def test_functions_with_and_without_lightcone(
     lc_mini,
     use_lightcone,
     use_mini_halos,
+    func: Callable,
 ):
     """Test that we can run functions with and without a lightcone as an input."""
     inputs = default_input_struct_lc_mini if use_mini_halos else default_input_struct_lc
@@ -556,46 +571,35 @@ def test_functions_with_and_without_lightcone(
     densities = np.linspace(-0.98, 1.7, num=800)
     radius = 5  # Mpc
 
-    sfrd, sfrd_mini = cf.evaluate_SFRD_z(
-        inputs=inputs, redshifts=redshifts, lightcone=lightcone
-    )
-    assert len(sfrd) == len(redshifts)
-    assert len(sfrd_mini) == len(redshifts)
+    kwargs = {
+        cf.evaluate_SFRD_z: {"redshifts": redshifts},
+        cf.evaluate_Nion_z: {"redshifts": redshifts},
+        cf.evaluate_SFRD_cond: {
+            "redshift": redshifts[0],
+            "radius": radius,
+            "densities": densities,
+        },
+        cf.evaluate_Nion_cond: {
+            "redshift": redshifts[0],
+            "radius": radius,
+            "densities": densities,
+        },
+        cf.evaluate_Xray_cond: {
+            "redshift": redshifts[0],
+            "radius": radius,
+            "densities": densities,
+        },
+    }
 
-    nion, nion_mini = cf.evaluate_Nion_z(
-        inputs=inputs, redshifts=redshifts, lightcone=lightcone
-    )
-    assert len(nion) == len(redshifts)
-    assert len(nion_mini) == len(redshifts)
-
-    sfrd, sfrd_mini = cf.evaluate_SFRD_cond(
-        inputs=inputs,
-        redshift=redshifts[0],
-        radius=radius,
-        densities=densities,
-        lightcone=lightcone,
-    )
-    assert len(sfrd) == len(densities)
-    assert len(sfrd_mini) == len(densities)
-
-    nion, nion_mini = cf.evaluate_Nion_cond(
-        inputs=inputs,
-        redshift=redshifts[0],
-        radius=radius,
-        densities=densities,
-        lightcone=lightcone,
-    )
-    assert len(nion) == len(densities)
-    assert len(nion_mini) == len(densities)
-
-    xray_luminosity = cf.evaluate_Xray_cond(
-        inputs=inputs,
-        redshift=redshifts[0],
-        radius=radius,
-        densities=densities,
-        lightcone=lightcone,
-    )
-    assert len(xray_luminosity) == len(densities)
+    output = func(inputs=inputs, **kwargs[func], lightcone=lightcone)
+    if func in [cf.evaluate_SFRD_z, cf.evaluate_Nion_z]:
+        assert len(output[0]) == len(redshifts)
+        assert len(output[1]) == len(redshifts)  # output_mini
+    elif func in [cf.evaluate_SFRD_cond, cf.evaluate_Nion_cond]:
+        assert len(output[0]) == len(densities)
+        assert len(output[1]) == len(densities)  # output_mini
+    elif func == cf.evaluate_Xray_cond:
+        assert len(output) == len(densities)
 
 
 def test_removed_log10mturns_argument(default_input_struct):

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -117,6 +117,16 @@ def test_bad_integral_inputs(default_input_struct):
     lnM_base = np.linspace(7, 13, num=30)
     densities = np.linspace(-1, 3, num=25)
 
+    with pytest.raises(ValueError, match="The shapes of redshifts and"):
+        cf.compute_mturns(
+            inputs=default_input_struct,
+            redshifts=redshifts,
+            J_LW_21=redshifts,
+            v_cb=redshifts,
+            ionisation_rate_G12=redshifts,
+            z_reion=densities,
+        )
+
     with pytest.raises(ValueError, match="the shapes of"):
         cf.integrate_chmf_interval(
             inputs=default_input_struct,
@@ -654,3 +664,38 @@ def test_removed_arguments_are_cleaned_up_in_v5():
             "Version is now >= 5.0 — please remove the deprecated `mturnovers`, "
             "`log10mturns`, `l10mturns_acg`, and `l10mturns_mcg` arguments and this test."
         )
+
+
+def test_roundtrip_mturns(default_input_struct_ts):
+    """Test that the mturns computed in the global evolution can be used to compute the same mturns through the compute_mturns function."""
+    inputs = default_input_struct_ts.evolve_input_structs(
+        USE_MINI_HALOS=True, RECOMB_MODEL="inhomogeneous", K_MAX_FOR_CLASS=1.0
+    )
+    # Run global evolution and extract global fields
+    global_evolution = p21c.run_global_evolution(inputs=inputs)
+    log10_mturn_acg_global = global_evolution.quantities["log10_mturn_acg"]
+    log10_mturn_mcg_global = global_evolution.quantities["log10_mturn_mcg"]
+    J_21_LW_global = global_evolution.quantities["J_21_LW"]
+    z_reion_global = global_evolution.quantities["z_reion"]
+    ionisation_rate_G12_global = global_evolution.quantities["ionisation_rate_G12"]
+    v_cb = inputs.astro_params.FIXED_VAVG if inputs.astro_options.FIX_VCB_AVG else 0.0
+    # Given the above fields, compute mturns using the cfuncs function
+    Mturn_a_global, M_turn_m_global = cf.compute_mturns(
+        inputs=inputs,
+        redshifts=global_evolution.node_redshifts,
+        J_LW_21=J_21_LW_global,
+        v_cb=np.full_like(global_evolution.node_redshifts, v_cb),
+        ionisation_rate_G12=ionisation_rate_G12_global,
+        z_reion=z_reion_global,
+    )
+    # And compare!
+    np.testing.assert_allclose(
+        log10_mturn_acg_global,
+        np.log10(Mturn_a_global),
+        rtol=1e-4,
+    )
+    np.testing.assert_allclose(
+        log10_mturn_mcg_global,
+        np.log10(M_turn_m_global),
+        rtol=1e-4,
+    )

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -120,16 +120,6 @@ def test_bad_integral_inputs(default_input_struct):
             probabilities=np.ones(len(densities) - 1),
         )
 
-    with pytest.raises(ValueError, match="the shapes of"):
-        cf.evaluate_Nion_cond(
-            inputs=default_input_struct,
-            redshift=redshifts[0],
-            densities=densities,
-            l10mturns_acg=lnM_base,
-            l10mturns_mcg=lnM_base,
-            radius=10.0,
-        )
-
     with pytest.raises(
         ValueError, match="Halo masses and rng shapes must be identical"
     ):
@@ -554,6 +544,16 @@ def test_functions_with_and_without_lightcone(
     )
     assert len(sfrd) == len(densities)
     assert len(sfrd_mini) == len(densities)
+
+    nion, nion_mini = cf.evaluate_Nion_cond(
+        inputs=inputs,
+        redshift=redshifts[0],
+        radius=radius,
+        densities=densities,
+        lightcone=lightcone,
+    )
+    assert len(nion) == len(densities)
+    assert len(nion_mini) == len(densities)
 
     xray_luminosity = cf.evaluate_Xray_cond(
         inputs=inputs,

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -35,39 +35,34 @@ def default_input_struct_lc_mini(default_input_struct_lc):
         RECOMB_MODEL="inhomogeneous",
         USE_TS_FLUCT=True,
         K_MAX_FOR_CLASS=1.0,
-        N_THREADS=4,  # To speed it up
-        HII_DIM=2,  # it's a mini lightcone!
-        DIM=None,
-        BOX_LEN=None,
-        HIRES_TO_LOWRES_FACTOR=3,
-        LOWRES_CELL_SIZE_MPC=1.5,
-        R_BUBBLE_MAX=2,
     )
 
 
 @pytest.fixture(scope="module")
-def lc_mini(default_input_struct_lc_mini, rectlcn, cache):
-    """A lightcone with mini halos turned on."""
-    return p21c.run_lightcone(
-        lightconer=rectlcn,
-        inputs=default_input_struct_lc_mini,
-        write=p21c.CacheConfig(),
-        cache=cache,
-        include_dvdr_in_tau21=False,
-    )
+def default_global_evolution(default_input_struct_lc_mini):
+    """A default global signal (with mini halos)."""
+    return p21c.run_global_evolution(inputs=default_input_struct_lc_mini)
 
 
-@pytest.mark.parametrize("use_lightcone", [True, False])
+@pytest.mark.parametrize("what_to_use", ["lightcone", "global_evolution", "nothing"])
 def test_run_lf(
-    default_input_struct_lc, default_input_struct_lc_mini, lc, lc_mini, use_lightcone
+    default_input_struct_lc,
+    default_input_struct_lc_mini,
+    lc,
+    default_global_evolution,
+    what_to_use,
 ):
     inputs = default_input_struct_lc
-    lightcone = lc if use_lightcone else None
+    lightcone = lc if what_to_use == "lightcone" else None
+    global_evolution = (
+        default_global_evolution if what_to_use == "global_evolution" else None
+    )
     *_, lf = p21c.compute_luminosity_function(
         inputs=inputs,
         redshifts=[7, 8, 9],
         nbins=100,
         lightcone=lightcone,
+        global_evolution=global_evolution,
     )
     assert np.all(lf[~np.isnan(lf)] > -30)
     assert lf.shape == (3, 100)
@@ -78,16 +73,16 @@ def test_run_lf(
         redshifts=[7, 8, 9],
         nbins=100,
         lightcone=lightcone,
+        global_evolution=global_evolution,
     )
     assert lf2.shape == (3, 100)
     assert np.allclose(lf2[~np.isnan(lf2)], lf[~np.isnan(lf)])
 
-    lightcone_mini = lc_mini if use_lightcone else None
-
     _muv_minih, _mhalo_minih, lf_minih = p21c.compute_luminosity_function(
         redshifts=[7, 8, 9],
         nbins=100,
-        lightcone=lightcone_mini,
+        lightcone=lightcone,
+        global_evolution=global_evolution,
         component="mcg",
         inputs=default_input_struct_lc_mini,
     )
@@ -539,7 +534,7 @@ def make_matterfield_comparison_plot(
     axs[1, 3].semilogx(k, (test[3] - true[3]) / true[3], **kwargs)
 
 
-@pytest.mark.parametrize("use_lightcone", [True, False])
+@pytest.mark.parametrize("what_to_use", ["lightcone", "global_evolution", "nothing"])
 @pytest.mark.parametrize("use_mini_halos", [True, False])
 @pytest.mark.parametrize(
     "func",
@@ -553,19 +548,24 @@ def make_matterfield_comparison_plot(
 )
 def test_functions_with_and_without_lightcone(
     default_input_struct_lc,
-    lc,
     default_input_struct_lc_mini,
-    lc_mini,
-    use_lightcone,
+    lc,
+    default_global_evolution,
+    what_to_use,
     use_mini_halos,
     func: Callable,
 ):
-    """Test that we can run functions with and without a lightcone as an input."""
+    """
+    Test that we can run functions with and without a lightcone as an input.
+
+    NOTE: The used inputs and lightcone.inputs are actually not the same when using mini halos!
+          But it should not concern us for this test :)
+    """
     inputs = default_input_struct_lc_mini if use_mini_halos else default_input_struct_lc
-    if use_mini_halos:
-        lightcone = lc_mini if use_lightcone else None
-    else:
-        lightcone = lc if use_lightcone else None
+    lightcone = lc if what_to_use == "lightcone" else None
+    global_evolution = (
+        default_global_evolution if what_to_use == "global_evolution" else None
+    )
 
     redshifts = [7, 8, 9]
     densities = np.linspace(-0.98, 1.7, num=800)
@@ -591,7 +591,12 @@ def test_functions_with_and_without_lightcone(
         },
     }
 
-    output = func(inputs=inputs, **kwargs[func], lightcone=lightcone)
+    output = func(
+        inputs=inputs,
+        **kwargs[func],
+        lightcone=lightcone,
+        global_evolution=global_evolution,
+    )
     if func in [cf.evaluate_SFRD_z, cf.evaluate_Nion_z]:
         assert len(output[0]) == len(redshifts)
         if use_mini_halos:

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -121,13 +121,6 @@ def test_bad_integral_inputs(default_input_struct):
         )
 
     with pytest.raises(ValueError, match="the shapes of"):
-        cf.evaluate_Nion_z(
-            inputs=default_input_struct,
-            redshifts=redshifts,
-            log10mturns=lnM_base,
-        )
-
-    with pytest.raises(ValueError, match="the shapes of"):
         cf.evaluate_Nion_cond(
             inputs=default_input_struct,
             redshift=redshifts[0],
@@ -545,6 +538,12 @@ def test_functions_with_and_without_lightcone(
     )
     assert len(sfrd) == len(redshifts)
     assert len(sfrd_mini) == len(redshifts)
+
+    nion, nion_mini = cf.evaluate_Nion_z(
+        inputs=inputs, redshifts=redshifts, lightcone=lightcone
+    )
+    assert len(nion) == len(redshifts)
+    assert len(nion_mini) == len(redshifts)
 
     sfrd, sfrd_mini = cf.evaluate_SFRD_cond(
         inputs=inputs,

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -25,17 +25,25 @@ YUNG24_PHYSICAL_PARAMS = {
 }
 
 
-def test_run_lf():
-    inputs = p21c.InputParameters(random_seed=9)
+@pytest.mark.parametrize("use_lightcone", [True, False])
+def test_run_lf(default_input_struct_lc, lc, use_lightcone):
+    inputs = default_input_struct_lc
+    lightcone = lc if use_lightcone else None
     *_, lf = p21c.compute_luminosity_function(
-        inputs=inputs, redshifts=[7, 8, 9], nbins=100
+        inputs=inputs,
+        redshifts=[7, 8, 9],
+        nbins=100,
+        lightcone=lightcone,
     )
     assert np.all(lf[~np.isnan(lf)] > -30)
     assert lf.shape == (3, 100)
 
     # Check that memory is in-tact and a second run also works:
     _muv, _mhalo, lf2 = p21c.compute_luminosity_function(
-        inputs=inputs, redshifts=[7, 8, 9], nbins=100
+        inputs=inputs,
+        redshifts=[7, 8, 9],
+        nbins=100,
+        lightcone=lightcone,
     )
     assert lf2.shape == (3, 100)
     assert np.allclose(lf2[~np.isnan(lf2)], lf[~np.isnan(lf)])
@@ -45,10 +53,9 @@ def test_run_lf():
     _muv_minih, _mhalo_minih, lf_minih = p21c.compute_luminosity_function(
         redshifts=[7, 8, 9],
         nbins=100,
+        lightcone=lightcone,
         component="mcg",
         inputs=inputs,
-        mturnovers=[7.0, 7.0, 7.0],
-        mturnovers_mini=[5.0, 5.0, 5.0],
     )
     assert np.all(lf_minih[~np.isnan(lf_minih)] > -30)
     assert lf_minih.shape == (3, 100)

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -25,8 +25,38 @@ YUNG24_PHYSICAL_PARAMS = {
 }
 
 
+@pytest.fixture(scope="module")
+def default_input_struct_lc_mini(default_input_struct_lc):
+    """A default input struct with mini halos turned on."""
+    return default_input_struct_lc.evolve_input_structs(
+        USE_MINI_HALOS=True,
+        RECOMB_MODEL="inhomogeneous",
+        USE_TS_FLUCT=True,
+        K_MAX_FOR_CLASS=1.0,
+        N_THREADS=4.0,  # To speed it up
+        HII_DIM=2,  # it's a mini lightcone!
+        DIM=2 * 3,
+        BOX_LEN=2 * 1.5,
+        R_BUBBLE_MAX=2,
+    )
+
+
+@pytest.fixture(scope="module")
+def lc_mini(default_input_struct_lc_mini, rectlcn, cache):
+    """A lightcone with mini halos turned on."""
+    return p21c.run_lightcone(
+        lightconer=rectlcn,
+        inputs=default_input_struct_lc_mini,
+        write=p21c.CacheConfig(),
+        cache=cache,
+        include_dvdr_in_tau21=False,
+    )
+
+
 @pytest.mark.parametrize("use_lightcone", [True, False])
-def test_run_lf(default_input_struct_lc, lc, use_lightcone, cache):
+def test_run_lf(
+    default_input_struct_lc, default_input_struct_lc_mini, lc, lc_mini, use_lightcone
+):
     inputs = default_input_struct_lc
     lightcone = lc if use_lightcone else None
     *_, lf = p21c.compute_luminosity_function(
@@ -48,30 +78,14 @@ def test_run_lf(default_input_struct_lc, lc, use_lightcone, cache):
     assert lf2.shape == (3, 100)
     assert np.allclose(lf2[~np.isnan(lf2)], lf[~np.isnan(lf)])
 
-    inputs = inputs.from_template(["mini", "tiny"], random_seed=9)
-    if use_lightcone:
-        pytest.skip("run_lightcone + mini-halo LF too time consuming (about 4 minutes)")
-        lightcone_mini = p21c.run_lightcone(
-            lightconer=p21c.RectilinearLightconer.between_redshifts(
-                min_redshift=inputs.node_redshifts[-1] + 0.5,
-                max_redshift=inputs.node_redshifts[0] - 0.5,
-                resolution=inputs.simulation_options.cell_size,
-                cosmo=inputs.cosmo_params.cosmo,
-            ),
-            inputs=inputs,
-            write=p21c.CacheConfig(),
-            cache=cache,
-            include_dvdr_in_tau21=False,
-        )
-    else:
-        lightcone_mini = None
+    lightcone_mini = lc_mini if use_lightcone else None
 
     _muv_minih, _mhalo_minih, lf_minih = p21c.compute_luminosity_function(
         redshifts=[7, 8, 9],
         nbins=100,
         lightcone=lightcone_mini,
         component="mcg",
-        inputs=inputs,
+        inputs=default_input_struct_lc_mini,
     )
     assert np.all(lf_minih[~np.isnan(lf_minih)] > -30)
     assert lf_minih.shape == (3, 100)
@@ -512,12 +526,21 @@ def make_matterfield_comparison_plot(
 
 
 @pytest.mark.parametrize("use_lightcone", [True, False])
+@pytest.mark.parametrize("use_mini_halos", [True, False])
 def test_functions_with_and_without_lightcone(
-    default_input_struct_lc, lc, use_lightcone
+    default_input_struct_lc,
+    lc,
+    default_input_struct_lc_mini,
+    lc_mini,
+    use_lightcone,
+    use_mini_halos,
 ):
     """Test that we can run functions with and without a lightcone as an input."""
-    inputs = default_input_struct_lc
-    lightcone = lc if use_lightcone else None
+    inputs = default_input_struct_lc_mini if use_mini_halos else default_input_struct_lc
+    if use_mini_halos:
+        lightcone = lc_mini if use_lightcone else None
+    else:
+        lightcone = lc if use_lightcone else None
 
     redshifts = [7, 8, 9]
     densities = np.linspace(-0.98, 1.7, num=800)

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -586,3 +586,71 @@ def test_functions_with_and_without_lightcone(
         lightcone=lightcone,
     )
     assert len(xray_luminosity) == len(densities)
+
+
+def test_removed_log10mturns_argument(default_input_struct):
+    """Test that removed `log10mturns` arguments raise a TypeError with a message."""
+    with pytest.raises(
+        TypeError, match="`mturnovers` and `mturnovers_mini` have been removed"
+    ):
+        cf.compute_luminosity_function(
+            inputs=default_input_struct,
+            redshifts=[7, 8, 9],
+            nbins=100,
+            mturnovers=np.array([1e7, 1e8, 1e9]),
+            mturnovers_mini=np.array([1e4, 1e5, 1e6]),
+        )
+
+    with pytest.raises(TypeError, match="`log10mturns` has been removed"):
+        cf.evaluate_SFRD_z(
+            inputs=default_input_struct,
+            redshifts=[7, 8, 9],
+            log10mturns=np.array([8.0, 8.5, 9.0]),
+        )
+
+    with pytest.raises(TypeError, match="`log10mturns` has been removed"):
+        cf.evaluate_Nion_z(
+            inputs=default_input_struct,
+            redshifts=[7, 8, 9],
+            log10mturns=np.array([8.0, 8.5, 9.0]),
+        )
+
+    with pytest.raises(TypeError, match="`log10mturns` has been removed"):
+        cf.evaluate_SFRD_cond(
+            inputs=default_input_struct,
+            redshift=8.0,
+            radius=5,
+            densities=np.linspace(-0.98, 1.7, num=800),
+            log10mturns=np.linspace(8.0, 9.0, num=800),
+        )
+
+    with pytest.raises(
+        TypeError, match="`l10mturns_acg` and `l10mturns_mcg` have been removed"
+    ):
+        cf.evaluate_Nion_cond(
+            inputs=default_input_struct,
+            redshift=8.0,
+            radius=5,
+            densities=np.linspace(-0.98, 1.7, num=800),
+            l10mturns_acg=np.linspace(8.0, 9.0, num=800),
+            l10mturns_mcg=np.linspace(7.0, 8.0, num=800),
+        )
+
+    with pytest.raises(TypeError, match="`log10mturns` has been removed"):
+        cf.evaluate_Xray_cond(
+            inputs=default_input_struct,
+            redshift=8.0,
+            radius=5,
+            densities=np.linspace(-0.98, 1.7, num=800),
+            log10mturns=np.linspace(8.0, 9.0, num=800),
+        )
+
+
+def test_removed_arguments_are_cleaned_up_in_v5():
+    """Reminder to remove the TypeError checks for log10mturns etc. in v5."""
+    version = tuple(int(x) for x in p21c.__version__.split(".")[:2])
+    if version >= (5, 0):
+        pytest.fail(
+            "Version is now >= 5.0 — please remove the deprecated `mturnovers`, "
+            "`log10mturns`, `l10mturns_acg`, and `l10mturns_mcg` arguments and this test."
+        )

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -121,13 +121,6 @@ def test_bad_integral_inputs(default_input_struct):
         )
 
     with pytest.raises(ValueError, match="the shapes of"):
-        cf.evaluate_SFRD_z(
-            inputs=default_input_struct,
-            redshifts=redshifts,
-            log10mturns=lnM_base,
-        )
-
-    with pytest.raises(ValueError, match="the shapes of"):
         cf.evaluate_Nion_z(
             inputs=default_input_struct,
             redshifts=redshifts,
@@ -551,3 +544,20 @@ def make_matterfield_comparison_plot(
     axs[0, 3].loglog(k, true[3], linestyle="-", label="Truth", **kwargs)
     axs[0, 3].loglog(k, test[3], linestyle=":", linewidth=3, label="Test", **kwargs)
     axs[1, 3].semilogx(k, (test[3] - true[3]) / true[3], **kwargs)
+
+
+@pytest.mark.parametrize("use_lightcone", [True, False])
+def test_functions_with_and_without_lightcone(
+    default_input_struct_lc, lc, use_lightcone
+):
+    """Test that we can run functions with and without a lightcone as an input."""
+    inputs = default_input_struct_lc
+    lightcone = lc if use_lightcone else None
+
+    redshifts = [7, 8, 9]
+
+    sfrd, sfrd_mini = cf.evaluate_SFRD_z(
+        inputs=inputs, redshifts=redshifts, lightcone=lightcone
+    )
+    assert len(sfrd) == len(redshifts)
+    assert len(sfrd_mini) == len(redshifts)

--- a/tests/test_perturb.py
+++ b/tests/test_perturb.py
@@ -186,10 +186,7 @@ class TestPerturb:
         )
         prefac_nion = (
             inputs.cosmo_params.cosmo.critical_density(0).to("Msun Mpc-3").value
-            * inputs.astro_params.cdict["F_STAR10"]
             * inputs.cosmo_params.OMb
-            * inputs.astro_params.cdict["F_ESC10"]
-            * inputs.astro_params.cdict["POP2_ION"]
         )
         prefac_xray = (
             inputs.cosmo_params.cosmo.critical_density(0).to("Msun Mpc-3").value

--- a/tests/test_perturb.py
+++ b/tests/test_perturb.py
@@ -219,7 +219,6 @@ class TestPerturb:
             redshift=test_pt_z,
             radius=cell_radius,
             densities=dens,
-            log10mturns=mt_grid,
         )
         integral_xray *= prefac_xray
 

--- a/tests/test_perturb.py
+++ b/tests/test_perturb.py
@@ -177,13 +177,6 @@ class TestPerturb:
         }[inputs.matter_options.PERTURB_ALGORITHM]
         dens = np.roll(ics.get("lowres_density"), roll_var, (0, 1, 2)) * d_z
 
-        prefac_sfr = (
-            inputs.cosmo_params.cosmo.critical_density(0).to("Msun Mpc-3").value
-            * inputs.astro_params.cdict["F_STAR10"]
-            * inputs.cosmo_params.OMb
-            * inputs.cosmo_params.cosmo.H(test_pt_z).to("s-1").value
-            / inputs.astro_params.t_STAR
-        )
         prefac_nion = (
             inputs.cosmo_params.cosmo.critical_density(0).to("Msun Mpc-3").value
             * inputs.cosmo_params.OMb
@@ -198,7 +191,6 @@ class TestPerturb:
             radius=cell_radius,
             densities=dens,
         )
-        integral_sfrd *= prefac_sfr
 
         integral_nion, _ = cf.evaluate_Nion_cond(
             inputs=inputs,

--- a/tests/test_perturb.py
+++ b/tests/test_perturb.py
@@ -176,7 +176,6 @@ class TestPerturb:
             "2LPT": (0, 1, -1),
         }[inputs.matter_options.PERTURB_ALGORITHM]
         dens = np.roll(ics.get("lowres_density"), roll_var, (0, 1, 2)) * d_z
-        mt_grid = np.full_like(dens, inputs.astro_params.M_TURN)
 
         prefac_sfr = (
             inputs.cosmo_params.cosmo.critical_density(0).to("Msun Mpc-3").value
@@ -209,8 +208,6 @@ class TestPerturb:
             redshift=test_pt_z,
             radius=cell_radius,
             densities=dens,
-            l10mturns_acg=mt_grid,
-            l10mturns_mcg=mt_grid,
         )
         integral_nion *= prefac_nion
 

--- a/tests/test_perturb.py
+++ b/tests/test_perturb.py
@@ -181,10 +181,8 @@ class TestPerturb:
             inputs.cosmo_params.cosmo.critical_density(0).to("Msun Mpc-3").value
             * inputs.cosmo_params.OMb
         )
-        prefac_xray = (
-            inputs.cosmo_params.cosmo.critical_density(0).to("Msun Mpc-3").value
-            * inputs.cosmo_params.OMm
-        )
+        prefac_xray = 1e-38
+
         integral_sfrd, _ = cf.evaluate_SFRD_cond(
             inputs=inputs,
             redshift=test_pt_z,

--- a/tests/test_perturb.py
+++ b/tests/test_perturb.py
@@ -201,7 +201,6 @@ class TestPerturb:
             redshift=test_pt_z,
             radius=cell_radius,
             densities=dens,
-            log10mturns=mt_grid,
         )
         integral_sfrd *= prefac_sfr
 


### PR DESCRIPTION
Fixes #115 (and also somewhat of #688).

 This PR contains the following:

1. New python and C functions with the same name were made, `compute_mturns`.
2. Using `compute_mturns`, the fields `log10_Mturnover_ave` and `log10_Mturnover_MINI_ave` from `IonisationBox` are computed as part of `run_global_evolution`.
3. In `compute_luminosity_function`, a `TypeError` with a message is raised if either `mturnovers` or `mturnovers_mini` is not `None`.
4. If both `mturnovers` and `mturnovers_mini` are `None`, the code checks if the possible argument `lightcone` is provided. If it is provided, the global turnover masses are extracted from the lightcone, otherwise the code performs a quick `run_global_evolution` simulation and extracts the global turnover masses from its output.
5. A similar logic has been implemented also for `evaluate_SFRD_z`, `evaluate_Nion_z`, `evaluate_SFRD_cond`, `evaluate_Nion_cond`, and `evaluate_Xray_cond`. Moreover, these functions now return a physically meaningful output (before this change, these functions basically returned weighted integrals over the HMF, without the multiplicative factors that make them interesting physical quantities). The doctorings of all these functions have been improved a lot.
6. In addition, since the global turnover masses are extracted/computed automatically, they mostly depend on their `redshifts`, not `densities`. This has been reflected in both C and python.
7. Three new tests were added in `test_cfuncs.py`: these are `test_functions_with_and_without_lightcone`, `test_removed_log10mturns_argument`, and `test_removed_arguments_are_cleaned_up_in_v5`.

## Summary by Sourcery

Automate computation and propagation of global turnover masses for ACGs and MCGs, and update related high-level integrals to use physically meaningful, self-consistent quantities derived from global evolution or lightcone data.

New Features:
- Add Python and C helper functions to compute halo turnover masses for atomic and molecular cooling galaxies from thermochemical quantities.
- Automatically compute and store global turnover masses in global evolution and lightcone outputs, and expose them through new IonisationBox and global_evolution quantities.
- Allow luminosity function and global/conditional SFRD, Nion, and X-ray evaluators to infer turnover masses from either a provided lightcone or an internal global evolution run instead of requiring them as inputs.

Bug Fixes:
- Ensure SFRD, Nion, and X-ray evaluators now include the correct physical prefactors so their outputs are in meaningful physical units.
- Fix mini-halo handling in conditional and global emissivity/SFRD calculations so that mini-halo contributions are consistently gated by USE_MINI_HALOS and source model choices.

Enhancements:
- Simplify APIs for turnover-mass-dependent routines by deprecating explicit mturn/log10mturn arguments in favor of automatic estimation, with clear TypeError messages for legacy usage.
- Refine integral wrappers to work with scalar global turnover masses (especially for mini-halos) and apply consistent efficiency and normalization factors in C.
- Extend global evolution to track and interpolate global turnover masses across redshift and feed them into downstream calculations.
- Improve docstrings, tests, and interpolation-table validations around global and conditional SFRD, Nion, and X-ray quantities, including support for running with and without lightcones and mini-halos.

Tests:
- Add end-to-end tests for turnover-mass-dependent functions with and without a lightcone, and with/without mini-halos enabled.
- Add regression tests ensuring removed mturn/log10mturn arguments now raise informative TypeErrors and are cleaned up in v5.
- Update interpolation-table tests for SFRD, Nion, and conditional integrals to the new turnover-mass API and physical normalization assumptions.