### PR TITLE
Compatibility with `astropy` v8 

### DIFF
--- a/src/py21cmfast/wrapper/classy_interface.py
+++ b/src/py21cmfast/wrapper/classy_interface.py
@@ -285,7 +285,7 @@ def compute_rms(
         kr_small = kr[kr < 1.0e-3]
         W_k[kr < 1.0e-3] = 1.0 - 3.0 * (kr_small**2) / 10.0
 
-        integrand = priomordial_PS * (transfer * W_k) ** 2
+        integrand = priomordial_PS * (transfer.value * W_k) ** 2
         var = intg.simpson(integrand, x=np.log(k_transfer / k_transfer.unit))
         rms_list.append(np.sqrt(var))
     # NOTE: intg.simpson removes the unit information, which is why we multiply by the unit when we return


### PR DESCRIPTION
Tests have been breaking recently due to `astropy` v8. This PR fixes that.

## Summary by Sourcery

Enhancements:
- Adjust power spectrum integrand to operate on unitless transfer values for compatibility with newer Astropy versions.