### PR TITLE
Fix NumPy 2.5 deprecation: replace .shape assignment with np.zeros((m,n)) in cfuncs.py

### DIFF
--- a/src/py21cmfast/wrapper/cfuncs.py
+++ b/src/py21cmfast/wrapper/cfuncs.py
@@ -290,25 +290,17 @@ def compute_luminosity_function(
         redshifts, inputs.node_redshifts[::-1], mturnovers_mini_global[::-1]
     )
 
-    lfunc = np.zeros(len(redshifts) * nbins)
-    Muvfunc = np.zeros(len(redshifts) * nbins)
-    Mhfunc = np.zeros(len(redshifts) * nbins)
-
-    lfunc.shape = (len(redshifts), nbins)
-    Muvfunc.shape = (len(redshifts), nbins)
-    Mhfunc.shape = (len(redshifts), nbins)
+    lfunc = np.zeros((len(redshifts), nbins))
+    Muvfunc = np.zeros((len(redshifts), nbins))
+    Mhfunc = np.zeros((len(redshifts), nbins))
 
     c_Muvfunc = ffi.cast("double *", ffi.from_buffer(Muvfunc))
     c_Mhfunc = ffi.cast("double *", ffi.from_buffer(Mhfunc))
     c_lfunc = ffi.cast("double *", ffi.from_buffer(lfunc))
 
-    lfunc_MINI = np.zeros(len(redshifts) * nbins)
-    Muvfunc_MINI = np.zeros(len(redshifts) * nbins)
-    Mhfunc_MINI = np.zeros(len(redshifts) * nbins)
-
-    lfunc_MINI.shape = (len(redshifts), nbins)
-    Muvfunc_MINI.shape = (len(redshifts), nbins)
-    Mhfunc_MINI.shape = (len(redshifts), nbins)
+    lfunc_MINI = np.zeros((len(redshifts), nbins))
+    Muvfunc_MINI = np.zeros((len(redshifts), nbins))
+    Mhfunc_MINI = np.zeros((len(redshifts), nbins))
 
     c_Muvfunc_MINI = ffi.cast("double *", ffi.from_buffer(Muvfunc_MINI))
     c_Mhfunc_MINI = ffi.cast("double *", ffi.from_buffer(Mhfunc_MINI))


### PR DESCRIPTION
NumPy 2.5 deprecated direct `.shape` assignment on arrays (numpy/numpy#27313).
Six instances in `cfuncs.py` triggered DeprecationWarnings during `test_run_lf`.

Replaced the two-step pattern:

    arr = np.zeros(m * n)
    arr.shape = (m, n)

with direct 2D allocation:

    arr = np.zeros((m, n))

Memory layout is identical so C backend behaviour is unchanged.
All `test_run_lf` variants pass with no deprecation warnings.
Full test suite result: 1 failed, 973 passed, 26 skipped, 30 xfailed , 
the single failure (test_hyper_2F3[0.0]) is pre-existing and unrelated to this change.

## Summary by Sourcery

Enhancements:
- Allocate luminosity-function-related arrays with 2D shapes directly instead of reshaping 1D arrays to avoid deprecated NumPy .shape assignment.