### PR TITLE
Add pytest warning filters to catch deprecation warnings and fix misclassified DeprecationWarning

### DIFF
--- a/src/py21cmfast/lightconers.py
+++ b/src/py21cmfast/lightconers.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 from functools import cached_property, partial
 
 import attrs
+import deprecation
 import numpy as np
 from astropy import units
 from astropy.cosmology import FLRW, z_at_value
@@ -147,8 +148,15 @@ class Lightconer(ABC):
         slices in comoving distance.
         """
         warnings.warn(
-            "with_equal_cdist_slices is deprecated and will be removed in future versions. "
-            "Call between_redshifts instead to silence this warning.",
+            deprecation.DeprecatedWarning(
+                "with_equal_cdist_slices",
+                deprecated_in="4.2.0",
+                removed_in="5.0.0",
+                details=(
+                    "with_equal_cdist_slices is deprecated and will be removed in a future version. "
+                    "Call between_redshifts instead to silence this warning."
+                ),
+            ),
             stacklevel=2,
         )
         return cls.between_redshifts(

--- a/tests/test_lightconer.py
+++ b/tests/test_lightconer.py
@@ -3,6 +3,7 @@
 import re
 from dataclasses import dataclass
 
+import deprecation
 import numpy as np
 import pytest
 from astropy import units as un
@@ -166,6 +167,28 @@ def test_equal_cdist_endpoint():
         resolution=res,
     )
     assert np.isclose(lc.lc_distances.max(), d1, atol=d1 / 20)
+
+
+def test_with_equal_cdist_slices_deprecated_warning():
+    """Test that with_equal_cdist_slices raises a deprecation warning."""
+    with pytest.warns(
+        deprecation.DeprecatedWarning, match="with_equal_cdist_slices is deprecated"
+    ):
+        lcn.RectilinearLightconer.with_equal_cdist_slices(
+            min_redshift=6.0,
+            max_redshift=7.0,
+            resolution=2 * un.Mpc,
+        )
+
+
+@deprecation.fail_if_not_removed
+def test_with_equal_cdist_slices_is_removed():
+    """Fails when removed_in version is reached, reminding you to delete with_equal_cdist_slices."""
+    lcn.RectilinearLightconer.with_equal_cdist_slices(
+        min_redshift=6.0,
+        max_redshift=7.0,
+        resolution=2 * un.Mpc,
+    )
 
 
 def test_angular_lightconer_bad_instantiation():


### PR DESCRIPTION
Implements #715.

**Approach**

Rather than manually auditing warnings, I added the filterwarnings block to setup.cfg first and let the suite surface exactly which tests needed attention. This reduced 718 warnings in the CI log down to 5 specific failing tests.

ini
filterwarnings =
    error::DeprecationWarning
    error::PendingDeprecationWarning
    error::FutureWarning

**UserWarning audit**

I audited all UserWarnings in the suite comprehensively to decide whether to add ignore::UserWarning. Every UserWarning in the codebase is intentional: physics domain advisories, operational notifications, and test comparison reporting. I attempted ignore::UserWarning but it broke test_warn_formatting because UserWarnings are part of 21cmFAST's user-facing CLI interface. Conclusion: UserWarning cannot be globally suppressed.

**Bonus finding: misclassified DeprecationWarning**

During the audit, I found with_equal_cdist_slices in lightconers.py raising UserWarning for a deprecation message. Root cause: the warning category argument was omitted from warnings.warn(), causing Python to default to UserWarning. Fixed by adding DeprecationWarning as the second argument. Without this fix, the new filter would not catch this deprecation.

**The 5 failing tests**

All 5 were tests deliberately exercising deprecated backwards-compatible parameters. Each needed a pytest.warns(DeprecationWarning) wrapper:

- test_inhomo_reco_false_sets_none: split into two tests; deprecated variant wrapped
- test_use_relative_velocities_false_sets_none: same pattern, split and wrapped
- test_fix_vcb_avg_conflict: pytest.warns combined with existing pytest.raises
- test_compatability_with_database: old database file triggers deprecation warnings when deserializing old parameter names; wrapped with pytest.warns(DeprecationWarning, match="is deprecated")
- Three with_equal_cdist_slices calls in test_drivers_lc.py: wrapped after fixing the source classification

**Test results**

192 tests across all affected files: 192 passed, 0 failed. Full suite: 968 passed, 1 failed (pre-existing test_hyper_2F3[0.0], unrelated to this change).

**Open questions for reviewers**

A few decisions I made that I'd welcome feedback on:

- ignore::UserWarning: I initially added this to reduce CI log noise (one of the stated motivations in #715) but it broke test_warn_formatting since UserWarnings are part of the CLI interface. I removed it. If there's a more targeted way to reduce UserWarning noise in CI logs without suppressing them globally, I'm open to implementing it.
- test_compatability_with_database: I used pytest.warns(DeprecationWarning, match="is deprecated") rather than matching the exact parameter names, since the old database file triggers two different deprecation warnings (USE_RELATIVE_VELOCITIES and INHOMO_RECO). Happy to make this more explicit if preferred.
- FutureWarning: I included this alongside DeprecationWarning and PendingDeprecationWarning since NumPy and other scientific libraries use it for upcoming breaking changes. Let me know if this should be scoped differently.

## Summary by Sourcery

Enforce strict handling of deprecation-related warnings and correctly classify the deprecated lightconer API warning.

Bug Fixes:
- Correct the classification of the `with_equal_cdist_slices` deprecation warning so it is reported as a deprecation rather than a user warning.

Enhancements:
- Add regression coverage for the deprecated lightconer API, including verification that it will eventually be removed.

Build:
- Configure pytest warning filters to treat deprecation, pending deprecation, and future warnings as errors.

Tests:
- Update affected tests to explicitly expect warnings from deprecated compatibility paths.