### PR TITLE
Fix segfault in `test_global_initialization.py`

### DIFF
--- a/src/py21cmfast/drivers/_global_initialization.py
+++ b/src/py21cmfast/drivers/_global_initialization.py
@@ -85,17 +85,17 @@ class GlobalInitializationManager:
             self.inputs = inputs
 
         if broadcast_inputs:
-            self.broadcast_input_struct()
+            self._broadcast_input_struct()
         if ps:
-            self.initialize_power_spectrum()
+            self._initialize_power_spectrum()
         if sigma:
-            self.initialize_sigma_tables()
+            self._initialize_sigma_tables()
         if heat:
-            self.initialize_heat()
+            self._initialize_heat()
         if recomb:
-            self.initialize_recombination_rate()
+            self._initialize_recombination_rate()
 
-    def broadcast_input_struct(self):
+    def _broadcast_input_struct(self):
         """Broadcast the parameters to the C library, and construct FFTW wisdoms if necessary."""
         if not self.inputs_are_broadcast:
             lib.Broadcast_struct_global_all(
@@ -111,19 +111,19 @@ class GlobalInitializationManager:
 
             self.inputs_are_broadcast = True
 
-    def initialize_power_spectrum(self):
+    def _initialize_power_spectrum(self):
         """Initialize power spectrum at the C backend."""
         if not self.inputs_are_broadcast:
-            self.broadcast_input_struct()
+            self._broadcast_input_struct()
 
         if not self.ps_inited:
             lib.init_ps()
             self.ps_inited = True
 
-    def initialize_sigma_tables(self):
+    def _initialize_sigma_tables(self):
         """Initialize sigma interpolation tables at the C backend."""
         if not self.ps_inited:
-            self.initialize_power_spectrum()
+            self._initialize_power_spectrum()
 
         if (
             self.inputs.matter_options.USE_INTERPOLATION_TABLES != "no-interpolation"
@@ -134,19 +134,19 @@ class GlobalInitializationManager:
             lib.initialiseSigmaMInterpTable(sigma_min_mass, sigma_max_mass)
             self.sigma_inited = True
 
-    def initialize_heat(self):
+    def _initialize_heat(self):
         """Initialize heat interpolation tables at the C backend."""
         if not self.inputs_are_broadcast:
-            self.broadcast_input_struct()
+            self._broadcast_input_struct()
 
         if not self.heat_inited:
             lib.init_heat()
             self.heat_inited = True
 
-    def initialize_recombination_rate(self):
+    def _initialize_recombination_rate(self):
         """Initialize recombination rate interpolation tables at the C backend."""
         if not self.inputs_are_broadcast:
-            self.broadcast_input_struct()
+            self._broadcast_input_struct()
 
         # NOTE: run_global_evolution at the moment does not do recombination calculations, so we only initialize if HII_DIM > 1.
         # If this is changed in the future, it will be necessary to remove the HII_DIM > 1 condition below, since it would cause a segfault!

--- a/tests/test_global_initialization.py
+++ b/tests/test_global_initialization.py
@@ -69,11 +69,11 @@ def test_direct_initializations(_run):
         )
     )
 
-    _GlobalInitManagerSingleton.broadcast_input_struct()
-    _GlobalInitManagerSingleton.initialize_power_spectrum()
-    _GlobalInitManagerSingleton.initialize_sigma_tables()
-    _GlobalInitManagerSingleton.initialize_heat()
-    _GlobalInitManagerSingleton.initialize_recombination_rate()
+    _GlobalInitManagerSingleton._broadcast_input_struct()
+    _GlobalInitManagerSingleton._initialize_power_spectrum()
+    _GlobalInitManagerSingleton._initialize_sigma_tables()
+    _GlobalInitManagerSingleton._initialize_heat()
+    _GlobalInitManagerSingleton._initialize_recombination_rate()
 
     assert _GlobalInitManagerSingleton.inputs_are_broadcast
     assert _GlobalInitManagerSingleton.ps_inited
@@ -93,11 +93,11 @@ def test_direct_initializations(_run):
         RECOMB_MODEL="inhomogeneous",
     )
 
-    _GlobalInitManagerSingleton.broadcast_input_struct()
-    _GlobalInitManagerSingleton.initialize_power_spectrum()
-    _GlobalInitManagerSingleton.initialize_sigma_tables()
-    _GlobalInitManagerSingleton.initialize_heat()
-    _GlobalInitManagerSingleton.initialize_recombination_rate()
+    _GlobalInitManagerSingleton._broadcast_input_struct()
+    _GlobalInitManagerSingleton._initialize_power_spectrum()
+    _GlobalInitManagerSingleton._initialize_sigma_tables()
+    _GlobalInitManagerSingleton._initialize_heat()
+    _GlobalInitManagerSingleton._initialize_recombination_rate()
 
     assert _GlobalInitManagerSingleton.inputs_are_broadcast
     assert _GlobalInitManagerSingleton.ps_inited
@@ -131,7 +131,7 @@ def test_direct_initializations_for_heat_and_recomb():
     _GlobalInitManagerSingleton.free()
 
     # Let's begin with a direct initialization of the heating tables
-    _GlobalInitManagerSingleton.initialize_heat()
+    _GlobalInitManagerSingleton._initialize_heat()
     assert _GlobalInitManagerSingleton.inputs_are_broadcast
     assert not _GlobalInitManagerSingleton.ps_inited
     assert not _GlobalInitManagerSingleton.sigma_inited
@@ -145,7 +145,7 @@ def test_direct_initializations_for_heat_and_recomb():
     _GlobalInitManagerSingleton.inputs = _GlobalInitManagerSingleton.inputs.with_logspaced_redshifts().evolve_input_structs(
         RECOMB_MODEL="inhomogeneous"
     )
-    _GlobalInitManagerSingleton.initialize_recombination_rate()
+    _GlobalInitManagerSingleton._initialize_recombination_rate()
     assert _GlobalInitManagerSingleton.inputs_are_broadcast
     assert not _GlobalInitManagerSingleton.ps_inited
     assert not _GlobalInitManagerSingleton.sigma_inited

--- a/tests/test_global_initialization.py
+++ b/tests/test_global_initialization.py
@@ -49,9 +49,9 @@ def test_init():
 
 
 @pytest.mark.parametrize("_run", range(N_REPEAT))
-def test_initializations(_run):
+def test_direct_initializations(_run):
     """
-    Test that initializations work as expected.
+    Test that direct initializations work as expected.
 
     We run this test several times because segfaults can still occur unexpectedly, even if one test passes smoothly.
     """
@@ -81,7 +81,8 @@ def test_initializations(_run):
     assert _GlobalInitManagerSingleton.heat_inited
     assert not _GlobalInitManagerSingleton.recomb_inited
 
-    # NOTE: it is very important to free everything that was initialized, otherwise segfaults could occur!
+    # NOTE: before initializing again below with different inputs, it is very important to free everything that was initialized,
+    # otherwise segfaults could occur!
     _GlobalInitManagerSingleton.free()
 
     # Now let's change the inputs to ones that will allow the initialization of all tables, and check that it works as expected

--- a/tests/test_global_initialization.py
+++ b/tests/test_global_initialization.py
@@ -54,6 +54,9 @@ def test_direct_initializations(_run):
     Test that direct initializations work as expected.
 
     We run this test several times because segfaults can still occur unexpectedly, even if one test passes smoothly.
+
+    NOTE: it is NOT a good idea to call directly these initialization functions, as they could lead to segfaults
+    with uncautious usage!
     """
     # Ensure we start with a clean slate
     _GlobalInitManagerSingleton.free()
@@ -82,7 +85,8 @@ def test_direct_initializations(_run):
     assert not _GlobalInitManagerSingleton.recomb_inited
 
     # NOTE: before initializing again below with different inputs, it is very important to free everything that was initialized,
-    # otherwise segfaults could occur!
+    # otherwise segfaults could occur! Note that these segfaults are not a problem with the user-facing logic of the code, but
+    # rather due to our attempts of calling the private functions directly
     _GlobalInitManagerSingleton.free()
 
     # Now let's change the inputs to ones that will allow the initialization of all tables, and check that it works as expected

--- a/tests/test_global_initialization.py
+++ b/tests/test_global_initialization.py
@@ -8,6 +8,8 @@ from py21cmfast.drivers._global_initialization import (
     _GlobalInitManagerSingleton,
 )
 
+N_REPEAT = 10
+
 
 def test_global_initialization_is_singleton():
     """Test that the GlobalInitializationManager is a singleton."""
@@ -46,12 +48,18 @@ def test_init():
     )  # not initialized, because default is to have no recombinations
 
 
-def test_initializations():
-    """Test that initializations work as expected."""
+@pytest.mark.parametrize("_run", range(N_REPEAT))
+def test_initializations(_run):
+    """
+    Test that initializations work as expected.
+
+    We run this test several times because segfaults can still occur unexpectedly, even if one test passes smoothly.
+    """
     # Ensure we start with a clean slate
     _GlobalInitManagerSingleton.free()
 
-    # Let's give the initializer inputs that will prevent the initialization of sigma and recombination rate tables
+    # Let's give the initializer inputs that will prevent the initialization of sigma and recombination rate tables,
+    # as well as the CLASS transfer function tables
     _GlobalInitManagerSingleton.inputs = (
         _GlobalInitManagerSingleton.inputs.evolve_input_structs(
             SOURCE_MODEL="L-INTEGRAL",
@@ -73,9 +81,15 @@ def test_initializations():
     assert _GlobalInitManagerSingleton.heat_inited
     assert not _GlobalInitManagerSingleton.recomb_inited
 
+    # NOTE: it is very important to free everything that was initialized, otherwise segfaults could occur!
+    _GlobalInitManagerSingleton.free()
+
     # Now let's change the inputs to ones that will allow the initialization of all tables, and check that it works as expected
     _GlobalInitManagerSingleton.inputs = _GlobalInitManagerSingleton.inputs.with_logspaced_redshifts().evolve_input_structs(
-        USE_INTERPOLATION_TABLES="sigma-interpolation", RECOMB_MODEL="inhomogeneous"
+        POWER_SPECTRUM="CLASS",
+        K_MAX_FOR_CLASS=1.0,
+        USE_INTERPOLATION_TABLES="sigma-interpolation",
+        RECOMB_MODEL="inhomogeneous",
     )
 
     _GlobalInitManagerSingleton.broadcast_input_struct()


### PR DESCRIPTION
We have encountered some segfaults in `test_global_initialization.py`. These segfaults are not due to faulty design in `_global_initialization.py`, but rather because of how `test_initializations` was written. 
In short, when calling directly the initialization functions (not recommended!), a segfault could occur when two direct initialization calls with different `inputs` are executed consecutively. This happens because in using the direct initialization methods, `_GlobalInitManagerSingleton` does not know if the current `inputs` are the same ones that were used for previous initializations. 
In normal usage, users should not be concerned about initializations, since they are automatically performed via the `init_c_state` decorator, which calls `_GlobalInitManagerSingleton.init`, where `free()` is called if the current `inputs` don't match the saved `inputs`. 

While it is possible to keep `test_initializations` as it was written and avoid the segfaults, it would unnecessarily make the logic in `_global_initialization.py` more complicated, just to pass a test of an unrecommended usage of the code. An easier solution, that was made in this PR, was to call `free()` between the two direct initialization calls in `test_initializations`. This behavior mimics the logic in `_GlobalInitManagerSingleton.init`, and thus solves the segfault in `test_initializations`.

Apart from this, a few other minor changes were made:
1. Renamed `test_initializations` -> `test_direct_initializations`, to stress that direct initializations are tested in this test.
2. Because the segfault that we had was not deterministic (sometimes the test passed smoothly, sometimes it segfaulted), `test_direct_initializations` is performed now `N_REPEAT = 10` times. This could help catching similar segfaults in the future, if we change something in the logic of `_global_initialization.py`.
3. In `test_direct_initializations`, the second tested `inputs` now have `POWER_SPECTRUM="CLASS"` (+`K_MAX_FOR_CLASS=1`, to make the CLASS run short in time). This helps to test the extra allocations/initializations that are done when the CLASS settings are active.
4. Made the direct initializations private (with an underscore in the beginning of their names), to stress that these methods should not be called by users.

## Summary by Sourcery

Strengthen and clarify global initialization handling by privatizing low-level initialization methods and updating tests to prevent nondeterministic segfaults when invoking them directly.

Enhancements:
- Make direct initialization methods on the global initialization manager private and route the public init path through them to better encapsulate low-level behavior.

Tests:
- Rename the global initialization test to focus on direct initializations, ensure resources are freed between different input configurations, and repeat it multiple times to expose nondeterministic segfaults.
- Extend direct initialization tests to cover CLASS-based power spectrum settings and to use the new private initialization API.