### PR TITLE
LW bug:

### DIFF
--- a/src/py21cmfast/src/SpinTemperatureBox.c
+++ b/src/py21cmfast/src/SpinTemperatureBox.c
@@ -397,8 +397,8 @@ void calculate_spectral_factors(double zp) {
             if (astro_options_global->USE_MINI_HALOS) {
                 sum_ly2_val_MINI = frecycle(2) * spectral_emissivity(nuprime, 0, 3);
 
-                if (nuprime < physconst.nu_LW_thresh / physconst.nu_ion_HI)
-                    nuprime = physconst.nu_LW_thresh / physconst.nu_ion_HI;
+                if (nuprime < physconst.nu_LW_thresh / physconst.nu_Ly_alpha)
+                    nuprime = physconst.nu_LW_thresh / physconst.nu_Ly_alpha;
                 // NOTE: are we comparing nuprime at z' and z'' correctly here?
                 //   currently: emitted frequency >= received frequency of next n
                 if (nuprime >= nu_n(2 + 1)) continue;
@@ -418,8 +418,8 @@ void calculate_spectral_factors(double zp) {
             if (astro_options_global->USE_MINI_HALOS) {
                 sum_lynto2_val_MINI += frecycle(n_ct) * spectral_emissivity(nuprime, 0, 3);
 
-                if (nuprime < physconst.nu_LW_thresh / physconst.nu_ion_HI)
-                    nuprime = physconst.nu_LW_thresh / physconst.nu_ion_HI;
+                if (nuprime < physconst.nu_LW_thresh / physconst.nu_Ly_alpha)
+                    nuprime = physconst.nu_LW_thresh / physconst.nu_Ly_alpha;
                 if (nuprime >= nu_n(n_ct + 1)) continue;
                 sum_lyLW_val +=
                     (1. - astro_params_global->F_H2_SHIELD) * spectral_emissivity(nuprime, 2, 2);
@@ -1840,8 +1840,11 @@ void ts_main(float redshift, float prev_redshift, float perturbed_field_redshift
                 dstarlya_dt_box[box_ct] * zp_consts.lya_star_prefactor * zp_consts.volunit_inv;
             rad.delta = curr_delta;
             if (astro_options_global->USE_MINI_HALOS) {
+                // Convert the energy-weighted dimensionless spectrum to an intensity per unit
+                // LW-band frequency, in units of 1e-21 erg s^-1 Hz^-1 cm^-2 sr^-1.
                 rad.dstarLW_dt = dstarlyLW_dt_box[box_ct] * zp_consts.lya_star_prefactor *
-                                 zp_consts.volunit_inv * physconst.h_p * 1e21;
+                                 zp_consts.volunit_inv * physconst.h_p * physconst.nu_Ly_alpha /
+                                 (physconst.nu_ion_HI - physconst.nu_LW_thresh) * 1e21;
             }
             if (astro_options_global->USE_LYA_HEATING) {
                 rad.dstarlya_cont_dt = dstarlya_cont_dt_box[box_ct] * zp_consts.lya_star_prefactor *

--- a/src/py21cmfast/src/heating_helper_progs.c
+++ b/src/py21cmfast/src/heating_helper_progs.c
@@ -282,20 +282,20 @@ double spectral_emissivity(double nu_norm, int flag, int Population) {
 
     switch (flag) {
         case 2:
-            // For LW calculateion. New in v1.5, see...
+            // Energy-weighted spectral integral for the LW calculation.
             for (i = 1; i < (NSPEC_MAX - 1); i++) {
                 if ((nu_norm >= nu_n[i]) && (nu_norm < nu_n[i + 1])) {
                     // We are in the correct spectral region
                     if (Population == 2) {
                         // moved (1. - F_H2_SHIELD) outside
                         result =
-                            N0_2[i] / (alpha_S_2[i] + 1) *
-                            (pow(nu_n[i + 1], alpha_S_2[i] + 1) - pow(nu_norm, alpha_S_2[i] + 1));
+                            N0_2[i] / (alpha_S_2[i] + 2) *
+                            (pow(nu_n[i + 1], alpha_S_2[i] + 2) - pow(nu_norm, alpha_S_2[i] + 2));
                         return result > 0 ? result : 1e-40;
                     } else {
                         result =
-                            N0_3[i] / (alpha_S_3[i] + 1) *
-                            (pow(nu_n[i + 1], alpha_S_3[i] + 1) - pow(nu_norm, alpha_S_3[i] + 1));
+                            N0_3[i] / (alpha_S_3[i] + 2) *
+                            (pow(nu_n[i + 1], alpha_S_3[i] + 2) - pow(nu_norm, alpha_S_3[i] + 2));
                         return result > 0 ? result : 1e-40;
                     }
                 }


### PR DESCRIPTION
1. LW threshold now uses NU_LW / NU_Lya.
2. LW spectral integration is energy-weighted using a + 2.
3. J21 conversion now includes NU_Lya / (NU_HI − NU_LW).

## Summary by Sourcery

Correct LW spectral integration and intensity normalization to use the appropriate band limits and energy weighting.

Bug Fixes:
- Correct LW band threshold handling by applying the target-frame lower-frequency limit during spectral integration.
- Correct LW intensity conversion to account for the Lyman-alpha to LW-band frequency range.

Enhancements:
- Use energy-weighted spectral integration for LW radiation contributions.