### PR TITLE
Better `v_cb` logic in `run_global_evolution`

### DIFF
--- a/src/py21cmfast/drivers/global_evolution.py
+++ b/src/py21cmfast/drivers/global_evolution.py
@@ -123,7 +123,8 @@ def compute_global_reionization_at_z(
             .with_value(val=val * np.ones(shape)),
         )
     box.log10_Mturnover_ave = np.log10(M_turn_a)
-    box.log10_Mturnover_MINI_ave = np.log10(M_turn_m)
+    if M_turn_m is not None:
+        box.log10_Mturnover_MINI_ave = np.log10(M_turn_m)
     return box
 
 

--- a/src/py21cmfast/drivers/global_evolution.py
+++ b/src/py21cmfast/drivers/global_evolution.py
@@ -90,7 +90,14 @@ def compute_global_reionization_at_z(
     z_reion = -1.0 if Q_HI > 0.0 else redshift
 
     # Global v_cb is determined according to the flag FIX_VCB_AVG
-    v_cb = inputs.astro_params.FIXED_VAVG if inputs.astro_options.FIX_VCB_AVG else 0.0
+    v_cb = (
+        inputs.astro_params.FIXED_VAVG
+        if (
+            inputs.matter_options.USE_RELATIVE_VELOCITIES
+            or inputs.astro_options.FIX_VCB_AVG
+        )
+        else 0.0
+    )
 
     M_turn_a, M_turn_m = compute_mturns(
         inputs=inputs,

--- a/src/py21cmfast/src/thermochem.c
+++ b/src/py21cmfast/src/thermochem.c
@@ -310,8 +310,10 @@ void compute_mturns(float z, float J_21_LW, float vcb, float Gamma12, float z_re
                     double *M_turn_a, double *M_turn_m) {
     double M_turn_r = reionization_feedback(z, Gamma12, z_reion);
     *M_turn_a = atomic_cooling_threshold(z);
-    *M_turn_m = lyman_werner_threshold(z, J_21_LW, vcb);
     *M_turn_a = fmax(*M_turn_a, fmax(M_turn_r, astro_params_global->M_TURN));
-    *M_turn_m = fmax(*M_turn_m, fmax(M_turn_r, astro_params_global->M_TURN));
+    if (astro_options_global->USE_MINI_HALOS) {
+        *M_turn_m = lyman_werner_threshold(z, J_21_LW, vcb);
+        *M_turn_m = fmax(*M_turn_m, fmax(M_turn_r, astro_params_global->M_TURN));
+    }
     return;
 }

--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -109,8 +109,9 @@ def compute_mturns(
     -------
     M_turn_a : array-like
         The turnover mass for atomic cooling halos at the given redshifts.
-    M_turn_m : array-like
+    M_turn_m : array-like or None
         The turnover mass for molecular cooling halos at the given redshifts.
+        Will be None if `USE_MINI_HALOS` is False.
 
     Raises
     ------
@@ -143,8 +144,12 @@ def compute_mturns(
     vfunc = np.vectorize(_scalar_call, otypes=[np.float64, np.float64])
     M_turn_a, M_turn_m = vfunc(redshifts, J_LW_21, v_cb, ionisation_rate_G12, z_reion)
 
+    if not inputs.astro_options.USE_MINI_HALOS:
+        M_turn_m = None
+
     if M_turn_a.ndim == 0:  # scalar input case
-        return float(M_turn_a), float(M_turn_m)
+        M_turn_m_float = None if M_turn_m is None else float(M_turn_m)
+        return float(M_turn_a), M_turn_m_float
     return M_turn_a, M_turn_m
 
 

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -685,10 +685,19 @@ def test_removed_arguments_are_cleaned_up_in_v5():
         )
 
 
-def test_roundtrip_mturns(default_input_struct_ts):
+@pytest.mark.parametrize("use_relative_velocities", [True, False])
+@pytest.mark.parametrize("fix_vcb_avg", [True, False])
+def test_roundtrip_mturns(
+    default_input_struct_ts, use_relative_velocities, fix_vcb_avg
+):
     """Test that the mturns computed in the global evolution can be used to compute the same mturns through the compute_mturns function."""
     inputs = default_input_struct_ts.evolve_input_structs(
-        USE_MINI_HALOS=True, RECOMB_MODEL="inhomogeneous", K_MAX_FOR_CLASS=1.0
+        USE_MINI_HALOS=True,
+        RECOMB_MODEL="inhomogeneous",
+        K_MAX_FOR_CLASS=1.0,
+        USE_RELATIVE_VELOCITIES=use_relative_velocities,
+        FIX_VCB_AVG=fix_vcb_avg,
+        POWER_SPECTRUM="CLASS" if use_relative_velocities else "EH",
     )
     # Run global evolution and extract global fields
     global_evolution = p21c.run_global_evolution(inputs=inputs)
@@ -699,10 +708,7 @@ def test_roundtrip_mturns(default_input_struct_ts):
     ionisation_rate_G12_global = global_evolution.quantities["ionisation_rate_G12"]
     v_cb = (
         inputs.astro_params.FIXED_VAVG
-        if (
-            inputs.matter_options.USE_RELATIVE_VELOCITIES
-            or inputs.astro_options.FIX_VCB_AVG
-        )
+        if (use_relative_velocities or fix_vcb_avg)
         else 0.0
     )
     # Given the above fields, compute mturns using the cfuncs function

--- a/tests/test_cfuncs.py
+++ b/tests/test_cfuncs.py
@@ -697,7 +697,14 @@ def test_roundtrip_mturns(default_input_struct_ts):
     J_21_LW_global = global_evolution.quantities["J_21_LW"]
     z_reion_global = global_evolution.quantities["z_reion"]
     ionisation_rate_G12_global = global_evolution.quantities["ionisation_rate_G12"]
-    v_cb = inputs.astro_params.FIXED_VAVG if inputs.astro_options.FIX_VCB_AVG else 0.0
+    v_cb = (
+        inputs.astro_params.FIXED_VAVG
+        if (
+            inputs.matter_options.USE_RELATIVE_VELOCITIES
+            or inputs.astro_options.FIX_VCB_AVG
+        )
+        else 0.0
+    )
     # Given the above fields, compute mturns using the cfuncs function
     Mturn_a_global, M_turn_m_global = cf.compute_mturns(
         inputs=inputs,


### PR DESCRIPTION
We have introduced in #721 the ability to compute the global turnover masses. The MCG turnover mass depends on the local value of `v_cb`. Our previous logic for setting the global `v_cb` was
```python
v_cb = inputs.astro_params.FIXED_VAVG if inputs.astro_options.FIX_VCB_AVG else 0.0
```
This logic however does not match the logic we have in the C code, and could lead to some embarrassing mistakes (see for example #688).

In the C code, we have
```C
// In set_scaling_constants (scaling_relations.c)
if (astro_options_global->USE_MINI_HALOS) {
    consts->vcb_norel = astro_options_global->FIX_VCB_AVG ? astro_params_global->FIXED_VAVG : 0;
}
// In get_log10_turnovers (HaloBox.c)
double curr_vcb = consts->vcb_norel;
if (!astro_options_global->FIX_VCB_AVG && matter_options_global->USE_RELATIVE_VELOCITIES) {
   curr_vcb = ini_boxes->lowres_vcb[i];
}
```
Because `USE_RELATIVE_VELOCITIES` becomes effective only when we `USE_MINI_HALOS`, this logic is equivalent to having something like the following:
```python
if not inputs.simulation_options.USE_RELATIVE_VELOCITIES and not inputs.astro_options.FIX_VCB_AVG:
   v_cb = 0
elif not inputs.simulation_options.USE_RELATIVE_VELOCITIES:
   v_cb = inputs.astro_params.FIXED_VAVG # This shows btw that USE_RELATIVE_VELOCITIES is a bad naming...
else:
   v_cb = v_cb_local #local fluctuating v_cb from initial conditions
```
Since in our global evolution calculation we don't have a fluctuating `v_cb` field, only its mean, the above logic corresponds to having
```python
if not inputs.simulation_options.USE_RELATIVE_VELOCITIES and not inputs.astro_options.FIX_VCB_AVG:
   v_cb = 0
else:
   v_cb = inputs.astro_params.FIXED_VAVG
```
which can be written more compactly like this:
```python
v_cb = (
   inputs.astro_params.FIXED_VAVG
   if (
      inputs.matter_options.USE_RELATIVE_VELOCITIES
      or inputs.astro_options.FIX_VCB_AVG
   )
   else 0.0
)
```
The above logic is what's implemented in this PR.

**Note**: I'm also planning to push a commit where we set `M_turn_m = None` if `USE_MINI_HALOS=False`.

## Summary by Sourcery

Align global v_cb selection in global reionization calculations with the C implementation and ensure tests reflect the updated logic.

Enhancements:
- Update global v_cb computation in run_global_evolution to depend on relative velocity and FIX_VCB_AVG flags consistent with the C backend.

Tests:
- Adjust mturns roundtrip test to use the new global v_cb selection logic.